### PR TITLE
Update 4 example mods

### DIFF
--- a/docs/lua/examples/Mario-Run.lua
+++ b/docs/lua/examples/Mario-Run.lua
@@ -1,23 +1,16 @@
 -- name: Mario RUN!
 -- description: Mario is constantly running.
 
-Threshold = 50 --set Threshold to 50
+local speedThreshold = 50
 
-function mario_update(m)
-    --Prevent mario from ideling
-    if m.action == ACT_IDLE then --If idle
-        set_mario_action(m, ACT_WALKING, 0) --Make Mario walk
+local function mario_update(m)
+    --Prevent mario from crouching or idling
+    if m.action == ACT_IDLE or m.action == ACT_CROUCHING then
+        set_mario_action(m, ACT_WALKING, 0)
     end
 
-    --Crouching doesnt apply vel so prevent that
-    if m.action == ACT_CROUCHING then --If crouching
-        set_mario_action(m, ACT_WALKING, 0) --Make Mario walk
-    end
-
-    --Speed floor
-    if (m.forwardVel > Threshold) and (m.forwardVel < Threshold) then --If Mario isn't moveing fast enough
-        m.forwardVel = Threshold --set forwards velocity to whatevet the threashold is set to
-    end
+    -- Ensures that Mario moves at a speed greater than or equal to speedThreshold
+    m.forwardVel = math.max(m.forwardVel,speedThreshold)
 end
 
 -- hooks --

--- a/docs/lua/examples/Moonjump.lua
+++ b/docs/lua/examples/Moonjump.lua
@@ -1,7 +1,8 @@
 -- name: MoonJump
 -- description: Hold the A button to Moonjump
-function mario_update(m)
-    if (m.controller.buttonDown & A_BUTTON) ~= 0 then --If the A button is pressed
+
+local function mario_update(m)
+    if (m.controller.buttonDown & A_BUTTON) ~= 0 then --If the A button is held
         m.vel.y = 25 --Set Y velocity to 25
     end
 end

--- a/docs/lua/examples/hud.lua
+++ b/docs/lua/examples/hud.lua
@@ -1,15 +1,15 @@
 -- This file is an example of how to render to the screen
 
-rainbow = 0
+local rainbow = 0
 
-function test_text()
+local function test_text()
     -- set text and scale
     local text = "This is example text in the bottom right."
     local scale = 1
 
     -- render to native screen space, with the MENU font
-    djui_hud_set_resolution(RESOLUTION_DJUI);
-    djui_hud_set_font(FONT_MENU);
+    djui_hud_set_resolution(RESOLUTION_DJUI)
+    djui_hud_set_font(FONT_MENU)
 
     -- get width of screen and text
     local screenWidth = djui_hud_get_screen_width()
@@ -24,31 +24,23 @@ function test_text()
     local y = screenHeight - height
 
     -- set color and render
-    djui_hud_set_color(255, 0, 255, 255);
-    djui_hud_print_text(text, x, y, scale);
+    djui_hud_set_color(255, 0, 255, 255)
+    djui_hud_print_text(text, x, y, scale)
 end
 
-function test_texture()
+local function test_texture()
     -- render to N64's screen space
     djui_hud_set_resolution(RESOLUTION_N64)
 
     -- get player's character texture
     local tex = gMarioStates[0].character.hudHeadTexture
 
-    -- set scale
-    local wscale = 1
-    local hscale = 1
-
-    -- set position
-    local x = 256
-    local y = 64
-
-    -- set color and render
+    -- color and render
     djui_hud_set_color(255, 0, 255, 255)
-    djui_hud_render_texture(tex, x, y, wscale, hscale)
+    djui_hud_render_texture(tex, 256, 64, 1, 1)
 end
 
-function test_rect()
+local function test_rect()
     -- render to native screen space
     djui_hud_set_resolution(RESOLUTION_DJUI)
 
@@ -85,15 +77,31 @@ function test_rect()
     djui_hud_render_rect(x, y, w, h)
 end
 
-function test_rainbow_text()
+
+local function test_mouse()
+    -- render to native screen space (recommended for this)
+    djui_hud_set_resolution(RESOLUTION_DJUI)
+
+    -- get mouse position
+    local mouseX = djui_hud_get_mouse_x()
+    local mouseY = djui_hud_get_mouse_y()
+
+    local scale = 4
+
+    -- set color and render
+    djui_hud_set_color(255, 255, 255, 255)
+    djui_hud_render_texture(gTextures.arrow_up, mouseX, mouseY, scale, scale)
+end
+
+local function test_rainbow_text()
     -- this function is incredibly silly
     -- don't do anything like this
     local res = RESOLUTION_DJUI
     local text = "HELLO WORLD"
     local scale = 3
 
-    djui_hud_set_resolution(res);
-    djui_hud_set_font(FONT_NORMAL);
+    djui_hud_set_resolution(res)
+    djui_hud_set_font(FONT_NORMAL)
 
     for i=0,255 do
         j = rainbow / 50
@@ -107,17 +115,110 @@ function test_rainbow_text()
             g = 0
             b = 0
         end
-        djui_hud_set_color(r, g, b, i);
-        djui_hud_print_text(text, x, y, scale);
+        djui_hud_set_color(r, g, b, i)
+        djui_hud_print_text(text, x, y, scale)
     end
     rainbow = rainbow + 1
 end
 
