### PR TITLE
Fix the branch bloat found in the atan2s and atan2_lookup functions

### DIFF
--- a/src/engine/math_util.c
+++ b/src/engine/math_util.c
@@ -822,7 +822,7 @@ f32 approach_f32(f32 current, f32 target, f32 inc, f32 dec) {
  * Helper function for atan2s. Does a look up of the arctangent of y/x assuming
  * the resulting angle is in range [0, 0x2000] (1/8 of a circle).
  */
-static inline u16 atan2_lookup(f32 y, f32 x) {
+static u16 atan2_lookup(f32 y, f32 x) {
     s16 idx = (s16)(y / x * 1024.0f + 0.5f);
     idx = (idx >= 0 && idx < 0x401) ? idx : 0;
     return gArctanTable[idx];


### PR DESCRIPTION
Hello,

Currently, both the `atan2s` and `atan2_lookup` functions contain unnecessary branching that can be significantly optimized. This proposal implements changes aimed at reducing branch complexity through the use of bit manipulation, ternary operators where appropriate, and static constant tables. These optimizations not only simplify the code but also result in a minor performance improvement, likely attributed to enhanced CPU caching behavior due to the static tables as well as move towards inlining.

Before PR Changes:
![image](https://github.com/user-attachments/assets/13bd1487-9eb2-4944-ab7d-eaa006962b4c)

After PR Changes:
![image](https://github.com/user-attachments/assets/fcaecff9-75ad-4eef-8d26-94dedc2edd0c)
