### PR TITLE
Reorganize Info and Misc.

### DIFF
--- a/src/pc/djui/djui_panel_info.c
+++ b/src/pc/djui/djui_panel_info.c
@@ -4,21 +4,24 @@
 #include "djui_panel_changelog.h"
 #include "pc/lua/utils/smlua_misc_utils.h"
 
-static char sInfo[1024];
+static char sInfo[5][1024];
 
 void djui_panel_info_create(struct DjuiBase* caller) {
     struct DjuiThreePanel* panel = djui_panel_menu_create(DLANG(INFORMATION, INFORMATION_TITLE));
     struct DjuiBase* body = djui_three_panel_get_body(panel);
     {
-        snprintf(sInfo, 1024, "sm64coopdx is a project started by the Coop Deluxe team \
+        struct DjuiPaginated* paginated = djui_paginated_create(body, 1);
+        struct DjuiBase* layoutBase = &paginated->layout->base;
+
+        snprintf(sInfo[0], 1024, "sm64coopdx is a project started by the Coop Deluxe team \
 to actively maintain, improve on and provide a better \
 community for sm64ex-coop. We are adding more features, \
 customizability, and power to the Lua API without having to \
 jump through the many hoops of issues sm64ex-coop \
 development has, or deal with cool new features being \
-turned down by overly cautious developers.\n\
-\n\
-Coop Deluxe Team:\n\
+turned down by overly cautious developers.");
+
+        snprintf(sInfo[1], 1024, "Coop Deluxe Team:\n\
 Agent X: Lead Developer, Creator\n\
 AngelicMiracles: Creator\n\
 eros71: Tester & Developer\n\
@@ -29,13 +32,18 @@ Pup64HCP: Website\n\
 ArcticJaguar725: Fixing a sound engine bug\n\
 Mr. Porkchop: New aliased font"
         );
+        
+        for (int i = 0; i < 2; i++) {
+            struct DjuiText* text = djui_text_create(layoutBase, sInfo[i]);
+            djui_base_set_location(&text->base, 0, 0);
+            djui_base_set_size(&text->base, (DJUI_DEFAULT_PANEL_WIDTH * (configDjuiThemeCenter ? DJUI_THEME_CENTERED_WIDTH : 1)) - 64, 250);
+            djui_base_set_color(&text->base, 220, 220, 220, 255);
+            djui_text_set_drop_shadow(text, 64, 64, 64, 100);
+            djui_text_set_alignment(text, DJUI_HALIGN_CENTER, DJUI_VALIGN_TOP);
+        }
 
-        struct DjuiText* text = djui_text_create(body, sInfo);
-        djui_base_set_location(&text->base, 0, 0);
-        djui_base_set_size(&text->base, (DJUI_DEFAULT_PANEL_WIDTH * (configDjuiThemeCenter ? DJUI_THEME_CENTERED_WIDTH : 1)) - 64, 480);
-        djui_base_set_color(&text->base, 220, 220, 220, 255);
-        djui_text_set_drop_shadow(text, 64, 64, 64, 100);
-        djui_text_set_alignment(text, DJUI_HALIGN_CENTER, DJUI_VALIGN_TOP);
+        djui_paginated_calculate_height(paginated);
+
         struct DjuiRect* rect1 = djui_rect_container_create(body, 64);
         {
             djui_button_left_create(&rect1->base, DLANG(MENU, BACK), DJUI_BUTTON_STYLE_BACK, djui_panel_menu_back);

--- a/src/pc/djui/djui_panel_misc.c
+++ b/src/pc/djui/djui_panel_misc.c
@@ -11,6 +11,9 @@
 #ifdef DISCORD_SDK
 #include "pc/discord/discord.h"
 #endif
+#if defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
+#endif
 
 static void djui_panel_compatibility_checkbox_on_value_change(UNUSED struct DjuiBase* caller) {
 #ifdef DISCORD_SDK
@@ -38,6 +41,23 @@ void djui_panel_options_debug_create(struct DjuiBase* caller) {
 }
 #endif
 
+static void djui_panel_options_open_user_folder(UNUSED struct DjuiBase* caller) {
+#if defined(_WIN32) || defined(_WIN64)
+    // Windows
+    ShellExecuteA(NULL, "open", sys_user_path(), NULL, NULL, SW_SHOWNORMAL);
+#elif __linux__
+    // Linux
+    char command[512];
+    snprintf(command, sizeof(command), "xdg-open %s", sys_user_path());
+    system(command);
+#elif __APPLE__
+    // macOS
+    char command[512];
+    snprintf(command, sizeof(command), "open %s", sys_user_path());
+    system(command);
+#endif
+}
+
 void djui_panel_misc_create(struct DjuiBase* caller) {
     struct DjuiThreePanel* panel = djui_panel_menu_create(DLANG(MISC, MISC_TITLE));
     struct DjuiBase* body = djui_three_panel_get_body(panel);
@@ -58,6 +78,11 @@ void djui_panel_misc_create(struct DjuiBase* caller) {
         djui_button_create(body, DLANG(MISC, INFORMATION), DJUI_BUTTON_STYLE_NORMAL, djui_panel_info_create);
 #ifdef DEVELOPMENT
         djui_button_create(body, DLANG(MISC, DEBUG), DJUI_BUTTON_STYLE_NORMAL, djui_panel_options_debug_create);
+#endif
+#if defined(_WIN32) || defined(_WIN64)
+        djui_button_create(body, DLANG(OPTIONS, APPDATA), DJUI_BUTTON_STYLE_NORMAL, djui_panel_options_open_user_folder);
+#elif __linux__ || __APPLE__ || __MACH__
+        djui_button_create(body, DLANG(OPTIONS, USER_FOLDER), DJUI_BUTTON_STYLE_NORMAL, djui_panel_options_open_user_folder);
 #endif
         djui_button_create(body, DLANG(MENU, BACK), DJUI_BUTTON_STYLE_BACK, djui_panel_menu_back);
     }

--- a/src/pc/djui/djui_panel_options.c
+++ b/src/pc/djui/djui_panel_options.c
@@ -1,7 +1,3 @@
-#if defined(_WIN32) || defined(_WIN64)
-#include <windows.h>
-#endif
-
 #include "djui.h"
 #include "djui_panel.h"
 #include "djui_panel_player.h"
@@ -15,23 +11,6 @@
 #include "pc/network/network.h"
 #include "pc/utils/misc.h"
 #include "pc/pc_main.h"
-
-static void djui_panel_options_open_user_folder(UNUSED struct DjuiBase* caller) {
-#if defined(_WIN32) || defined(_WIN64)
-    // Windows
-    ShellExecuteA(NULL, "open", sys_user_path(), NULL, NULL, SW_SHOWNORMAL);
-#elif __linux__
-    // Linux
-    char command[512];
-    snprintf(command, sizeof(command), "xdg-open %s", sys_user_path());
-    system(command);
-#elif __APPLE__
-    // macOS
-    char command[512];
-    snprintf(command, sizeof(command), "open %s", sys_user_path());
-    system(command);
-#endif
-}
 
 static void djui_panel_options_back(struct DjuiBase* caller) {
     configfile_save(configfile_name());
@@ -54,11 +33,6 @@ void djui_panel_options_create(struct DjuiBase* caller) {
         djui_button_create(body, DLANG(OPTIONS, DISPLAY), DJUI_BUTTON_STYLE_NORMAL, djui_panel_display_create);
         djui_button_create(body, DLANG(OPTIONS, SOUND), DJUI_BUTTON_STYLE_NORMAL, djui_panel_sound_create);
         djui_button_create(body, DLANG(OPTIONS, MISC), DJUI_BUTTON_STYLE_NORMAL, djui_panel_misc_create);
-#if defined(_WIN32) || defined(_WIN64)
-        djui_button_create(body, DLANG(OPTIONS, APPDATA), DJUI_BUTTON_STYLE_NORMAL, djui_panel_options_open_user_folder);
-#elif __linux__ || __APPLE__ || __MACH__
-        djui_button_create(body, DLANG(OPTIONS, USER_FOLDER), DJUI_BUTTON_STYLE_NORMAL, djui_panel_options_open_user_folder);
-#endif
         djui_button_create(body, DLANG(MENU, BACK), DJUI_BUTTON_STYLE_BACK, djui_panel_options_back);
     }
 


### PR DESCRIPTION
Makes the info credits paginated so we can add more text over time with no issues and also moves the Open Appdata/User Folder button to the Misc. menu to avoid cluttering.