### PR TITLE
Fix build on Linux

### DIFF
--- a/src/pc/mumble/mumble.c
+++ b/src/pc/mumble/mumble.c
@@ -18,7 +18,7 @@
 #else
 	#include <sys/mman.h>
 	#include <fcntl.h> /* For O_* constants */
-	#include <libc.h>
+	#include <unistd.h>
 #endif // _WIN32
 
 struct LinkedMem *lm = NULL;


### PR DESCRIPTION
The newly added Mumble support fails to build on Linux due to the lack of the `libc.h` header (my assumption is that the non-Windows includes were mainly tested on macOS, where that header does exist). This replaces it with an include for the `unistd.h` header, which works on both macOS and Linux and is where the `getuid` function is actually defined.