### PR TITLE
Fix texture format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1240,8 +1240,15 @@ $(BUILD_DIR)/%: %.png
 	$(V)$(N64GRAPHICS) -s raw -i $@ -g $< -f $(lastword $(subst ., ,$@))
 
 $(BUILD_DIR)/%.inc.c: %.png
-	$(call print,Converting:,$<,$@)
-	$(V)$(N64GRAPHICS) -s $(TEXTURE_ENCODING) -i $@ -g $< -f $(lastword ,$(subst ., ,$(basename $<)))
+	$(call print,Converting(inc.c):,$<,$@)
+	# If the texture filename does not identify its format (e.g. with a .i8)
+	# then dont pass the -f argument to n64graphics
+	@if echo "$(basename $<)" | grep -q "\."; then \
+		$(V)$(N64GRAPHICS) -i $@ -g $< -f $(lastword ,$(subst ., ,$(basename $<))) -s $(TEXTURE_ENCODING); \
+	else \
+		$(V)$(N64GRAPHICS) -i $@ -g $< -s $(TEXTURE_ENCODING); \
+	fi
+	
 
 # Color Index CI8
 $(BUILD_DIR)/%.ci8: %.ci8.png


### PR DESCRIPTION
Fixes an issue where if a texture filename did not include the format n64graphics was called incorrectly in the Makefile.

Pasting context from discord: 

I have the standard game building using the baserom, but what I'm really trying to do is get different varaints of the sm64 port to build end-to-end without any manual and obfuscated step involving copyrighted assets. Towards this end I've build a randomized asset generator: https://github.com/Erotemic/sm64-random-assets

But when I run the asset generator (which should put roughly comparable files in the same place as the extract asset script), and then run: VERBOSE=1 NOEXTRACT=1 COMPARE=0 NON_MATCHING=0 VERSION=us make in the sm64coopdx repo root, I get an error when it tries to call n64graphics, specifically:

```
Converting: levels/ending/cake.png -> build/us_pc/levels/ending/cake.inc.c
 tools/n64graphics -s u8 -i build/us_pc/levels/ending/cake.inc.c -g levels/ending/cake.png -f ,levels/ending/cake
Usage: n64graphics -e/-i BIN_FILE -g IMG_FILE [-p PAL_FILE] [-o BIN_OFFSET] [-P PAL_OFFSET] [-f FORMAT] [-c CI_FORMAT] [-w WIDTH] [-h HEIGHT] [-V]
```

And I'm wondering what could be causing that to happen with my random assets, but not the official assets.

Looks like the above is called on line 1242 of the Makefile.

```
$(BUILD_DIR)/%.inc.c: %.png
    $(call print,Converting:,$<,$@)
    $(V)$(N64GRAPHICS) -s $(TEXTURE_ENCODING) -i $@ -g $< -f $(lastword ,$(subst ., ,$(basename $<)))
```

After some debugging, it looks like it doesn't like the "-f" argument.

Hmm, I see a coment saying that "Ending cake textures are generated in a special way", so maybe the fact that I've effectively pre-extracted the assets is causing a bug?

Something about $(lastword ,$(subst ., ,$(basename $<))) is not producing the correct format. I'm not super familiar with makefile syntax, but it looks like this is parsing info out of a filename. I have a hard time seeing what could be different between the ROM assets and generated assets in terms of file names, they should be the same.

Hmm, ok, so the issue was that cake.png doesn't identify what its format is, so I made a modification that drops the -f argument if there isn't a "." in the filename

```
$(BUILD_DIR)/%.inc.c: %.png
    $(call print,Converting(inc.c):,$<,$@)
    # If the texture filename does not identify its format (e.g. with a .i8)
    # then dont pass the -f argument to n64graphics
    @if echo "$(basename $<)" | grep -q "\."; then \
        $(V)$(N64GRAPHICS) -i $@ -g $< -f $(lastword ,$(subst ., ,$(basename $<))) -s $(TEXTURE_ENCODING); \
    else \
        $(V)$(N64GRAPHICS) -i $@ -g $< -s $(TEXTURE_ENCODING); \
    fi
```