### PR TITLE
Add rotation interpolation

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -3199,6 +3199,16 @@ function djui_hud_set_rotation(rotation, pivotX, pivotY)
     -- ...
 end
 
+--- @param prevRotation integer
+--- @param prevPivotX number
+--- @param prevPivotY number
+--- @param rotation integer
+--- @param pivotX number
+--- @param pivotY number
+function djui_hud_set_rotation_interpolated(prevRotation, prevPivotX, prevPivotY, rotation, pivotX, pivotY)
+    -- ...
+end
+
 --- @param pos Vec3f
 --- @param out Vec3f
 --- @return boolean

--- a/autogen/lua_definitions/structs.lua
+++ b/autogen/lua_definitions/structs.lua
@@ -839,8 +839,8 @@
 --- @field public pivotY number
 --- @field public prevPivotX number
 --- @field public prevPivotY number
---- @field public rotation integer
---- @field public rotationDiff integer
+--- @field public rotation number
+--- @field public rotationDiff number
 
 --- @class InstantWarp
 --- @field public area integer

--- a/autogen/lua_definitions/structs.lua
+++ b/autogen/lua_definitions/structs.lua
@@ -837,7 +837,10 @@
 --- @class HudUtilsRotation
 --- @field public pivotX number
 --- @field public pivotY number
---- @field public rotation number
+--- @field public prevPivotX number
+--- @field public prevPivotY number
+--- @field public rotation integer
+--- @field public rotationDiff integer
 
 --- @class InstantWarp
 --- @field public area integer

--- a/docs/lua/functions-3.md
+++ b/docs/lua/functions-3.md
@@ -2594,6 +2594,31 @@
 
 <br />
 
