### PR TITLE
Updating mumble.c non-Windows Include (libc.h -> unistd.h)

### DIFF
--- a/src/pc/mumble/mumble.c
+++ b/src/pc/mumble/mumble.c
@@ -18,7 +18,7 @@
 #else
 	#include <sys/mman.h>
 	#include <fcntl.h> /* For O_* constants */
-	#include <libc.h>
+	#include <unistd.h>
 #endif // _WIN32
 
 struct LinkedMem *lm = NULL;


### PR DESCRIPTION
Changing non-Windows include from libc.h (non existent?) to unistd.h for the getuid() function dependency.

Compiling on Ubuntu and SteamOS resulted in a failed build:
```
src/pc/mumble/mumble.c:21:18: fatal error: libc.h: No such file or directory
   21 |         #include <libc.h>
      |                  ^~~~~~~~
compilation terminated.
make: *** [Makefile:1407: build/us_pc/src/pc/mumble/mumble.o] Error 1
make: *** Waiting for unfinished jobs....
```

Confirmed build is successful on Linux with `unistd.h` (Ubuntu and SteamOS [Arch Linux])