### PR TITLE
Fix buffer length with coopnet description

### DIFF
--- a/src/pc/network/coopnet/coopnet.c
+++ b/src/pc/network/coopnet/coopnet.c
@@ -22,7 +22,7 @@
 
 uint64_t gCoopNetDesiredLobby = 0;
 char gCoopNetPassword[64] = "";
-char sCoopNetDescription[512] = "";
+char sCoopNetDescription[MAX_COOPNET_DESCRIPTION_LENGTH] = "";
 
 static uint64_t sLocalLobbyId = 0;
 static uint64_t sLocalLobbyOwnerId = 0;
@@ -176,7 +176,7 @@ bool ns_coopnet_is_connected(void) {
 
 static void coopnet_populate_description(void) {
     char* buffer = sCoopNetDescription;
-    int bufferLength = 1024;
+    int bufferLength = MAX_COOPNET_DESCRIPTION_LENGTH;
     // get version
     const char* version = get_version_online();
     int versionLength = strlen(version);

--- a/src/pc/network/coopnet/coopnet.h
+++ b/src/pc/network/coopnet/coopnet.h
@@ -9,6 +9,8 @@ extern struct NetworkSystem gNetworkSystemCoopNet;
 extern uint64_t gCoopNetDesiredLobby;
 extern char gCoopNetPassword[];
 
+#define MAX_COOPNET_DESCRIPTION_LENGTH 1024
+
 bool ns_coopnet_query(QueryCallbackPtr callback, QueryFinishCallbackPtr finishCallback, const char* password);
 bool ns_coopnet_is_connected(void);
 void ns_coopnet_update(void);

--- a/src/pc/network/coopnet/coopnet.h
+++ b/src/pc/network/coopnet/coopnet.h
@@ -2,14 +2,14 @@
 #define COOPNET_H
 #ifdef COOPNET
 
+#define MAX_COOPNET_DESCRIPTION_LENGTH 1024
+
 typedef void (*QueryCallbackPtr)(uint64_t aLobbyId, uint64_t aOwnerId, uint16_t aConnections, uint16_t aMaxConnections, const char* aGame, const char* aVersion, const char* aHostName, const char* aMode, const char* aDescription);
 typedef void (*QueryFinishCallbackPtr)(void);
 
 extern struct NetworkSystem gNetworkSystemCoopNet;
 extern uint64_t gCoopNetDesiredLobby;
 extern char gCoopNetPassword[];
-
-#define MAX_COOPNET_DESCRIPTION_LENGTH 1024
 
 bool ns_coopnet_query(QueryCallbackPtr callback, QueryFinishCallbackPtr finishCallback, const char* password);
 bool ns_coopnet_is_connected(void);


### PR DESCRIPTION
Resolves [this issue](https://github.com/coop-deluxe/sm64coopdx/issues/189).

So, the issue that was occurring was on line 183 of coopnet.c. On that line, `snprintf(buffer, bufferLength, "%s", version);` is being ran. This causes a crash due to an overflow. The reason this happens is because the `buffer` is set to `sCoopNetDescription`, which has a size of 512, but the `bufferLength` has a size of `1024`. To fix this, I chose to create a definition called `MAX_COOPNET_DESCRIPTION_LENGTH`, and plug that into the `bufferLength` and size of `sCoopNetDescription`, so to change that size, you only have to edit 1 variable.