### PR TITLE
Fix mod compatibility check

### DIFF
--- a/src/pc/mods/mods_utils.c
+++ b/src/pc/mods/mods_utils.c
@@ -52,7 +52,7 @@ static bool mods_incompatible_match(struct Mod* a, struct Mod* b) {
     char* brest = NULL;
 
     for (atoken = strtok_r(ai, " ", &arest); atoken != NULL; atoken = strtok_r(NULL, " ", &arest)) {
-        for (btoken = strtok_r(bi, " ", &brest); btoken != NULL; btoken = strtok_r(NULL, " ", &brest)) {z
+        for (btoken = strtok_r(bi, " ", &brest); btoken != NULL; btoken = strtok_r(NULL, " ", &brest)) {
             if (!strcmp(atoken, btoken)) {
                 return true;
             }

--- a/src/pc/mods/mods_utils.c
+++ b/src/pc/mods/mods_utils.c
@@ -44,20 +44,23 @@ static bool mods_incompatible_match(struct Mod* a, struct Mod* b) {
         return false;
     }
 
-    char* ai = a->incompatible;
-    char* bi = b->incompatible;
+    char* ai = strdup(a->incompatible);
+    char* bi = strdup(b->incompatible);
     char* atoken = NULL;
     char* btoken = NULL;
     char* arest = NULL;
     char* brest = NULL;
 
     for (atoken = strtok_r(ai, " ", &arest); atoken != NULL; atoken = strtok_r(NULL, " ", &arest)) {
-        for (btoken = strtok_r(bi, " ", &brest); btoken != NULL; btoken = strtok_r(NULL, " ", &brest)) {
+        for (btoken = strtok_r(bi, " ", &brest); btoken != NULL; btoken = strtok_r(NULL, " ", &brest)) {z
             if (!strcmp(atoken, btoken)) {
                 return true;
             }
         }
     }
+
+    free(ai);
+    free(bi);
 
     return false;
 }


### PR DESCRIPTION
When checking mod compatibilities, the original strings are used and in turn they are modified by strtok_r.
This PR makes it use copies of the strings instead.

(there is probably a better way to do this but i know next to nothing about c)