### PR TITLE
Fix weird comment in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ COOPNET ?= 1
 # Enable docker build workarounds
 DOCKERBUILD ?= 0
 # Sets your optimization level for building.
-# A choose is chosen by default for you.
+# A choice is made by default for you.
 OPT_LEVEL ?= -1
 # Enable compiling with more debug info.
 DEBUG_INFO_LEVEL ?= 2


### PR DESCRIPTION
This is perhaps as simple as a PR gets, the comment `# A choose is chosen by default for you.` in the Makefile uses really weird language. This has been corrected into something that is a little easier to read `# A choice is made by default for you.`.