-function on_hud_render()
+local function test_rotation()
+    -- render to native screen space
+    djui_hud_set_resolution(RESOLUTION_DJUI)
+
+    -- get SM64 global timer
+    local gt = get_global_timer()
+
+    -- rotate object around pivot (center)
+    djui_hud_set_rotation(gt * 512, 0.5, 0.5)
+
+    -- color and render
+    djui_hud_set_color(255, 255, 0, 128)
+    djui_hud_render_rect(1280, 512, 64, 64)
+
+    -- rotate object around pivot (top-left); color and render
+    djui_hud_set_rotation(gt * 512, 0, 0)
+    djui_hud_set_color(0, 255, 255, 128)
+    djui_hud_render_rect(1280, 512, 64, 64)
+
+    -- rotate object around pivot (bottom-right); color and render
+    djui_hud_set_rotation(gt * 512, 1, 1)
+    djui_hud_set_color(255, 0, 255, 128)
+    djui_hud_render_rect(1280, 512, 64, 64)
+end
+
+local function test_filtering()
+    local scale = 1
+
+    -- render to N64's screen space with the MENU font
+    djui_hud_set_resolution(RESOLUTION_N64)
+    djui_hud_set_font(FONT_HUD)
+    djui_hud_set_color(255, 255, 255, 255)
+
+    -- get height of screen and text
+    local screenHeight = djui_hud_get_screen_height()
+    local height = 16 * scale
+
+    local y = screenHeight - height
+
+    -- set filtering and render
+    djui_hud_set_filter(FILTER_NEAREST)
+    djui_hud_print_text("NEAREST", 0, y, scale)
+
+    -- adjust position 
+    y = y - height
+
+    -- set filtering and render
+    djui_hud_set_filter(FILTER_LINEAR)
+    djui_hud_print_text("LINEAR", 0, y, scale)
+end
+
+local function test_world_to_screen()
+    -- render to N64's screen space (recommended for this)
+    djui_hud_set_resolution(RESOLUTION_N64)
+
+    -- reset rotation and filtering from earlier
+    djui_hud_set_rotation(0, 0, 0)
+    djui_hud_set_filter(FILTER_NEAREST)
+
+    local out = {x = 0, y = 0, z = 0}
+    djui_hud_world_pos_to_screen_pos(gMarioStates[0].pos,out)
+
+    -- get player's character texture
+    local tex = gMarioStates[0].character.hudHeadTexture
+
+    djui_hud_set_color(255, 255, 255, 255)
+    djui_hud_render_texture(tex, out.x, out.y, 1, 1)
+end
+
+
+local function on_hud_render()
     test_text()
     test_rect()
     test_texture()
+    test_mouse()
     test_rainbow_text()
+    test_rotation()
+    test_filtering()
+    test_world_to_screen()
+end
+
+-- HOOK_ON_HUD_RENDER_BEHIND will render behind SM64's hud
+local function on_hud_render_behind()
+
+    local scale = 0.5
+    local text = "This text renders behind SM64's HUD!"
+
+    djui_hud_set_resolution(RESOLUTION_N64)
+    djui_hud_set_font(FONT_RECOLOR_HUD)
+
+    local screenWidth = djui_hud_get_screen_width()
+    local width = djui_hud_measure_text(text) * scale
+
+    local x = screenWidth - width
+
+    djui_hud_set_color(0, 255, 255, 255)
+    djui_hud_print_text(text, x, 22, scale)
 end
 
 hook_event(HOOK_ON_HUD_RENDER, on_hud_render)
+hook_event(HOOK_ON_HUD_RENDER_BEHIND, on_hud_render_behind)

--- a/docs/lua/examples/water-level.lua
+++ b/docs/lua/examples/water-level.lua
@@ -1,7 +1,7 @@
 -- name: Water Height Changer
 -- description: Use /waterset and /waterget to manipulate water height.
 
-function on_get_command(msg)
+local function on_get_command(msg)
     if not network_is_server() then
         djui_chat_message_create("You need to be the host!")
         return true
@@ -12,7 +12,7 @@ function on_get_command(msg)
     return true
 end
 
-function on_set_command(msg)
+local function on_set_command(msg)
     if not network_is_server() then
         djui_chat_message_create("You need to be the host!")
         return true

--- a/docs/lua/examples/water-level.lua
+++ b/docs/lua/examples/water-level.lua
@@ -7,9 +7,9 @@ function on_get_command(msg)
         return true
     end
 
-    djui_chat_message_create(tostring(get_environment_region(1)))
-    djui_chat_message_create(tostring(get_environment_region(2)))
-    return false
+    djui_chat_message_create(tostring(get_water_level(0)))
+    djui_chat_message_create(tostring(get_water_level(1)))
+    return true
 end
 
 function on_set_command(msg)
@@ -19,9 +19,14 @@ function on_set_command(msg)
     end
 
     local num = tonumber(msg)
-    set_environment_region(1, num)
-    set_environment_region(2, num)
-    return false
+    if not num then
+        djui_chat_message_create("Not a number!")
+        return true
+    end
+
+    set_water_level(0, num, true)
+    set_water_level(1, num, true)
+    return true
 end
 
 hook_chat_command("waterset", "to set the first two water levels", on_set_command)


### PR DESCRIPTION
Mario-Run.lua
  - Script was broken because it tried to check if mario's forward speed is below _and_ above a certain value; this is no longer the case

hud.lua
  - Added example functions for mouse position, rotation, filtering types, world-to-screen projection and rendering elements behind the hud via `HOOK_ON_HUD_RENDER_BEHIND`
  
water-level.lua
  - Now uses `get_water_level` and `set_water_level` instead of `get_environment_region` and `set_environment_region`
  - Added error handling for `on_set_command` to check if input is a number
  
Moonjump.lua
  - Updated a comment
