### PR TITLE
Makes Character Select compatible with Personal Star Counter

### DIFF
--- a/mods/character-select-coop/a-utils.lua
+++ b/mods/character-select-coop/a-utils.lua
@@ -118,7 +118,7 @@ charBeingSet = false
 
 stopPalettes = false
 for i in pairs(gActiveMods) do
-    if (gActiveMods[i].incompatible ~= nil and gActiveMods[i].incompatible:find("gamemode")) and not (gActiveMods[i].name:find("Personal Star Counter EX+")) then
+    if (gActiveMods[i].incompatible ~= nil and gActiveMods[i].incompatible:find("gamemode")) and not (gActiveMods[i].name:find("Personal Star Counter")) then
         stopPalettes = true
     end
 end


### PR DESCRIPTION
The Character Select mod has a special case for working with the Personal Star Counter, but it was looking for the wrong name (as Personal Star Counter was renamed in https://github.com/djoslin0/sm64ex-coop/commit/068aa442fc2bbf61e5e2ce28d0fe3adb9f7cd619 ). So I fixed the name reference.