### PR TITLE
Added missing dynos support to / hud character

### DIFF
--- a/data/dynos_mgr_builtin_externs.h
+++ b/data/dynos_mgr_builtin_externs.h
@@ -656,6 +656,7 @@ extern ALIGNED8 const Texture texture_hud_char_hashtag[];
 extern ALIGNED8 const Texture texture_hud_char_question[];
 extern ALIGNED8 const Texture texture_hud_char_ampersand[];
 extern ALIGNED8 const Texture texture_hud_char_percent[];
+extern ALIGNED8 const Texture texture_hud_char_slash[];
 extern ALIGNED8 const Texture texture_hud_char_multiply[];
 extern ALIGNED8 const Texture texture_hud_char_coin[];
 extern ALIGNED8 const Texture texture_hud_char_mario_head[];

--- a/data/dynos_mgr_builtin_tex.cpp
+++ b/data/dynos_mgr_builtin_tex.cpp
@@ -669,6 +669,7 @@ static const struct BuiltinTexInfo sDynosBuiltinTexs[] = {
     define_builtin_tex(texture_hud_char_question, "textures/segment2/segment2.05000.rgba16.png", 16, 16, 16),
     define_builtin_tex(texture_hud_char_ampersand, "textures/segment2/custom_hud_ampersand.rgba16.png", 16, 16, 16),
     define_builtin_tex(texture_hud_char_percent, "textures/segment2/custom_hud_percent.rgba16.png", 16, 16, 16),
+    define_builtin_tex(texture_hud_char_slash, "textures/segment2/custom_hud_slash.rgba16.png", 16, 16, 16),
     define_builtin_tex(texture_hud_char_multiply, "textures/segment2/segment2.05600.rgba16.png", 16, 16, 16),
     define_builtin_tex(texture_hud_char_coin, "textures/segment2/segment2.05800.rgba16.png", 16, 16, 16),
     define_builtin_tex(texture_hud_char_mario_head, "textures/segment2/segment2.05A00.rgba16.png", 16, 16, 16),


### PR DESCRIPTION
Yes, somehow no one noticed it was missing, if you're wondering how I found out, I was porting a hack with a custom hud character and could've used it