### PR TITLE
Add ban-kick buttons to playerlist

### DIFF
--- a/src/pc/djui/djui_cursor.c
+++ b/src/pc/djui/djui_cursor.c
@@ -1,5 +1,6 @@
 #include "djui.h"
 #include "djui_panel.h"
+#include "djui_panel_playerlist.h"
 #include "pc/controller/controller_mouse.h"
 #include "pc/gfx/gfx_window_manager_api.h"
 #include "pc/pc_main.h"
@@ -115,7 +116,7 @@ void djui_cursor_update(void) {
 #if defined(CAPI_SDL2) || defined(CAPI_SDL1)
     if (djui_interactable_is_binding()) { return; }
     if (sMouseCursor == NULL) { return; }
-    if (!djui_panel_is_active()) { return; }
+    if (!djui_panel_is_active() && !gDjuiPlayerList->base.visible) { return; }
 
     controller_mouse_read_window();
 
@@ -135,6 +136,7 @@ void djui_cursor_update(void) {
     }
 
     // update mouse cursor
+    if (gDjuiPlayerList->base.visible) sCursorMouseControlled = true;
     if (sCursorMouseControlled) {
         gCursorX = mouse_window_x / djui_gfx_get_scale();
         gCursorY = mouse_window_y / djui_gfx_get_scale();

--- a/src/pc/djui/djui_interactable.c
+++ b/src/pc/djui/djui_interactable.c
@@ -241,7 +241,7 @@ bool djui_interactable_on_key_down(int scancode) {
                 if (gServerSettings.enablePlayerList) {
                     if (gDjuiPlayerList != NULL) {
                         djui_base_set_visible(&gDjuiPlayerList->base, true);
-                        djui_cursor_set_visible(true);
+                        if (!gDjuiPanelPauseCreated) djui_cursor_set_visible(true);
                     }
                     if (gDjuiModList != NULL) {
                         djui_base_set_visible(&gDjuiModList->base, true);
@@ -295,7 +295,7 @@ void djui_interactable_on_key_up(int scancode) {
             if (scancode == (int)configKeyPlayerList[i]) {
                 if (gDjuiPlayerList != NULL) {
                     djui_base_set_visible(&gDjuiPlayerList->base, false);
-                    djui_cursor_set_visible(true);
+                    if (!gDjuiPanelPauseCreated) djui_cursor_set_visible(false);
                 }
                 if (gDjuiModList != NULL) {
                     djui_base_set_visible(&gDjuiModList->base, false);

--- a/src/pc/djui/djui_interactable.c
+++ b/src/pc/djui/djui_interactable.c
@@ -237,10 +237,11 @@ bool djui_interactable_on_key_down(int scancode) {
 
     if ((gDjuiPlayerList != NULL || gDjuiModList != NULL)) {
         for (int i = 0; i < MAX_BINDS; i++) {
-            if (scancode == (int)configKeyPlayerList[i] && !gDjuiInMainMenu && gNetworkType != NT_NONE) {
+            if (scancode == (int)configKeyPlayerList[i] && !gDjuiInMainMenu && !gDjuiPanelPauseCreated && gNetworkType != NT_NONE) {
                 if (gServerSettings.enablePlayerList) {
                     if (gDjuiPlayerList != NULL) {
                         djui_base_set_visible(&gDjuiPlayerList->base, true);
+                        djui_cursor_set_visible(true);
                     }
                     if (gDjuiModList != NULL) {
                         djui_base_set_visible(&gDjuiModList->base, true);
@@ -294,6 +295,7 @@ void djui_interactable_on_key_up(int scancode) {
             if (scancode == (int)configKeyPlayerList[i]) {
                 if (gDjuiPlayerList != NULL) {
                     djui_base_set_visible(&gDjuiPlayerList->base, false);
+                    djui_cursor_set_visible(true);
                 }
                 if (gDjuiModList != NULL) {
                     djui_base_set_visible(&gDjuiModList->base, false);

--- a/src/pc/djui/djui_panel_playerlist.h
+++ b/src/pc/djui/djui_panel_playerlist.h
@@ -8,3 +8,11 @@ extern const u8 sPlayerListSize;
 extern u8 sPageIndex;
 
 void djui_panel_playerlist_create(UNUSED struct DjuiBase* caller);
+
+#define BK_LEFT  lr & 1
+#define BK_RIGHT lr & 2
+
+#define NONE        0
+#define KICK        (1 << 0)
+#define BAN         (1 << 1)
+#define PERM_BAN    (1 << 2)


### PR DESCRIPTION
Adds two buttons for banning/kicking when hovering over a player list entry.

# Kick
Click once to bring up a confirmation button, click again to kick.
![image](https://github.com/user-attachments/assets/ef88539a-70dc-481d-9c2f-ae79985164c9)
![image](https://github.com/user-attachments/assets/b7cab2a0-e40f-4481-be34-02b3313f403f)
![image](https://github.com/user-attachments/assets/e8b2bc73-5df9-4cd3-b0b0-0767e9c464d2)

# Ban
Click once to bring up a confirmation button, click again to ban.
![image](https://github.com/user-attachments/assets/0edb5602-f29d-42fd-974b-a53cc3bb2d87)

# Perm Ban
Click the ban button, then the Kick button will transform into the Perm Ban button. Once clicked, click again to confirm. You may also click Go Back (or stop hovering over the player) to reset the buttons.
![image](https://github.com/user-attachments/assets/8123a41e-643f-4ad2-ba72-61c92056e2b7)
![image](https://github.com/user-attachments/assets/f99a0ad5-f0ce-4590-ab4e-6d5fdab8451d)

  