### PR TITLE
Fix Linux compilation issues with mumble.c

### DIFF
--- a/src/pc/mumble/mumble.c
+++ b/src/pc/mumble/mumble.c
@@ -18,7 +18,7 @@
 #else
 	#include <sys/mman.h>
 	#include <fcntl.h> /* For O_* constants */
-	#include <libc.h>
+	#include <unistd.h> /* Fixes compilation issues on linux */
 #endif // _WIN32
 
 struct LinkedMem *lm = NULL;


### PR DESCRIPTION
Found this issue on my system when trying to compile the latest version (v 1.0.3) on my Nobara 40 system.

src/pc/mumble/mumble.c:21:18: fatal error: libc.h: No such file or directory
   21 |         #include <libc.h>
      |                  ^~~~~~~~
compilation terminated.
 