### PR TITLE
Modify Mario's head and torso rotation outside of specific cases

### DIFF
--- a/autogen/lua_definitions/structs.lua
+++ b/autogen/lua_definitions/structs.lua
@@ -942,6 +942,7 @@
 
 --- @class MarioBodyState
 --- @field public action integer
+--- @field public allowPartRotation integer
 --- @field public capState integer
 --- @field public eyeState integer
 --- @field public grabPos integer
@@ -1990,6 +1991,7 @@
 --- @field public surface Surface
 
 --- @class ServerSettings
+--- @field public bouncyLevelBounds BouncyLevelBounds
 --- @field public bubbleDeath integer
 --- @field public enableCheats integer
 --- @field public enablePlayerList integer

--- a/docs/lua/structs.md
+++ b/docs/lua/structs.md
@@ -1314,6 +1314,7 @@
 | Field | Type | Access |
 | ----- | ---- | ------ |
 | action | `integer` |  |
+| allowPartRotation | `integer` |  |
 | capState | `integer` |  |
 | eyeState | `integer` |  |
 | grabPos | `integer` |  |
@@ -2510,6 +2511,7 @@
 
 | Field | Type | Access |
 | ----- | ---- | ------ |
+| bouncyLevelBounds | [enum BouncyLevelBounds](constants.md#enum-BouncyLevelBounds) |  |
 | bubbleDeath | `integer` |  |
 | enablePlayerList | `integer` |  |
 | enablePlayersInLevelDisplay | `integer` |  |

--- a/include/types.h
+++ b/include/types.h
@@ -316,6 +316,7 @@ struct MarioBodyState
     /*????*/ f32 lightingDirX;
     /*????*/ f32 lightingDirY;
     /*????*/ f32 lightingDirZ;
+    /*????*/ u8 allowPartRotation;
     // u8 padding[4];
 };
 

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -2323,6 +2323,8 @@ void init_single_mario(struct MarioState* m) {
     m->marioBodyState->lightingDirY = 0;
     m->marioBodyState->lightingDirZ = 0;
 
+    m->marioBodyState->allowPartRotation = FALSE;
+
     m->marioObj->oPosX = m->pos[0];
     m->marioObj->oPosY = m->pos[1];
     m->marioObj->oPosZ = m->pos[2];

--- a/src/game/mario_misc.c
+++ b/src/game/mario_misc.c
@@ -430,7 +430,8 @@ Gfx* geo_mario_tilt_torso(s32 callContext, struct GraphNode* node, Mat4* mtx) {
     if (callContext == GEO_CONTEXT_RENDER) {
         struct GraphNodeRotation* rotNode = (struct GraphNodeRotation*) node->next;
 
-        if (action != ACT_BUTT_SLIDE && action != ACT_HOLD_BUTT_SLIDE && action != ACT_WALKING && action != ACT_RIDING_SHELL_GROUND) {
+        if (action != ACT_BUTT_SLIDE && action != ACT_HOLD_BUTT_SLIDE && action != ACT_WALKING && action != ACT_RIDING_SHELL_GROUND 
+        && !bodyState->allowPartRotation) {
             vec3s_copy(bodyState->torsoAngle, gVec3sZero);
         }
         rotNode->rotation[0] = bodyState->torsoAngle[1] * character->torsoRotMult;
@@ -468,7 +469,7 @@ Gfx* geo_mario_head_rotation(s32 callContext, struct GraphNode* node, Mat4* c) {
             rotNode->rotation[0] = gPlayerCameraState[plrIdx].headRotation[1];
             rotNode->rotation[2] = gPlayerCameraState[plrIdx].headRotation[0];
         }
-        else if (action & ACT_FLAG_WATER_OR_TEXT) {
+        else if (action & ACT_FLAG_WATER_OR_TEXT || bodyState->allowPartRotation) {
             rotNode->rotation[0] = bodyState->headAngle[1];
             rotNode->rotation[1] = bodyState->headAngle[2];
             rotNode->rotation[2] = bodyState->headAngle[0];

--- a/src/pc/lua/smlua_cobject_autogen.c
+++ b/src/pc/lua/smlua_cobject_autogen.c
@@ -1059,9 +1059,10 @@ static struct LuaObjectField sMarioAnimationFields[LUA_MARIO_ANIMATION_FIELD_COU
     { "targetAnim",      LVT_COBJECT_P, offsetof(struct MarioAnimation, targetAnim),      false, LOT_ANIMATION },
 };
 
-#define LUA_MARIO_BODY_STATE_FIELD_COUNT 23
+#define LUA_MARIO_BODY_STATE_FIELD_COUNT 24
 static struct LuaObjectField sMarioBodyStateFields[LUA_MARIO_BODY_STATE_FIELD_COUNT] = {
     { "action",              LVT_U32,     offsetof(struct MarioBodyState, action),              false, LOT_NONE  },
+    { "allowPartRotation",   LVT_U8,      offsetof(struct MarioBodyState, allowPartRotation),   false, LOT_NONE  },
     { "capState",            LVT_S8,      offsetof(struct MarioBodyState, capState),            false, LOT_NONE  },
     { "eyeState",            LVT_S8,      offsetof(struct MarioBodyState, eyeState),            false, LOT_NONE  },
     { "grabPos",             LVT_S8,      offsetof(struct MarioBodyState, grabPos),             false, LOT_NONE  },
@@ -2179,8 +2180,9 @@ static struct LuaObjectField sRayIntersectionInfoFields[LUA_RAY_INTERSECTION_INF
     { "surface", LVT_COBJECT_P, offsetof(struct RayIntersectionInfo, surface), false, LOT_SURFACE },
 };
 
-#define LUA_SERVER_SETTINGS_FIELD_COUNT 11
+#define LUA_SERVER_SETTINGS_FIELD_COUNT 12
 static struct LuaObjectField sServerSettingsFields[LUA_SERVER_SETTINGS_FIELD_COUNT] = {
+    { "bouncyLevelBounds",           LVT_S32, offsetof(struct ServerSettings, bouncyLevelBounds),           false, LOT_NONE },
     { "bubbleDeath",                 LVT_U8,  offsetof(struct ServerSettings, bubbleDeath),                 false, LOT_NONE },
     { "enableCheats",                LVT_U8,  offsetof(struct ServerSettings, enableCheats),                false, LOT_NONE },
     { "enablePlayerList",            LVT_U8,  offsetof(struct ServerSettings, enablePlayerList),            false, LOT_NONE },


### PR DESCRIPTION
**Adds _"m.marioBodyState.allowPartRotation"_, which when set to 1, will make _"m.marioBodyState.headAngle"_ and _"m.marioBodyState.torsoAngle"_ actually change where Mario's head and torso face** outside of very specific cases (like running, or being underwater).