### PR TITLE
Display native language name in languages menu

### DIFF
--- a/src/pc/djui/djui_panel_language.c
+++ b/src/pc/djui/djui_panel_language.c
@@ -29,13 +29,12 @@ const char* language_hell[][2] = {
     {"Polish", "język polski (Polish)"},
     {"Portuguese", "português (Portuguese)"},
     {"Russian", "русский (Russian)"},
-    {"Spanish", "Español (Spanish)"},
-    {NULL, NULL}
+    {"Spanish", "Español (Spanish)"}
 };
 
 // HACK: Better than the original but still not good
 static const char* lang_native_name(const char* lang_name) {
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 9; i++) {
         if (!strcmp(lang_name, language_hell[i][0])) return language_hell[i][1];
     }
 
@@ -43,7 +42,7 @@ static const char* lang_native_name(const char* lang_name) {
 }
 
 static const char* lang_native_to_eng_name(const char* lang_name) {
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 9; i++) {
         if (!strcmp(lang_name, language_hell[i][1])) return language_hell[i][0];
     }
 

--- a/src/pc/djui/djui_panel_language.c
+++ b/src/pc/djui/djui_panel_language.c
@@ -17,6 +17,21 @@ static bool sLanguageChanged = false;
 static struct DjuiBase* sLayoutBase = NULL;
 bool gPanelLanguageOnStartup = false;
 
+// HACK: this is abysmal, replace soon or god so help me
+static const char* lang_native_name(const char* en_name) {
+    if (!strcmp(en_name, "German")) return "Deutsch";
+    else if (!strcmp(en_name, "Czech")) return "čeština";
+    else if (!strcmp(en_name, "Dutch")) return "Nederlands";
+    else if (!strcmp(en_name, "French")) return "Français";
+    else if (!strcmp(en_name, "Italian")) return "Italiano";
+    else if (!strcmp(en_name, "Polish")) return "język polski";
+    else if (!strcmp(en_name, "Portuguese")) return "português";
+    else if (!strcmp(en_name, "Russian")) return "русский";
+    else if (!strcmp(en_name, "Spanish")) return "Español";
+
+    return en_name;
+}
+
 static void select_language(struct DjuiBase* caller) {
     // god this is so hacky and terrible
     struct DjuiCheckbox* checkbox = (struct DjuiCheckbox*) caller;
@@ -122,10 +137,18 @@ void djui_panel_language_create(struct DjuiBase* caller) {
             }
             if (strlen(path) == 0) { continue; }
 
+            char* fmtPath;
+
+            // This is actually shit but it works
+            if (strcmp(path, "English") != 0) asprintf(&fmtPath, "%s (%s)", lang_native_name(path), path);
+            else asprintf(&fmtPath, "%s", path);
+
             bool match = !strcmp(path, configLanguage);
             if (match) { foundMatch = true; }
-            struct DjuiCheckbox* checkbox = djui_checkbox_create(sLayoutBase, path, match ? &sTrue : &sFalse, select_language);
+            struct DjuiCheckbox* checkbox = djui_checkbox_create(sLayoutBase, fmtPath, match ? &sTrue : &sFalse, select_language);
             if (!strcmp(path, "English")) { chkEnglish = checkbox; }
+
+            free(fmtPath);
         }
 
         os_closedir(d);

--- a/src/pc/djui/djui_panel_language.c
+++ b/src/pc/djui/djui_panel_language.c
@@ -20,32 +20,32 @@ static bool sLanguageChanged = false;
 static struct DjuiBase* sLayoutBase = NULL;
 bool gPanelLanguageOnStartup = false;
 
