### PR TITLE
Update smlua_cobject_map.c

### DIFF
--- a/src/pc/lua/smlua_cobject_map.c
+++ b/src/pc/lua/smlua_cobject_map.c
@@ -4,12 +4,12 @@
 
 static void* sPointers = NULL;
 
-void smlua_pointer_user_data_init(void) {
-    smlua_pointer_user_data_shutdown();
-}
-
 void smlua_pointer_user_data_shutdown(void) {
     hmap_clear(sPointers);
+}
+
+void smlua_pointer_user_data_init(void) {
+    smlua_pointer_user_data_shutdown();
 }
 
 void smlua_pointer_user_data_add(u64 pointer, CObject *obj) {


### PR DESCRIPTION
Found this issue when compiling the latest dev branch, the function is being used before its declaration.

src/pc/lua/smlua_cobject_map.c: In function 'smlua_pointer_user_data_init':
src/pc/lua/smlua_cobject_map.c:8:5: error: implicit declaration of function 'smlua_pointer_user_data_shutdown'; did you mean 'smlua_pointer_user_data_init'? [-Wimplicit-function-declaration]
    8 |     smlua_pointer_user_data_shutdown();
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     smlua_pointer_user_data_init
