### PR TITLE
MacOS - Overcoming linker failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -761,7 +761,7 @@ else ifeq ($(findstring SDL,$(WINDOW_API)),SDL)
   else ifeq ($(TARGET_RPI),1)
     BACKEND_LDFLAGS += -lGLESv2
   else ifeq ($(OSX_BUILD),1)
-    BACKEND_LDFLAGS += -framework OpenGL `pkg-config --libs glew` -ld_classic
+    BACKEND_LDFLAGS += -framework OpenGL `pkg-config --libs glew`
     EXTRA_CPP_FLAGS += -stdlib=libc++ -std=c++0x
   else
     BACKEND_LDFLAGS += -lGL


### PR DESCRIPTION
### Deprecated `-ld_classic`'s removal fixes compilation on MacOS

A very minor modification has been made to the Makefile in order to remove the now deprecated linker flag `-ld_classic`.
The existence of the flag would halt the very last step of compilation on MacOS, as it would complain about the library for it not being found. It was deprecated in one of the recent xcode updates.
```
ld: library not found for -ld_classic
```

The game compiles successfully on MacOS after the removal of the flag.