### PR TITLE
Allowed Dynos to use geo_mario_cap_display_list

### DIFF
--- a/data/dynos_mgr_builtin.cpp
+++ b/data/dynos_mgr_builtin.cpp
@@ -1398,6 +1398,7 @@ static const void* sDynosBuiltinFuncs[] = {
     define_builtin(geo_movtex_draw_water_regions_ext),
     define_builtin(lvl_init_or_update),
     define_builtin(geo_choose_area_ext),
+    define_builtin(geo_mario_cap_display_list),
 
     // Behaviors
     define_builtin(bhv_cap_switch_loop),

--- a/mods/char-select-extra-chars/z-voices.lua
+++ b/mods/char-select-extra-chars/z-voices.lua
@@ -3,11 +3,19 @@
 
 if not _G.charSelectExists then return end
 
+local voiceTables = {
+    [VOICETABLE_TOADETTE] = true,
+    [VOICETABLE_YOSHI]    = true,
+    [VOICETABLE_PEACH]    = true,
+    [VOICETABLE_DAISY]    = true,
+    [VOICETABLE_BIRDO]    = true
+}
+
 --- @param m MarioState
 local function mario_update(m)
     if is_player_active(m) == 0 then return end
     local voiceTable = charSelect.character_get_voice(m)
-    if voiceTable then
+    if voiceTables[voiceTable] then
         return charSelect.voice.snore(m)
     end
 end
@@ -16,7 +24,7 @@ end
 --- @param sound CharacterSound
 local function character_sound(m, sound)
     local voiceTable = charSelect.character_get_voice(m)
-    if voiceTable then
+    if voiceTables[voiceTable] then
         return charSelect.voice.sound(m, sound)
     end
 end


### PR DESCRIPTION
Maniscat2 pointed this out to me and asked me to add it. It's used by Ukiki and Klepto and without it they only show Mario's Cap.