### PR TITLE
Fix djui_panel_host_settings.c includes

### DIFF
--- a/src/pc/djui/djui_panel_host_settings.c
+++ b/src/pc/djui/djui_panel_host_settings.c
@@ -4,6 +4,7 @@
 #include "djui_panel_menu.h"
 #include "game/save_file.h"
 #include "pc/network/network.h"
+#include "pc/pc_main.h"
 #include "pc/utils/misc.h"
 #include "pc/configfile.h"
 #include "djui_inputbox.h"


### PR DESCRIPTION
Added the missing pc/pc_main.h include that prevented it from compiling because of the "undeclared" gCoopCompatibility