### PR TITLE
Fix windows compilation by undefining min and max when defined via minwindef.h (already in main)

### DIFF
--- a/src/engine/math_util.h
+++ b/src/engine/math_util.h
@@ -24,6 +24,14 @@ extern f32 gSineTable[];
 extern f32 gCosineTable[];
 #endif
 
+#if defined(min)
+#undef min
+#endif
+
+#if defined(max)
+#undef max
+#endif
+
 // Inline Function prototypes
 f32 minf(f32 a, f32 b);
 s16 min(s16 a, s16 b);


### PR DESCRIPTION
Hello,

For windows users the compilation of dev is currently broken since min and max are included (and subsequently redefined via `minwindef.h`). These lines were taken out in my previous PR and should be re-added. These are the issues I encountered when testing/compiling on windows:

```In file included from src/pc/network/network.c:36:
src/engine/math_util.h:37:9: warning: "min" redefined
   37 | #define min(a, b) _Generic((a), \
      |         ^~~
C:/msys64/mingw64/include/minwindef.h:177:9: note: this is the location of the previous definition
  177 | #define min(a, b) (((a) < (b)) ? (a) : (b))
      |         ^~~
src/engine/math_util.h:42:9: warning: "max" redefined
   42 | #define max(a, b) _Generic((a), \
      |         ^~~
C:/msys64/mingw64/include/minwindef.h:173:9: note: this is the location of the previous definition
  173 | #define max(a, b) (((a) > (b)) ? (a) : (b))
      |         ^~~```