### PR TITLE
Add `djui_attempting_to_open_playerlist`

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -8136,6 +8136,11 @@ function deref_s32_pointer(pointer)
 end
 
 --- @return boolean
+function djui_attempting_to_open_playerlist()
+    -- ...
+end
+
+--- @return boolean
 function djui_is_playerlist_open()
     -- ...
 end

--- a/docs/lua/functions-5.md
+++ b/docs/lua/functions-5.md
@@ -1953,6 +1953,24 @@
 
 <br />
 
+## [djui_attempting_to_open_playerlist](#djui_attempting_to_open_playerlist)
+
+### Lua Example
+`local booleanValue = djui_attempting_to_open_playerlist()`
+
+### Parameters
+- None
+
+### Returns
+- `boolean`
+
+### C Prototype
+`bool djui_attempting_to_open_playerlist(void);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ## [djui_is_playerlist_open](#djui_is_playerlist_open)
 
 ### Lua Example

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -1708,6 +1708,7 @@
    - [allocate_mario_action](functions-5.md#allocate_mario_action)
    - [course_is_main_course](functions-5.md#course_is_main_course)
    - [deref_s32_pointer](functions-5.md#deref_s32_pointer)
+   - [djui_attempting_to_open_playerlist](functions-5.md#djui_attempting_to_open_playerlist)
    - [djui_is_playerlist_open](functions-5.md#djui_is_playerlist_open)
    - [djui_is_popup_disabled](functions-5.md#djui_is_popup_disabled)
    - [djui_menu_get_font](functions-5.md#djui_menu_get_font)

--- a/src/pc/djui/djui_interactable.c
+++ b/src/pc/djui/djui_interactable.c
@@ -235,15 +235,18 @@ bool djui_interactable_on_key_down(int scancode) {
         }
     }
 
-    if ((gDjuiPlayerList != NULL || gDjuiModList != NULL) && gServerSettings.enablePlayerList) {
+    if ((gDjuiPlayerList != NULL || gDjuiModList != NULL)) {
         for (int i = 0; i < MAX_BINDS; i++) {
             if (scancode == (int)configKeyPlayerList[i] && !gDjuiInMainMenu && gNetworkType != NT_NONE) {
-                if (gDjuiPlayerList != NULL) {
-                    djui_base_set_visible(&gDjuiPlayerList->base, true);
+                if (gServerSettings.enablePlayerList) {
+                    if (gDjuiPlayerList != NULL) {
+                        djui_base_set_visible(&gDjuiPlayerList->base, true);
+                    }
+                    if (gDjuiModList != NULL) {
+                        djui_base_set_visible(&gDjuiModList->base, true);
+                    }
                 }
-                if (gDjuiModList != NULL) {
-                    djui_base_set_visible(&gDjuiModList->base, true);
-                }
+                gAttemptingToOpenPlayerlist = true;
                 break;
             }
             if (gDjuiPlayerList->base.visible) {
@@ -295,6 +298,7 @@ void djui_interactable_on_key_up(int scancode) {
                 if (gDjuiModList != NULL) {
                     djui_base_set_visible(&gDjuiModList->base, false);
                 }
+                gAttemptingToOpenPlayerlist = false;
                 break;
             }
         }

--- a/src/pc/djui/djui_panel_playerlist.c
+++ b/src/pc/djui/djui_panel_playerlist.c
@@ -11,6 +11,7 @@
 #include "pc/utils/misc.h"
 
 struct DjuiThreePanel* gDjuiPlayerList = NULL;
+bool gAttemptingToOpenPlayerlist = false;
 
 static struct DjuiFlowLayout* djuiRow[MAX_PLAYERS] = { 0 };
 static struct DjuiImage* djuiImages[MAX_PLAYERS] = { 0 };

--- a/src/pc/djui/djui_panel_playerlist.h
+++ b/src/pc/djui/djui_panel_playerlist.h
@@ -2,6 +2,7 @@
 #include "djui.h"
 
 extern struct DjuiThreePanel* gDjuiPlayerList;
+extern bool gAttemptingToOpenPlayerlist;
 
 extern const u8 sPlayerListSize;
 extern u8 sPageIndex;

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -30012,6 +30012,21 @@ int smlua_func_deref_s32_pointer(lua_State* L) {
     return 1;
 }
 
+int smlua_func_djui_attempting_to_open_playerlist(UNUSED lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 0) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "djui_attempting_to_open_playerlist", 0, top);
+        return 0;
+    }
+
+
+    lua_pushboolean(L, djui_attempting_to_open_playerlist());
+
+    return 1;
+}
+
 int smlua_func_djui_is_playerlist_open(UNUSED lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -34519,6 +34534,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "allocate_mario_action", smlua_func_allocate_mario_action);
     smlua_bind_function(L, "course_is_main_course", smlua_func_course_is_main_course);
     smlua_bind_function(L, "deref_s32_pointer", smlua_func_deref_s32_pointer);
+    smlua_bind_function(L, "djui_attempting_to_open_playerlist", smlua_func_djui_attempting_to_open_playerlist);
     smlua_bind_function(L, "djui_is_playerlist_open", smlua_func_djui_is_playerlist_open);
     smlua_bind_function(L, "djui_is_popup_disabled", smlua_func_djui_is_popup_disabled);
     smlua_bind_function(L, "djui_menu_get_font", smlua_func_djui_menu_get_font);

--- a/src/pc/lua/utils/smlua_misc_utils.c
+++ b/src/pc/lua/utils/smlua_misc_utils.c
@@ -91,6 +91,10 @@ bool djui_is_playerlist_open(void) {
     return gDjuiPlayerList->base.visible;
 }
 
+bool djui_attempting_to_open_playerlist(void) {
+    return gAttemptingToOpenPlayerlist;
+}
+
 enum DjuiFontType djui_menu_get_font(void) {
     return configDjuiThemeFont == 0 ? FONT_NORMAL : FONT_ALIASED;
 }

--- a/src/pc/lua/utils/smlua_misc_utils.h
+++ b/src/pc/lua/utils/smlua_misc_utils.h
@@ -50,6 +50,7 @@ bool djui_is_popup_disabled(void);
 void djui_set_popup_disabled_override(bool value);
 void djui_reset_popup_disabled_override(void);
 bool djui_is_playerlist_open(void);
+bool djui_attempting_to_open_playerlist(void);
 enum DjuiFontType djui_menu_get_font(void);
 
 s8 get_dialog_box_state(void);


### PR DESCRIPTION
Resolves #175

Since you can already disable the playerlist via `gServerSettings.enablePlayerList`, there was only one step to making #175 possible, that being allowing lua to detect if the playerlist was attempting to be opened, as outlined by Isaac.

I'm not fond of the implementation done here, however I couldn't think of a better implementation. Firstly, I create a global variable, `gAttemptingToOpenPlayerlist`. I create that variable in `djui_panel_playerlist.c` and define it in the corresponding .h file (could use a different location, since it isn't used in that c file). Then, in `smlua_misc_utils.c`, I create a function called `djui_attempting_to_open_playerlist` that just returns `gAttemptingToOpenPlayerlist`. This variable is set in the `djui_interactable_on_key_down ` and `djui_interactable_on_key_up` functions, where the playerlist visibility is also set.

Ideally there'd be a way I can detect what input is being pressed when the function `djui_attempting_to_open_playerlist` is being called, however I didn't find a way.

With this function, it's pretty easy to do what #175  was aiming to do. By first disabling the playerlist using `gServerSettings.enablePlayerList`, you can simply check if `djui_attempting_to_open_playerlist` is true. If it is, show the playerlist.