### PR TITLE
Fix Discord invites for paths with spaces

### DIFF
--- a/data/dynos.h
+++ b/data/dynos.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 #define DYNOS_VERSION           "1.0"
-#define DYNOS_EXE_FOLDER        sys_exe_path()
+#define DYNOS_EXE_FOLDER        sys_exe_path_dir()
 #define DYNOS_USER_FOLDER       fs_get_write_path("")
 #define DYNOS_RES_FOLDER        "dynos"
 #define DYNOS_PACKS_FOLDER      DYNOS_RES_FOLDER "/packs"

--- a/src/pc/crash_handler.c
+++ b/src/pc/crash_handler.c
@@ -457,8 +457,8 @@ static void crash_handler(const int signalNum, siginfo_t *info, UNUSED ucontext_
 
         // Load symbols
         char filename[256] = { 0 };
-        const char *exe_path = sys_exe_path();
-        if (NULL != exe_path) {
+        const char *exe_path = sys_exe_path_dir();
+        if (exe_path[0] != '\0') {
             snprintf(filename, 256, "%s/%s", exe_path, "coop.map");
         } else {
             snprintf(filename, 256, "%s", "coop.map");

--- a/src/pc/discord/discord.h
+++ b/src/pc/discord/discord.h
@@ -5,7 +5,6 @@
 
 #ifdef _WIN32
 #define DISCORD_ID_FORMAT "%lld"
-#include <Windows.h>
 #else
 #define DISCORD_ID_FORMAT "%ld"
 #endif

--- a/src/pc/djui/djui_language.c
+++ b/src/pc/djui/djui_language.c
@@ -19,7 +19,7 @@ bool djui_language_init(char* lang) {
     // construct path
     char path[SYS_MAX_PATH] = "";
     if (!lang || lang[0] == '\0') { lang = "English"; }
-    snprintf(path, SYS_MAX_PATH, "%s/lang/%s.ini", sys_exe_path(), lang);
+    snprintf(path, SYS_MAX_PATH, "%s/lang/%s.ini", sys_exe_path_dir(), lang);
 
     // load
     sLang = ini_load(path);

--- a/src/pc/djui/djui_panel_language.c
+++ b/src/pc/djui/djui_panel_language.c
@@ -82,7 +82,7 @@ void djui_panel_language_create(struct DjuiBase* caller) {
     {
         // construct lang path
         char lpath[SYS_MAX_PATH] = "";
-        snprintf(lpath, SYS_MAX_PATH, "%s/lang", sys_exe_path());
+        snprintf(lpath, SYS_MAX_PATH, "%s/lang", sys_exe_path_dir());
 
         // open directory
         struct dirent* dir = NULL;

--- a/src/pc/djui/djui_panel_player.c
+++ b/src/pc/djui/djui_panel_player.c
@@ -427,7 +427,7 @@ void djui_panel_player_create(struct DjuiBase* caller) {
         djui_selectionbox_create(body, DLANG(PLAYER, MODEL), characterChoices, CT_MAX, &configPlayerModel, djui_panel_player_value_changed);
 
         player_palettes_reset();
-        player_palettes_read(sys_exe_path(), true);
+        player_palettes_read(sys_exe_path_dir(), true);
         player_palettes_read(fs_get_write_path(PALETTES_DIRECTORY), false);
 
         char* palettePresets[MAX_PRESET_PALETTES + 1] = { DLANG(PALETTE, CUSTOM) };

--- a/src/pc/fs/fs.c
+++ b/src/pc/fs/fs.c
@@ -254,7 +254,7 @@ const char *fs_convert_path(char *buf, const size_t bufsiz, const char *path) {
 
     // ! means "executable directory"
     if (path[0] == '!') {
-        if (snprintf(buf, bufsiz, "%s%s", sys_exe_path(), path + 1) < 0) {
+        if (snprintf(buf, bufsiz, "%s%s", sys_exe_path_dir(), path + 1) < 0) {
             return "";
         }
     } else {

--- a/src/pc/mods/mods.c
+++ b/src/pc/mods/mods.c
@@ -276,7 +276,7 @@ void mods_refresh_local(void) {
     if (hasUserPath) { mods_load(&gLocalMods, userModPath, true); }
 
     char defaultModsPath[SYS_MAX_PATH] = { 0 };
-    snprintf(defaultModsPath, SYS_MAX_PATH, "%s/%s", sys_exe_path(), MOD_DIRECTORY);
+    snprintf(defaultModsPath, SYS_MAX_PATH, "%s/%s", sys_exe_path_dir(), MOD_DIRECTORY);
     mods_load(&gLocalMods, defaultModsPath, false);
 
     // sort

--- a/src/pc/platform.c
+++ b/src/pc/platform.c
@@ -5,14 +5,19 @@
 #include <string.h>
 #include <ctype.h>
 
-#ifdef _WIN32
+#if defined(_WIN32)
 #include <windows.h>
 #include <shlobj.h>
 #include <shlwapi.h>
+#elif defined(__APPLE__)
+#include <mach-o/dyld.h>
+#else
+#include <unistd.h>
 #endif
 
 #include "cliopts.h"
 #include "fs/fs.h"
+#include "debuglog.h"
 #include "configfile.h"
 
 /* these are not available on some platforms, so might as well */
@@ -247,17 +252,31 @@ const char *sys_user_path(void)
     return sys_windows_short_path_from_wcs(shortPath, SYS_MAX_PATH, widePath) ? shortPath : NULL;
 }
 
-const char *sys_exe_path(void)
+const char *sys_exe_path_dir(void)
+{
+    static char path[SYS_MAX_PATH];
+    if ('\0' != path[0]) { return path; }
+
+    const char *exeFilepath = sys_exe_path_file();
+    char *lastSeparator = strrchr(exeFilepath, '\\');
+    if (lastSeparator != NULL) {
+        size_t count = (size_t)(lastSeparator - exeFilepath);
+        strncpy(path, exeFilepath, count);
+    }
+
+    return path;
+}
+
+const char *sys_exe_path_file(void)
 {
     static char shortPath[SYS_MAX_PATH] = { 0 };
     if ('\0' != shortPath[0]) { return shortPath; }
 
     WCHAR widePath[SYS_MAX_PATH];
-    if (0 == GetModuleFileNameW(NULL, widePath, SYS_MAX_PATH)) { return NULL; }
-
-    WCHAR *lastBackslash = wcsrchr(widePath, L'\\');
-    if (NULL != lastBackslash) { *lastBackslash = L'\0'; }
-    else { return NULL; }
+    if (0 == GetModuleFileNameW(NULL, widePath, SYS_MAX_PATH)) {
+        LOG_ERROR("unable to retrieve absolute path.");
+        return shortPath;
+    }
 
     return sys_windows_short_path_from_wcs(shortPath, SYS_MAX_PATH, widePath) ? shortPath : NULL;
 }
@@ -307,20 +326,38 @@ const char *sys_user_path(void) {
     return path;
 }
 
-const char *sys_exe_path(void) {
-    static char path[SYS_MAX_PATH] = { 0 };
+const char *sys_exe_path_dir(void) {
+    static char path[SYS_MAX_PATH];
     if ('\0' != path[0]) { return path; }
 
-    char *sdlPath = SDL_GetBasePath();
-    if (sdlPath && sdlPath[0]) {
-        // use the SDL path if it exists
-        const unsigned int len = strlen(sdlPath);
-        snprintf(path, sizeof(path), "%s", sdlPath);
-        path[sizeof(path)-1] = 0;
-        SDL_free(sdlPath);
-        if (path[len-1] == '/' || path[len-1] == '\\')
-            path[len-1] = 0; // strip the trailing separator
+    const char *exeFilepath = sys_exe_path_file();
+    char *lastSeparator = strrchr(exeFilepath, '/');
+    if (lastSeparator != NULL) {
+        size_t count = (size_t)(lastSeparator - exeFilepath);
+        strncpy(path, exeFilepath, count);
     }
+
+    return path;
+}
+
+const char *sys_exe_path_file(void) {
+    static char path[SYS_MAX_PATH];
+    if ('\0' != path[0]) { return path; }
+
+#if defined(__APPLE__)
+    uint32_t bufsize = SYS_MAX_PATH;
+    int res = _NSGetExecutablePath(path, &bufsize);
+
+#else
+    char procPath[SYS_MAX_PATH];
+    snprintf(procPath, SYS_MAX_PATH, "/proc/%d/exe", getpid());
+    ssize_t res = readlink(procPath, path, SYS_MAX_PATH);
+
+#endif
+    if (res <= 0) {
+        LOG_ERROR("unable to retrieve absolute path.");
+    }
+
     return path;
 }
 

--- a/src/pc/platform.h
+++ b/src/pc/platform.h
@@ -20,7 +20,8 @@ bool sys_windows_short_path_from_wcs(char *destPath, size_t destSize, const wcha
 bool sys_windows_short_path_from_mbs(char* destPath, size_t destSize, const char *mbsLongPath);
 #endif
 const char *sys_user_path(void);
-const char *sys_exe_path(void);
+const char *sys_exe_path_dir(void);
+const char *sys_exe_path_file(void);
 const char *sys_file_extension(const char *fpath);
 const char *sys_file_name(const char *fpath);
 void sys_swap_backslashes(char* buffer);

--- a/src/pc/rom_checker.cpp
+++ b/src/pc/rom_checker.cpp
@@ -96,7 +96,7 @@ void legacy_folder_handler(void) {
 
 bool main_rom_handler(void) {
     if (scan_path_for_rom(fs_get_write_path(""))) { return true; }
-    scan_path_for_rom(sys_exe_path());
+    scan_path_for_rom(sys_exe_path_dir());
     return gRomIsValid;
 }
 


### PR DESCRIPTION
Reworked the platform-dependent executable paths code.

Testing required for cases when the game is installed in different directories, with Discord Activity enabled:
- Windows
    - simple paths (like `C:\Games\sm64coopdx\`)
    - paths with spaces and unicode characters (like `C:\users\Użytkownik\Desktop\My Games\Super Mario 64 Coop DX\`)
- Linux
    - simple paths (like `/home/user/Games/sm64coopdx/`)
    - paths with spaces (like `/home/user/Desktop/My Games/Super Mario 64 Coop DX/`)
- macOS

I can only confirm that this compiles for Linux and Windows, but I cannot test on macOS and I cannot test the Discord Invites feature at the moment.