### PR TITLE
Implemented smlua_text_utils_dialog_get

### DIFF
--- a/autogen/convert_functions.py
+++ b/autogen/convert_functions.py
@@ -117,7 +117,7 @@ override_disallowed_functions = {
     "src/pc/lua/utils/smlua_audio_utils.h":     [ "smlua_audio_utils_override", "audio_custom_shutdown", "smlua_audio_custom_init", "smlua_audio_custom_deinit", "audio_sample_destroy_pending_copies", "audio_custom_update_volume" ],
     "src/pc/djui/djui_hud_utils.h":             [ "djui_hud_render_texture", "djui_hud_render_texture_raw", "djui_hud_render_texture_tile", "djui_hud_render_texture_tile_raw" ],
     "src/pc/lua/utils/smlua_level_utils.h":     [ "smlua_level_util_reset" ],
-    "src/pc/lua/utils/smlua_text_utils.h":      [ "smlua_text_utils_init", "smlua_text_utils_shutdown", "smlua_text_utils_reset_all" ],
+    "src/pc/lua/utils/smlua_text_utils.h":      [ "smlua_text_utils_init", "smlua_text_utils_shutdown", "smlua_text_utils_reset_all", "smlua_text_utils_dialog_get" ],
     "src/pc/lua/utils/smlua_anim_utils.h":      [ "smlua_anim_util_reset", "smlua_anim_util_register_animation" ],
     "src/pc/network/lag_compensation.h":        [ "lag_compensation_clear", "lag_compensation_store" ],
     "src/game/first_person_cam.h":              [ "first_person_update" ],

--- a/src/pc/lua/smlua_functions.c
+++ b/src/pc/lua/smlua_functions.c
@@ -15,6 +15,7 @@
 #include "include/macro_presets.h"
 #include "utils/smlua_anim_utils.h"
 #include "utils/smlua_collision_utils.h"
+#include "utils/smlua_text_utils.h"
 
 bool smlua_functions_valid_param_count(lua_State* L, int expected) {
     int top = lua_gettop(L);
@@ -814,6 +815,58 @@ int smlua_func_log_to_console(lua_State* L) {
     return 1;
 }
 
+  /////////////
+ // dialogs //
+/////////////
+
+int smlua_func_smlua_text_utils_dialog_get(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 1) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "smlua_text_utils_dialog_get", 1, top);
+        return 0;
+    }
+
+    int dialogId = smlua_to_integer(L, 1);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "smlua_text_utils_dialog_get"); return 0; }
+
+    struct DialogEntry *dialog = smlua_text_utils_dialog_get(dialogId);
+
+    if (!dialog) { return 0; }
+
+    static char output[DIALOG_MAXIMUM_LENGTH];
+    convert_string_sm64_to_ascii(output, segmented_to_virtual(dialog->str));
+
+    lua_newtable(L);
+
+    lua_pushstring(L, "str");
+    lua_pushstring(L, output);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "dialogId");
+    lua_pushinteger(L, dialogId);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "unused");
+    lua_pushinteger(L, dialog->unused);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "linesPerBox");
+    lua_pushinteger(L, dialog->linesPerBox);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "leftOffset");
+    lua_pushinteger(L, dialog->leftOffset);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "width");
+    lua_pushinteger(L, dialog->width);
+    lua_settable(L, -3);
+
+    return 1;
+}
+
   ////////////////////
  // scroll targets //
 ////////////////////
@@ -902,4 +955,5 @@ void smlua_bind_functions(void) {
     smlua_bind_function(L, "log_to_console", smlua_func_log_to_console);
     smlua_bind_function(L, "add_scroll_target", smlua_func_add_scroll_target);
     smlua_bind_function(L, "collision_find_surface_on_ray", smlua_func_collision_find_surface_on_ray);
+    smlua_bind_function(L, "smlua_text_utils_dialog_get", smlua_func_smlua_text_utils_dialog_get);
 }

--- a/src/pc/lua/utils/smlua_text_utils.h
+++ b/src/pc/lua/utils/smlua_text_utils.h
@@ -4,6 +4,8 @@
 #include "types.h"
 #include "dialog_ids.h"
 
+#define DIALOG_MAXIMUM_LENGTH 1024
+
 #define MAX_ACTS 6
 #define MAX_ACTS_AND_100_COINS 7
 
@@ -25,6 +27,7 @@ extern struct CourseName *gReplacedActNameTable[];
 void smlua_text_utils_init(void);
 void smlua_text_utils_shutdown(void);
 void smlua_text_utils_reset_all(void);
+struct DialogEntry* smlua_text_utils_dialog_get(enum DialogId dialogId);
 void smlua_text_utils_dialog_replace(enum DialogId dialogId, u32 unused, s8 linesPerBox, s16 leftOffset, s16 width, const char* str);
 void smlua_text_utils_course_acts_replace(s16 courseNum, const char* courseName, const char* act1, const char* act2, const char* act3, const char* act4, const char* act5, const char* act6);
 void smlua_text_utils_secret_star_replace(s16 courseNum, const char* courseName);
@@ -39,5 +42,7 @@ void smlua_text_utils_act_name_reset(s16 courseNum, u8 actNum);
 void smlua_text_utils_castle_secret_stars_replace(const char* name);
 void smlua_text_utils_extra_text_replace(s16 index, const char* text);
 const char* smlua_text_utils_get_language(void);
+
+void convert_string_sm64_to_ascii(char *strAscii, const u8 *str64);
 
 #endif


### PR DESCRIPTION
- Implemented `smlua_text_utils_dialog_get` as a new Lua API function.
  - This function returns a table providing the information for a given line of dialog.
  - This allows for mods to create custom dialog interfaces, and for mods to perform inline replacements on the text of existing dialog (for example, replacing one name with another)
  - This function respects any previous replacements that have been performed using `smlua_text_utils_dialog_replace`.
- Added a hard-coded limit of 1024 characters to `smlua_text_utils_dialog_replace`.
  - This should not conflict with the vanilla game, as the longest dialog is the Lakitu roughly 780 characters.
- Added a Lua log warning to `smlua_text_utils_dialog_replace` which displays if the provided string exceeds the hard-coded length limit of `1024`.
- Added a Lua log warning to `smlua_text_utils_dialog_replace` which displays if the target dialog ID is invalid (outside the range of 1-170).