+## [djui_hud_set_rotation_interpolated](#djui_hud_set_rotation_interpolated)
+
+### Lua Example
+`djui_hud_set_rotation_interpolated(prevRotation, prevPivotX, prevPivotY, rotation, pivotX, pivotY)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| prevRotation | `integer` |
+| prevPivotX | `number` |
+| prevPivotY | `number` |
+| rotation | `integer` |
+| pivotX | `number` |
+| pivotY | `number` |
+
+### Returns
+- None
+
+### C Prototype
+`void djui_hud_set_rotation_interpolated(s32 prevRotation, f32 prevPivotX, f32 prevPivotY, s32 rotation, f32 pivotX, f32 pivotY);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ## [djui_hud_world_pos_to_screen_pos](#djui_hud_world_pos_to_screen_pos)
 
 ### Lua Example

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -769,6 +769,7 @@
    - [djui_hud_set_mouse_locked](functions-3.md#djui_hud_set_mouse_locked)
    - [djui_hud_set_resolution](functions-3.md#djui_hud_set_resolution)
    - [djui_hud_set_rotation](functions-3.md#djui_hud_set_rotation)
+   - [djui_hud_set_rotation_interpolated](functions-3.md#djui_hud_set_rotation_interpolated)
    - [djui_hud_world_pos_to_screen_pos](functions-3.md#djui_hud_world_pos_to_screen_pos)
    - [djui_open_pause_menu](functions-3.md#djui_open_pause_menu)
 

--- a/docs/lua/structs.md
+++ b/docs/lua/structs.md
@@ -1159,8 +1159,8 @@
 | pivotY | `number` |  |
 | prevPivotX | `number` |  |
 | prevPivotY | `number` |  |
-| rotation | `integer` |  |
-| rotationDiff | `integer` |  |
+| rotation | `number` |  |
+| rotationDiff | `number` |  |
 
 [:arrow_up_small:](#)
 

--- a/docs/lua/structs.md
+++ b/docs/lua/structs.md
@@ -1157,7 +1157,10 @@
 | ----- | ---- | ------ |
 | pivotX | `number` |  |
 | pivotY | `number` |  |
-| rotation | `number` |  |
+| prevPivotX | `number` |  |
+| prevPivotY | `number` |  |
+| rotation | `integer` |  |
+| rotationDiff | `integer` |  |
 
 [:arrow_up_small:](#)
 

--- a/src/pc/djui/djui_hud_utils.c
+++ b/src/pc/djui/djui_hud_utils.c
@@ -415,7 +415,6 @@ void djui_hud_print_text_interpolated(const char* message, f32 prevX, f32 prevY,
     interp->z = savedZ;
     interp->resolution = sResolution;
     interp->rotation = sRotation;
-    
 }
 
 static inline bool is_power_of_two(u32 n) {

--- a/src/pc/djui/djui_hud_utils.c
+++ b/src/pc/djui/djui_hud_utils.c
@@ -134,25 +134,23 @@ void patch_djui_hud(f32 delta) {
         djui_hud_position_translate(&translatedX, &translatedY);
         create_dl_translation_matrix(DJUI_MTX_PUSH, translatedX, translatedY, gDjuiHudUtilsZ);
 
-       // rotate
-       f32 translatedW = scaleW;
-       f32 translatedH = scaleH;
-       s32 rotation = delta_interpolate_s32(sRotation.rotation - sRotation.rotationDiff, sRotation.rotation, delta);
-       f32 pivotX = delta_interpolate_f32(sRotation.prevPivotX, sRotation.pivotX, delta);
-       f32 pivotY = delta_interpolate_f32(sRotation.prevPivotY, sRotation.pivotY, delta);
-       djui_hud_size_translate(&translatedW);
-       djui_hud_size_translate(&translatedH);
-       if (sRotation.rotationDiff != 0 || sRotation.rotation != 0) {
-           f32 pivotTranslationX = translatedW * pivotX;
-           f32 pivotTranslationY = translatedH * pivotY;
-           create_dl_translation_matrix(DJUI_MTX_NOPUSH, +pivotTranslationX, -pivotTranslationY, 0);
-           create_dl_rotation_matrix(DJUI_MTX_NOPUSH, rotation, 0, 0, 1);
-           create_dl_translation_matrix(DJUI_MTX_NOPUSH, -pivotTranslationX, +pivotTranslationY, 0);
-       }
+        // rotate
+        f32 translatedW = scaleW;
+        f32 translatedH = scaleH;
+        s32 rotation = delta_interpolate_s32(sRotation.rotation - sRotation.rotationDiff, sRotation.rotation, delta);
+        f32 pivotX = delta_interpolate_f32(sRotation.prevPivotX, sRotation.pivotX, delta);
+        f32 pivotY = delta_interpolate_f32(sRotation.prevPivotY, sRotation.pivotY, delta);
+        djui_hud_size_translate(&translatedW);
+        djui_hud_size_translate(&translatedH);
+        if (sRotation.rotationDiff != 0 || sRotation.rotation != 0) {
+            f32 pivotTranslationX = translatedW * pivotX;
+            f32 pivotTranslationY = translatedH * pivotY;
+            create_dl_translation_matrix(DJUI_MTX_NOPUSH, +pivotTranslationX, -pivotTranslationY, 0);
+            create_dl_rotation_matrix(DJUI_MTX_NOPUSH, rotation, 0, 0, 1);
+            create_dl_translation_matrix(DJUI_MTX_NOPUSH, -pivotTranslationX, +pivotTranslationY, 0);
+        }
 
         // scale
-     // djui_hud_size_translate(&translatedW);
-     // djui_hud_size_translate(&translatedH);
         create_dl_scale_matrix(DJUI_MTX_NOPUSH, interp->width * translatedW, interp->height * translatedH, 1.0f);
     }
     sResolution = savedResolution;

--- a/src/pc/djui/djui_hud_utils.c
+++ b/src/pc/djui/djui_hud_utils.c
@@ -137,7 +137,7 @@ void patch_djui_hud(f32 delta) {
        // rotate
        f32 translatedW = scaleW;
        f32 translatedH = scaleH;
-       s32 rotation = delta_interpolate_s32(sRotation.rotation-sRotation.rotationDiff, sRotation.rotation, delta);
+       s32 rotation = delta_interpolate_s32(sRotation.rotation - sRotation.rotationDiff, sRotation.rotation, delta);
        f32 pivotX = delta_interpolate_f32(sRotation.prevPivotX, sRotation.pivotX, delta);
        f32 pivotY = delta_interpolate_f32(sRotation.prevPivotY, sRotation.pivotY, delta);
        djui_hud_size_translate(&translatedW);

--- a/src/pc/djui/djui_hud_utils.h
+++ b/src/pc/djui/djui_hud_utils.h
@@ -24,10 +24,10 @@ enum DjuiFontType {
 };
 
 struct HudUtilsRotation {
+    s32 rotation;
     s32 rotationDiff;
     f32 prevPivotX;
     f32 prevPivotY;
-    s32 rotation;
     f32 pivotX;
     f32 pivotY;
 };

--- a/src/pc/djui/djui_hud_utils.h
+++ b/src/pc/djui/djui_hud_utils.h
@@ -24,8 +24,8 @@ enum DjuiFontType {
 };
 
 struct HudUtilsRotation {
-    s32 rotation;
-    s32 rotationDiff;
+    f32 rotation;
+    f32 rotationDiff;
     f32 prevPivotX;
     f32 prevPivotY;
     f32 pivotX;

--- a/src/pc/djui/djui_hud_utils.h
+++ b/src/pc/djui/djui_hud_utils.h
@@ -24,7 +24,10 @@ enum DjuiFontType {
 };
 
 struct HudUtilsRotation {
-    f32 rotation;
+    s32 rotationDiff;
+    f32 prevPivotX;
+    f32 prevPivotY;
+    s32 rotation;
     f32 pivotX;
     f32 pivotY;
 };
@@ -61,6 +64,7 @@ void djui_hud_set_color(u8 r, u8 g, u8 b, u8 a);
 void djui_hud_reset_color(void);
 struct HudUtilsRotation* djui_hud_get_rotation(void);
 void djui_hud_set_rotation(s16 rotation, f32 pivotX, f32 pivotY);
+void djui_hud_set_rotation_interpolated(s32 prevRotation, f32 prevPivotX, f32 prevPivotY, s32 rotation, f32 pivotX, f32 pivotY);
 
 u32 djui_hud_get_screen_width(void);
 u32 djui_hud_get_screen_height(void);

--- a/src/pc/lua/smlua_cobject_autogen.c
+++ b/src/pc/lua/smlua_cobject_autogen.c
@@ -942,11 +942,14 @@ static struct LuaObjectField sHandheldShakePointFields[LUA_HANDHELD_SHAKE_POINT_
     { "point", LVT_COBJECT, offsetof(struct HandheldShakePoint, point), true,  LOT_VEC3S },
 };
 
-#define LUA_HUD_UTILS_ROTATION_FIELD_COUNT 3
+#define LUA_HUD_UTILS_ROTATION_FIELD_COUNT 6
 static struct LuaObjectField sHudUtilsRotationFields[LUA_HUD_UTILS_ROTATION_FIELD_COUNT] = {
-    { "pivotX",   LVT_F32, offsetof(struct HudUtilsRotation, pivotX),   false, LOT_NONE },
-    { "pivotY",   LVT_F32, offsetof(struct HudUtilsRotation, pivotY),   false, LOT_NONE },
-    { "rotation", LVT_F32, offsetof(struct HudUtilsRotation, rotation), false, LOT_NONE },
+    { "pivotX",       LVT_F32, offsetof(struct HudUtilsRotation, pivotX),       false, LOT_NONE },
+    { "pivotY",       LVT_F32, offsetof(struct HudUtilsRotation, pivotY),       false, LOT_NONE },
+    { "prevPivotX",   LVT_F32, offsetof(struct HudUtilsRotation, prevPivotX),   false, LOT_NONE },
+    { "prevPivotY",   LVT_F32, offsetof(struct HudUtilsRotation, prevPivotY),   false, LOT_NONE },
+    { "rotation",     LVT_S32, offsetof(struct HudUtilsRotation, rotation),     false, LOT_NONE },
+    { "rotationDiff", LVT_S32, offsetof(struct HudUtilsRotation, rotationDiff), false, LOT_NONE },
 };
 
 #define LUA_INSTANT_WARP_FIELD_COUNT 3

--- a/src/pc/lua/smlua_cobject_autogen.c
+++ b/src/pc/lua/smlua_cobject_autogen.c
@@ -948,8 +948,8 @@ static struct LuaObjectField sHudUtilsRotationFields[LUA_HUD_UTILS_ROTATION_FIEL
     { "pivotY",       LVT_F32, offsetof(struct HudUtilsRotation, pivotY),       false, LOT_NONE },
     { "prevPivotX",   LVT_F32, offsetof(struct HudUtilsRotation, prevPivotX),   false, LOT_NONE },
     { "prevPivotY",   LVT_F32, offsetof(struct HudUtilsRotation, prevPivotY),   false, LOT_NONE },
-    { "rotation",     LVT_S32, offsetof(struct HudUtilsRotation, rotation),     false, LOT_NONE },
-    { "rotationDiff", LVT_S32, offsetof(struct HudUtilsRotation, rotationDiff), false, LOT_NONE },
+    { "rotation",     LVT_F32, offsetof(struct HudUtilsRotation, rotation),     false, LOT_NONE },
+    { "rotationDiff", LVT_F32, offsetof(struct HudUtilsRotation, rotationDiff), false, LOT_NONE },
 };
 
 #define LUA_INSTANT_WARP_FIELD_COUNT 3

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -12679,6 +12679,33 @@ int smlua_func_djui_hud_set_rotation(lua_State* L) {
     return 1;
 }
 
+int smlua_func_djui_hud_set_rotation_interpolated(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 6) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "djui_hud_set_rotation_interpolated", 6, top);
+        return 0;
+    }
+
+    s32 prevRotation = smlua_to_integer(L, 1);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "djui_hud_set_rotation_interpolated"); return 0; }
+    f32 prevPivotX = smlua_to_number(L, 2);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "djui_hud_set_rotation_interpolated"); return 0; }
+    f32 prevPivotY = smlua_to_number(L, 3);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "djui_hud_set_rotation_interpolated"); return 0; }
+    s32 rotation = smlua_to_integer(L, 4);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 4, "djui_hud_set_rotation_interpolated"); return 0; }
+    f32 pivotX = smlua_to_number(L, 5);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 5, "djui_hud_set_rotation_interpolated"); return 0; }
+    f32 pivotY = smlua_to_number(L, 6);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 6, "djui_hud_set_rotation_interpolated"); return 0; }
+
+    djui_hud_set_rotation_interpolated(prevRotation, prevPivotX, prevPivotY, rotation, pivotX, pivotY);
+
+    return 1;
+}
+
 int smlua_func_djui_hud_world_pos_to_screen_pos(lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -33634,6 +33661,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "djui_hud_set_mouse_locked", smlua_func_djui_hud_set_mouse_locked);
     smlua_bind_function(L, "djui_hud_set_resolution", smlua_func_djui_hud_set_resolution);
     smlua_bind_function(L, "djui_hud_set_rotation", smlua_func_djui_hud_set_rotation);
+    smlua_bind_function(L, "djui_hud_set_rotation_interpolated", smlua_func_djui_hud_set_rotation_interpolated);
     smlua_bind_function(L, "djui_hud_world_pos_to_screen_pos", smlua_func_djui_hud_world_pos_to_screen_pos);
     smlua_bind_function(L, "djui_open_pause_menu", smlua_func_djui_open_pause_menu);
 


### PR DESCRIPTION
A new function, `djui_hud_set_rotation_interpolated`, has been added, which allows rotation and pivot point interpolation for interpolated DJUI elements. The function takes `s32`s for the angles instead of `s16`s to allow for wide rotations.