-// HACK: this is abysmal, replace soon or god so help me
+const char* language_hell[][2] = {
+    {"German", "Deutsch (German)"},
+    {"Czech", "čeština (Czech)"},
+    {"Dutch", "Nederlands (Dutch)"},
+    {"French", "Français (French)"},
+    {"Italian", "Italiano (Italian)"},
+    {"Polish", "język polski (Polish)"},
+    {"Portuguese", "português (Portuguese)"},
+    {"Russian", "русский (Russian)"},
+    {"Spanish", "Español (Spanish)"},
+    {NULL, NULL}
+};
+
+// HACK: Better than the original but still not good
 static const char* lang_native_name(const char* lang_name) {
-    if (!strcmp(lang_name, "German")) return "Deutsch";
-    else if (!strcmp(lang_name, "Czech")) return "čeština";
-    else if (!strcmp(lang_name, "Dutch")) return "Nederlands";
-    else if (!strcmp(lang_name, "French")) return "Français";
-    else if (!strcmp(lang_name, "Italian")) return "Italiano";
-    else if (!strcmp(lang_name, "Polish")) return "język polski";
-    else if (!strcmp(lang_name, "Portuguese")) return "português";
-    else if (!strcmp(lang_name, "Russian")) return "русский";
-    else if (!strcmp(lang_name, "Spanish")) return "Español";
+    for (int i = 0; i < 10; i++) {
+        if (!strcmp(lang_name, language_hell[i][0])) return language_hell[i][1];
+    }
 
     return lang_name;
 }
 
