### PR TITLE
Accept .luac files as valid Lua

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@
 *.ld text
 *.inc text
 *.txt text
+*.lua text
 *.json text
 *.yaml text
 
@@ -28,3 +29,4 @@
 *.mp3 binary
 *.lvl binary
 *.tex binary
+*.luac binary

--- a/src/pc/lua/smlua.c
+++ b/src/pc/lua/smlua.c
@@ -275,7 +275,7 @@ void smlua_init(void) {
         gPcDebug.lastModRun = gLuaActiveMod;
         for (int j = 0; j < mod->fileCount; j++) {
             struct ModFile* file = &mod->files[j];
-            if (!str_ends_with(file->relativePath, ".lua")) {
+            if (!(str_ends_with(file->relativePath, ".lua") || str_ends_with(file->relativePath, ".luac"))) {
                 continue;
             }
             smlua_load_script(mod, file, i);
@@ -288,7 +288,7 @@ void smlua_init(void) {
 void smlua_update(void) {
     lua_State* L = gLuaState;
     if (L == NULL) { return; }
-    
+
     smlua_call_event_hooks(HOOK_UPDATE);
     // Collect our garbage after calling our hooks.
     // If we don't, Lag can quickly build up from our mods.

--- a/src/pc/mods/mod.c
+++ b/src/pc/mods/mod.c
@@ -13,7 +13,7 @@ size_t mod_get_lua_size(struct Mod* mod) {
 
     for (int i = 0; i < mod->fileCount; i++) {
         struct ModFile* file = &mod->files[i];
-        if (!str_ends_with(file->relativePath, ".lua")) { continue; }
+        if (!(str_ends_with(file->relativePath, ".lua") || str_ends_with(file->relativePath, ".luac"))) { continue; }
         size += file->size;
     }
 
@@ -318,7 +318,7 @@ static bool mod_load_files(struct Mod* mod, char* modName, char* fullPath) {
 
     // deal with mod directory
     {
-        const char* fileTypes[] = { ".lua", NULL };
+        const char* fileTypes[] = { ".lua", ".luac", NULL };
         if (!mod_load_files_dir(mod, fullPath, "", fileTypes)) { return false; }
     }
 

--- a/src/pc/mods/mod_import.c
+++ b/src/pc/mods/mod_import.c
@@ -76,7 +76,7 @@ static bool mod_import_zip(char* path, bool* isLua, bool* isDynos) {
             return false;
         }
 
-        if (str_ends_with(file_stat.m_filename, ".lua")) {
+        if (str_ends_with(file_stat.m_filename, ".lua") || str_ends_with(file_stat.m_filename, ".luac")) {
             path_get_folder(file_stat.m_filename, luaPath);
             *isLua = true;
             break;
@@ -214,7 +214,7 @@ bool mod_import_file(char* path) {
         return false;
     }
 
-    if (str_ends_with(path, ".lua")) {
+    if (str_ends_with(path, ".lua") || str_ends_with(path, ".luac")) {
         isLua = true;
         ret = mod_import_lua(path);
     } else if (str_ends_with(path, ".zip")) {


### PR DESCRIPTION
This lets us distinguish between source mods and compiled mods.
Compiled mods such as mquake will need to have the file extensions changed to .luac to prevent Git from trying to change line endings.