### PR TITLE
Fix function name back to fast_hypot()

### DIFF
--- a/src/pc/lua/utils/smlua_math_utils.c
+++ b/src/pc/lua/utils/smlua_math_utils.c
@@ -17,7 +17,7 @@ s16 degrees_to_sm64(f32 degreesAngle) {
     return degreesAngle * 0x8000 / 180.0f;
 }
 
-f32 hypotf(f32 a, f32 b) {
+f32 fast_hypot(f32 a, f32 b) {
     return sqrtf(a * a + b * b);
 }
 


### PR DESCRIPTION
Hello,

This somehow got messed up when I reverted the function to use `sqrtf()`. This will cause a broken behavior in the function and build unless properly fixed, thank you.