-// HACK: you thought the above func was bad? Well this is even fucking worse
-static const char* lang_native_to_orig(const char* lang_name) {
-    if (!strcmp(lang_name, "Deutsch (German)")) return "German";
-    else if (!strcmp(lang_name, "čeština (Czech)")) return "Czech";
-    else if (!strcmp(lang_name, "Nederlands (Dutch)")) return "Dutch";
-    else if (!strcmp(lang_name, "Français (French)")) return "French";
-    else if (!strcmp(lang_name, "Italiano (Italian)")) return "Italian";
-    else if (!strcmp(lang_name, "język polski (Polish)")) return "Polish";
-    else if (!strcmp(lang_name, "português (Portuguese)")) return "Portuguese";
-    else if (!strcmp(lang_name, "русский (Russian)")) return "Russian";
-    else if (!strcmp(lang_name, "Español (Spanish)")) return "Spanish";
+static const char* lang_native_to_eng_name(const char* lang_name) {
+    for (int i = 0; i < 10; i++) {
+        if (!strcmp(lang_name, language_hell[i][1])) return language_hell[i][0];
+    }
 
     return lang_name;
 }
@@ -64,7 +64,7 @@ static void select_language(struct DjuiBase* caller) {
         child = child->next;
     }
 
-    const char* orig_text = lang_native_to_orig(checkbox->text->message);
+    const char* orig_text = lang_native_to_eng_name(checkbox->text->message);
 
     if (strcmp(configLanguage, orig_text)) {
         snprintf(configLanguage, MAX_CONFIG_STRING, "%s", orig_text);
@@ -160,7 +160,7 @@ void djui_panel_language_create(struct DjuiBase* caller) {
             char* fmtPath;
 
             // This is actually shit but it works
-            if (strcmp(path, "English") != 0) asprintf(&fmtPath, "%s (%s)", lang_native_name(path), path);
+            if (strcmp(path, "English") != 0) asprintf(&fmtPath, "%s", lang_native_name(path));
             else asprintf(&fmtPath, "%s", path);
 
             bool match = !strcmp(path, configLanguage);

--- a/src/pc/djui/djui_panel_language.c
+++ b/src/pc/djui/djui_panel_language.c
@@ -66,8 +66,6 @@ static void select_language(struct DjuiBase* caller) {
 
     const char* orig_text = lang_native_to_orig(checkbox->text->message);
 
-    printf("Txt: %s\n", orig_text);
-
     if (strcmp(configLanguage, orig_text)) {
         snprintf(configLanguage, MAX_CONFIG_STRING, "%s", orig_text);
         sLanguageChanged = true;

--- a/src/pc/djui/djui_panel_language.c
+++ b/src/pc/djui/djui_panel_language.c
@@ -1,3 +1,6 @@
+#include <stdio.h>
+#include <string.h>
+
 #include "djui.h"
 #include "djui_panel.h"
 #include "djui_panel_menu.h"
@@ -18,18 +21,33 @@ static struct DjuiBase* sLayoutBase = NULL;
 bool gPanelLanguageOnStartup = false;
 
 // HACK: this is abysmal, replace soon or god so help me
-static const char* lang_native_name(const char* en_name) {
-    if (!strcmp(en_name, "German")) return "Deutsch";
-    else if (!strcmp(en_name, "Czech")) return "čeština";
-    else if (!strcmp(en_name, "Dutch")) return "Nederlands";
-    else if (!strcmp(en_name, "French")) return "Français";
-    else if (!strcmp(en_name, "Italian")) return "Italiano";
-    else if (!strcmp(en_name, "Polish")) return "język polski";
-    else if (!strcmp(en_name, "Portuguese")) return "português";
-    else if (!strcmp(en_name, "Russian")) return "русский";
-    else if (!strcmp(en_name, "Spanish")) return "Español";
+static const char* lang_native_name(const char* lang_name) {
+    if (!strcmp(lang_name, "German")) return "Deutsch";
+    else if (!strcmp(lang_name, "Czech")) return "čeština";
+    else if (!strcmp(lang_name, "Dutch")) return "Nederlands";
+    else if (!strcmp(lang_name, "French")) return "Français";
+    else if (!strcmp(lang_name, "Italian")) return "Italiano";
+    else if (!strcmp(lang_name, "Polish")) return "język polski";
+    else if (!strcmp(lang_name, "Portuguese")) return "português";
+    else if (!strcmp(lang_name, "Russian")) return "русский";
+    else if (!strcmp(lang_name, "Spanish")) return "Español";
 
-    return en_name;
+    return lang_name;
+}
+
+// HACK: you thought the above func was bad? Well this is even fucking worse
+static const char* lang_native_to_orig(const char* lang_name) {
+    if (!strcmp(lang_name, "Deutsch (German)")) return "German";
+    else if (!strcmp(lang_name, "čeština (Czech)")) return "Czech";
+    else if (!strcmp(lang_name, "Nederlands (Dutch)")) return "Dutch";
+    else if (!strcmp(lang_name, "Français (French)")) return "French";
+    else if (!strcmp(lang_name, "Italiano (Italian)")) return "Italian";
+    else if (!strcmp(lang_name, "język polski (Polish)")) return "Polish";
+    else if (!strcmp(lang_name, "português (Portuguese)")) return "Portuguese";
+    else if (!strcmp(lang_name, "русский (Russian)")) return "Russian";
+    else if (!strcmp(lang_name, "Español (Spanish)")) return "Spanish";
+
+    return lang_name;
 }
 
 static void select_language(struct DjuiBase* caller) {
@@ -46,8 +64,12 @@ static void select_language(struct DjuiBase* caller) {
         child = child->next;
     }
 
-    if (strcmp(configLanguage, checkbox->text->message)) {
-        snprintf(configLanguage, MAX_CONFIG_STRING, "%s", checkbox->text->message);
+    const char* orig_text = lang_native_to_orig(checkbox->text->message);
+
+    printf("Txt: %s\n", orig_text);
+
+    if (strcmp(configLanguage, orig_text)) {
+        snprintf(configLanguage, MAX_CONFIG_STRING, "%s", orig_text);
         sLanguageChanged = true;
     }
 


### PR DESCRIPTION
Small QoL feature that displays the native language name within the language menu for those that don't know the English name for their language.

Draft as the implementation could be better.

Screenshots:
![image](https://github.com/coop-deluxe/sm64coopdx/assets/63363329/14b572ad-2174-45c8-90ea-591da3c606ba)
![image](https://github.com/coop-deluxe/sm64coopdx/assets/63363329/97866246-a815-4258-96d0-18ef5644e225)
