### PR TITLE
Fix Cheat Mod Menu

### DIFF
--- a/mods/cheats.lua
+++ b/mods/cheats.lua
@@ -349,7 +349,7 @@ end
 --- @param value boolean
 local function update_cheat(index, value)
     for i, cheat in ipairs(sCheats) do
-        if i - 1 == index then
+        if i == index then
             gPlayerSyncTable[0][cheat.codename] = value
         end
     end


### PR DESCRIPTION
Each cheat did not work as labelled. The checkbox for the second cheat listed activated the first cheat listed, and the third checkbox did the second cheat, and so on.

The "- 1" in Line 352 did not need to be there.