### PR TITLE
Mumble Positional Audio Integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -506,6 +506,8 @@ ifeq ($(DISCORD_SDK),1)
   SRC_DIRS += src/pc/discord
 endif
 
+SRC_DIRS += src/pc/mumble
+
 ULTRA_SRC_DIRS := lib/src lib/src/math lib/asm lib/data
 ULTRA_BIN_DIRS := lib/bin
 

--- a/src/pc/mumble/mumble.c
+++ b/src/pc/mumble/mumble.c
@@ -1,0 +1,123 @@
+// adapted from https://www.mumble.info/documentation/developer/positional-audio/link-plugin/
+#include "mumble.h"
+
+#include "engine/math_util.h"
+
+#include "game/level_update.h"
+#include "game/camera.h"
+#include "game/area.h"
+
+#include "pc/configfile.h"
+
+
+#ifdef _WIN32
+	#include <windows.h>
+#else
+	#include <sys/mman.h>
+	#include <fcntl.h> /* For O_* constants */
+#endif // _WIN32
+
+struct LinkedMem *lm = NULL;
+
+void initMumble(void) {
+
+#ifdef _WIN32
+	HANDLE hMapObject = OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, L"MumbleLink");
+	if (hMapObject == NULL)
+		return;
+
+
+	lm = (struct LinkedMem *) MapViewOfFile(hMapObject, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(struct LinkedMem));
+	if (lm == NULL) {
+		CloseHandle(hMapObject);
+		hMapObject = NULL;
+		return;
+	}
+#else
+	char memname[256];
+	snprintf(memname, 256, "/MumbleLink.%d", getuid());
+
+	int shmfd = shm_open(memname, O_RDWR, S_IRUSR | S_IWUSR);
+
+	if (shmfd < 0) {
+		return;
+	}
+
+	lm = (LinkedMem *)(mmap(NULL, sizeof(struct LinkedMem), PROT_READ | PROT_WRITE, MAP_SHARED, shmfd,0));
+
+	if (lm == (void *)(-1)) {
+		lm = NULL;
+		return;
+	}
+#endif
+
+	if(lm->uiVersion != 2) {
+		wcsncpy(lm->name, L"SM64 Coop Deluxe", 256);
+		wcsncpy(lm->description, L"SM64 Coop Deluxe support via the Link plugin.", 2048);
+		lm->uiVersion = 2;
+	}
+
+    // not necessary, but we can set it here and forget about it
+    mbstowcs(lm->identity, configPlayerName, 256);
+
+    lm->context_len = 20;
+}
+
+void updateMumble(void) {
+
+	if (! lm) {
+		return;
+    }
+
+	lm->uiTick++;
+
+    // The hitbox is 160.0 for standing and 100.0 for crouching
+    // Also subtract a bit to go from top of the head to the middle
+    float headHeight = gMarioState->marioObj->hitboxHeight - 60;
+
+    // divide by 100 to convert units to meters as mumble expects
+	lm->fAvatarPosition[0] = gMarioState->pos[0] / 100;
+	lm->fAvatarPosition[1] = (gMarioState->pos[1] + headHeight) / 100;
+	lm->fAvatarPosition[2] = gMarioState->pos[2] / 100;
+
+    // mumble expects a unit vector so we need to convert the face angle
+    Vec3f faceVector;
+    faceVector[0] = coss(gMarioState->faceAngle[0]) * sins(gMarioState->faceAngle[1]);
+    faceVector[1] = sins(gMarioState->faceAngle[0]);
+    faceVector[2] = coss(gMarioState->faceAngle[0]) * coss(gMarioState->faceAngle[1]);
+    vec3f_normalize(faceVector);
+
+	lm->fAvatarFront[0] = faceVector[0];
+	lm->fAvatarFront[1] = faceVector[1];
+	lm->fAvatarFront[2] = faceVector[2];
+
+	// camera position
+	lm->fCameraPosition[0] = gLakituState.pos[0] / 100;
+	lm->fCameraPosition[1] = gLakituState.pos[1] / 100;
+	lm->fCameraPosition[2] = gLakituState.pos[2] / 100;
+
+    // get the unit vector direction of the camera
+    Vec3f normal;
+    vec3f_dif(normal, gLakituState.focus, gLakituState.pos);
+    vec3f_normalize(normal);
+
+	lm->fCameraFront[0] = normal[0];
+	lm->fCameraFront[1] = normal[1];
+	lm->fCameraFront[2] = normal[2];
+
+    // players with the same context can hear eachother, and is a concat of:
+    // level, area, and room
+    //
+    // some rooms are just small areas around doors which is a bit annoying as
+    // audio will cut out for players standing close to them or walking between,
+    // but I haven't found a good way to detect such rooms. It is better than 
+    // hearing through walls though, so a minor inconvience for now.
+    // 
+    // I might go through manually map levels and rooms which are not 'rooms' to
+    // and skip over them here as a work around if there is nothing better.
+    // JR - 2024-Jul-27
+
+    char context[20];
+    snprintf(context, 20, "%d-%d-%d", gCurrLevelNum, gCurrAreaIndex, gMarioState->currentRoom);
+    memcpy(lm->context, (unsigned char*)context, 20);
+}

--- a/src/pc/mumble/mumble.c
+++ b/src/pc/mumble/mumble.c
@@ -1,4 +1,5 @@
 // adapted from https://www.mumble.info/documentation/developer/positional-audio/link-plugin/
+
 #include "mumble.h"
 
 #include "engine/math_util.h"
@@ -8,8 +9,6 @@
 #include "game/area.h"
 
 #include "pc/configfile.h"
-
-
 
 #ifdef _WIN32
 	#include <windows.h>
@@ -27,7 +26,6 @@ void mumble_init(void) {
 	HANDLE hMapObject = OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, L"MumbleLink");
 	if (hMapObject == NULL)
 		return;
-
 
 	lm = (struct LinkedMem *) MapViewOfFile(hMapObject, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(struct LinkedMem));
 	if (lm == NULL) {

--- a/src/pc/mumble/mumble.c
+++ b/src/pc/mumble/mumble.c
@@ -83,44 +83,45 @@ void mumble_update(void) {
 	lm->fAvatarPosition[2] = gMarioState->pos[2] / 100;
 
     // mumble expects a unit vector so we need to convert the face angle
-    // it also seems to have x and z inverted
     Vec3f faceVector;
     faceVector[0] = coss(gMarioState->faceAngle[0]) * sins(gMarioState->faceAngle[1]);
     faceVector[1] = sins(gMarioState->faceAngle[0]);
     faceVector[2] = coss(gMarioState->faceAngle[0]) * coss(gMarioState->faceAngle[1]);
     vec3f_normalize(faceVector);
 
-	lm->fAvatarFront[0] = -faceVector[0];
-	lm->fAvatarFront[1] = faceVector[1];
-	lm->fAvatarFront[2] = -faceVector[2];
+    // mumble also seems to have x and z inverted
+    lm->fAvatarFront[0] = -faceVector[0];
+    lm->fAvatarFront[1] = faceVector[1];
+    lm->fAvatarFront[2] = -faceVector[2];
 
-	// camera position
-	lm->fCameraPosition[0] = gLakituState.pos[0] / 100;
-	lm->fCameraPosition[1] = gLakituState.pos[1] / 100;
-	lm->fCameraPosition[2] = gLakituState.pos[2] / 100;
+    // the actual camera can move too far away, and players will be louder near
+    // the camera, which can be diorienting, so we use the player pos instead.
+	lm->fCameraPosition[0] = gMarioState->pos[0] / 100;
+	lm->fCameraPosition[1] = (gMarioState->pos[1] + headHeight) / 100;
+	lm->fCameraPosition[2] = gMarioState->pos[2] / 100;
 
-    // get the unit vector direction of the camera
+    // still use the direction of the camera, so make it into a unit vector
     Vec3f normal;
     vec3f_dif(normal, gLakituState.focus, gLakituState.pos);
     vec3f_normalize(normal);
 
-	lm->fCameraFront[0] = -normal[0];
-	lm->fCameraFront[1] = normal[1];
-	lm->fCameraFront[2] = -normal[2];
+    lm->fCameraFront[0] = -normal[0];
+    lm->fCameraFront[1] = normal[1];
+    lm->fCameraFront[2] = -normal[2];
 
     // players with the same context can hear eachother, and is a concat of:
     // level, area, and room
     //
     // some rooms are just small areas around doors which is a bit annoying as
     // audio will cut out for players standing close to them or walking between,
-    // but I haven't found a good way to detect such rooms. It is better than 
+    // but I haven't found a good way to detect such rooms. It is better than
     // hearing through walls though, so a minor inconvience for now.
-    // 
+    //
     // I might go through manually map levels and rooms which are not 'rooms' to
     // and skip over them here as a work around if there is nothing better.
     // JR - 2024-Jul-27
 
     char context[20];
     snprintf(context, 20, "%d-%d-%d", gCurrLevelNum, gCurrAreaIndex, gMarioState->currentRoom);
-    memcpy(lm->context, (unsigned char*)context, 20);
+    memcpy(lm->context, (unsigned char *) context, 20);
 }

--- a/src/pc/mumble/mumble.c
+++ b/src/pc/mumble/mumble.c
@@ -9,6 +9,7 @@
 #include "game/area.h"
 
 #include "pc/configfile.h"
+#include "pc/djui/djui.h"
 
 #ifdef _WIN32
 	#include <windows.h>
@@ -19,6 +20,8 @@
 #endif // _WIN32
 
 struct LinkedMem *lm = NULL;
+
+extern bool gIsDemoActive;
 
 void mumble_init(void) {
 
@@ -71,6 +74,12 @@ void mumble_update(void) {
 
 	lm->uiTick++;
 
+    if (gDjuiInMainMenu)
+    {
+        mumble_update_menu();
+        return;
+    }
+
     // The hitbox is 160.0 for standing and 100.0 for crouching
     // Also subtract a bit to go from top of the head to the middle
     float headHeight = gMarioState->marioObj->hitboxHeight - 60;
@@ -122,4 +131,25 @@ void mumble_update(void) {
     char context[20];
     snprintf(context, 20, "%d-%d-%d", gCurrLevelNum, gCurrAreaIndex, gMarioState->currentRoom);
     memcpy(lm->context, (unsigned char *) context, 20);
+}
+
+void mumble_update_menu() {
+
+	lm->fAvatarPosition[0] = 0.0f;
+	lm->fAvatarPosition[1] = 0.0f;
+	lm->fAvatarPosition[2] = 1.0f;
+
+	lm->fAvatarFront[0] = 0.0f;
+	lm->fAvatarFront[1] = 0.0f;
+	lm->fAvatarFront[2] = 1.0f;
+
+	lm->fCameraPosition[0] = 0.0f;
+	lm->fCameraPosition[1] = 0.0f;
+	lm->fCameraPosition[2] = 0.0f;
+
+	lm->fCameraFront[0] = 0.0f;
+	lm->fCameraFront[1] = 0.0f;
+	lm->fCameraFront[2] = 1.0f;
+
+    memcpy(lm->context, "mainmenu\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 20);
 }

--- a/src/pc/mumble/mumble.c
+++ b/src/pc/mumble/mumble.c
@@ -10,11 +10,13 @@
 #include "pc/configfile.h"
 
 
+
 #ifdef _WIN32
 	#include <windows.h>
 #else
 	#include <sys/mman.h>
 	#include <fcntl.h> /* For O_* constants */
+	#include <libc.h>
 #endif // _WIN32
 
 struct LinkedMem *lm = NULL;
@@ -43,7 +45,7 @@ void initMumble(void) {
 		return;
 	}
 
-	lm = (LinkedMem *)(mmap(NULL, sizeof(struct LinkedMem), PROT_READ | PROT_WRITE, MAP_SHARED, shmfd,0));
+	lm = (struct LinkedMem *)(mmap(NULL, sizeof(struct LinkedMem), PROT_READ | PROT_WRITE, MAP_SHARED, shmfd,0));
 
 	if (lm == (void *)(-1)) {
 		lm = NULL;

--- a/src/pc/mumble/mumble.c
+++ b/src/pc/mumble/mumble.c
@@ -83,15 +83,16 @@ void mumble_update(void) {
 	lm->fAvatarPosition[2] = gMarioState->pos[2] / 100;
 
     // mumble expects a unit vector so we need to convert the face angle
+    // it also seems to have x and z inverted
     Vec3f faceVector;
     faceVector[0] = coss(gMarioState->faceAngle[0]) * sins(gMarioState->faceAngle[1]);
     faceVector[1] = sins(gMarioState->faceAngle[0]);
     faceVector[2] = coss(gMarioState->faceAngle[0]) * coss(gMarioState->faceAngle[1]);
     vec3f_normalize(faceVector);
 
-	lm->fAvatarFront[0] = faceVector[0];
+	lm->fAvatarFront[0] = -faceVector[0];
 	lm->fAvatarFront[1] = faceVector[1];
-	lm->fAvatarFront[2] = faceVector[2];
+	lm->fAvatarFront[2] = -faceVector[2];
 
 	// camera position
 	lm->fCameraPosition[0] = gLakituState.pos[0] / 100;
@@ -103,9 +104,9 @@ void mumble_update(void) {
     vec3f_dif(normal, gLakituState.focus, gLakituState.pos);
     vec3f_normalize(normal);
 
-	lm->fCameraFront[0] = normal[0];
+	lm->fCameraFront[0] = -normal[0];
 	lm->fCameraFront[1] = normal[1];
-	lm->fCameraFront[2] = normal[2];
+	lm->fCameraFront[2] = -normal[2];
 
     // players with the same context can hear eachother, and is a concat of:
     // level, area, and room

--- a/src/pc/mumble/mumble.c
+++ b/src/pc/mumble/mumble.c
@@ -21,7 +21,7 @@
 
 struct LinkedMem *lm = NULL;
 
-void initMumble(void) {
+void mumble_init(void) {
 
 #ifdef _WIN32
 	HANDLE hMapObject = OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, L"MumbleLink");
@@ -65,7 +65,7 @@ void initMumble(void) {
     lm->context_len = 20;
 }
 
-void updateMumble(void) {
+void mumble_update(void) {
 
 	if (! lm) {
 		return;

--- a/src/pc/mumble/mumble.h
+++ b/src/pc/mumble/mumble.h
@@ -1,0 +1,29 @@
+#ifndef MUMBLE_H
+#define MUMBLE_H
+
+#include <stdint.h>
+
+struct LinkedMem {
+
+	uint32_t uiVersion;
+	uint32_t uiTick;
+
+	float	fAvatarPosition[3];
+	float	fAvatarFront[3];
+	float	fAvatarTop[3];
+	wchar_t	name[256];
+	float	fCameraPosition[3];
+	float	fCameraFront[3];
+	float	fCameraTop[3];
+	wchar_t	identity[256];
+
+	uint32_t	context_len;
+
+	unsigned char context[256];
+	wchar_t description[2048];
+};
+
+void initMumble(void);
+void updateMumble(void);
+
+#endif /* MUMBLE_H */

--- a/src/pc/mumble/mumble.h
+++ b/src/pc/mumble/mumble.h
@@ -26,5 +26,6 @@ struct LinkedMem {
 
 void mumble_init(void);
 void mumble_update(void);
+void mumble_update_menu(void);
 
 #endif /* MUMBLE_H */

--- a/src/pc/mumble/mumble.h
+++ b/src/pc/mumble/mumble.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#include <wchar.h>
+
 struct LinkedMem {
 
 	uint32_t uiVersion;

--- a/src/pc/mumble/mumble.h
+++ b/src/pc/mumble/mumble.h
@@ -25,7 +25,7 @@ struct LinkedMem {
 	wchar_t description[2048];
 };
 
-void initMumble(void);
-void updateMumble(void);
+void mumble_init(void);
+void mumble_update(void);
 
 #endif /* MUMBLE_H */

--- a/src/pc/mumble/mumble.h
+++ b/src/pc/mumble/mumble.h
@@ -2,7 +2,6 @@
 #define MUMBLE_H
 
 #include <stdint.h>
-
 #include <wchar.h>
 
 struct LinkedMem {

--- a/src/pc/mumble/mumble.h
+++ b/src/pc/mumble/mumble.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <wchar.h>
+#include <stdbool.h>
 
 struct LinkedMem {
 
@@ -27,5 +28,7 @@ struct LinkedMem {
 void mumble_init(void);
 void mumble_update(void);
 void mumble_update_menu(void);
+
+bool should_update_context(void);
 
 #endif /* MUMBLE_H */

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -461,7 +461,7 @@ int main(int argc, char *argv[]) {
         network_init(NT_NONE, false);
     }
 
-    initMumble();
+    mumble_init();
 
     // main loop
     while (true) {
@@ -471,7 +471,7 @@ int main(int argc, char *argv[]) {
 #ifdef DISCORD_SDK
         discord_update();
 #endif
-        updateMumble();
+        mumble_update();
 #ifdef DEBUG
         fflush(stdout);
         fflush(stderr);

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -59,6 +59,8 @@
 #include "pc/discord/discord.h"
 #endif
 
+#include "pc/mumble/mumble.h"
+
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 #endif
@@ -459,6 +461,8 @@ int main(int argc, char *argv[]) {
         network_init(NT_NONE, false);
     }
 
+    initMumble();
+
     // main loop
     while (true) {
         debug_context_reset();
@@ -467,6 +471,7 @@ int main(int argc, char *argv[]) {
 #ifdef DISCORD_SDK
         discord_update();
 #endif
+        updateMumble();
 #ifdef DEBUG
         fflush(stdout);
         fflush(stderr);


### PR DESCRIPTION
Hi,

I've adapted the positional audio link plugin Mumble provide into sm64 coop dx. The mumble connection relies on sharing memory so I figured it would be more appropriate to integrate it into the project proper rather than as a mod.

the plugin details can be found here: https://www.mumble.info/documentation/developer/positional-audio/link-plugin/

![image](https://github.com/user-attachments/assets/c462c169-6386-45fc-b544-ab10c76e25c5)


I've tested it on Windows and OSX, and verified that the audio positioning works as expected by testing with two players connected to mumble. 


Let me know if there is anything else you need for the PR, otherwise happy to see it become part of the project!



