### PR TITLE
add controller.buttonReleased

### DIFF
--- a/autogen/lua_definitions/structs.lua
+++ b/autogen/lua_definitions/structs.lua
@@ -537,6 +537,7 @@
 --- @class Controller
 --- @field public buttonDown integer
 --- @field public buttonPressed integer
+--- @field public buttonReleased integer
 --- @field public extStickX integer
 --- @field public extStickY integer
 --- @field public port integer

--- a/data/dynos_warps.cpp
+++ b/data/dynos_warps.cpp
@@ -176,6 +176,7 @@ static void *DynOS_Warp_UpdateWarp(void *aCmd, bool aIsLevelInitDone) {
         gMarioState->numCoins = 0;
         gMarioState->input = 0;
         gMarioState->controller->buttonPressed = 0;
+        gMarioState->controller->buttonReleased = 0;
         gHudDisplay.coins = 0;
 
         // Set up new level values
@@ -337,6 +338,7 @@ static void *DynOS_Warp_UpdateExit(void *aCmd, bool aIsLevelInitDone) {
         gMarioState->numCoins = 0;
         gMarioState->input = 0;
         gMarioState->controller->buttonPressed = 0;
+        gMarioState->controller->buttonReleased = 0;
         gHudDisplay.coins = 0;
 
         // Set up new level values

--- a/docs/lua/structs.md
+++ b/docs/lua/structs.md
@@ -745,6 +745,7 @@
 | ----- | ---- | ------ |
 | buttonDown | `integer` |  |
 | buttonPressed | `integer` |  |
+| buttonReleased | `integer` |  |
 | extStickX | `integer` |  |
 | extStickY | `integer` |  |
 | port | `integer` |  |

--- a/include/types.h
+++ b/include/types.h
@@ -28,9 +28,10 @@ struct Controller
   /*0x0C*/ f32 stickMag;      // distance from center [0, 64]
   /*0x10*/ u16 buttonDown;
   /*0x12*/ u16 buttonPressed;
-  /*0x14*/ OSContStatus *statusData;
-  /*0x18*/ OSContPad *controllerData;
-  /*0x1C*/ s32 port;
+  /*0x14*/ u16 buttonReleased;
+  /*0x18*/ OSContStatus *statusData;
+  /*0x1C*/ OSContPad *controllerData;
+  /*0x20*/ s32 port;
   /*ext */ s16 extStickX;       // additional (right) stick values
   /*ext */ s16 extStickY;
 };

--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -476,8 +476,8 @@ void read_controller_inputs(void) {
             controller->rawStickY = controller->controllerData->stick_y;
             controller->extStickX = controller->controllerData->ext_stick_x;
             controller->extStickY = controller->controllerData->ext_stick_y;
-            controller->buttonPressed = controller->controllerData->button
-                                        & (controller->controllerData->button ^ controller->buttonDown);
+            controller->buttonPressed = (~controller->buttonDown & controller->controllerData->button);
+            controller->buttonReleased = (~controller->controllerData->button & controller->buttonDown);
             // 0.5x A presses are a good meme
             controller->buttonDown = controller->controllerData->button;
             adjust_analog_stick(controller);
@@ -488,6 +488,7 @@ void read_controller_inputs(void) {
             controller->extStickX = 0;
             controller->extStickY = 0;
             controller->buttonPressed = 0;
+            controller->buttonReleased = 0;
             controller->buttonDown = 0;
             controller->stickX = 0;
             controller->stickY = 0;
@@ -505,6 +506,7 @@ void read_controller_inputs(void) {
     gPlayer3Controller->stickY = gPlayer1Controller->stickY;
     gPlayer3Controller->stickMag = gPlayer1Controller->stickMag;
     gPlayer3Controller->buttonPressed = gPlayer1Controller->buttonPressed;
+    gPlayer3Controller->buttonReleased = gPlayer1Controller->buttonReleased;
     gPlayer3Controller->buttonDown = gPlayer1Controller->buttonDown;*/
 }
 

--- a/src/pc/lua/smlua_cobject_autogen.c
+++ b/src/pc/lua/smlua_cobject_autogen.c
@@ -604,10 +604,11 @@ static struct LuaObjectField sCharacterFields[LUA_CHARACTER_FIELD_COUNT] = {
     { "type",                               LVT_S32,      offsetof(struct Character, type),                               true, LOT_NONE        },
 };
 
-#define LUA_CONTROLLER_FIELD_COUNT 10
+#define LUA_CONTROLLER_FIELD_COUNT 11
 static struct LuaObjectField sControllerFields[LUA_CONTROLLER_FIELD_COUNT] = {
     { "buttonDown",     LVT_U16, offsetof(struct Controller, buttonDown),     false, LOT_NONE },
     { "buttonPressed",  LVT_U16, offsetof(struct Controller, buttonPressed),  false, LOT_NONE },
+    { "buttonReleased", LVT_U16, offsetof(struct Controller, buttonReleased), false, LOT_NONE },
 //  { "controllerData", LVT_???, offsetof(struct Controller, controllerData), true,  LOT_???  }, <--- UNIMPLEMENTED
     { "extStickX",      LVT_S16, offsetof(struct Controller, extStickX),      false, LOT_NONE },
     { "extStickY",      LVT_S16, offsetof(struct Controller, extStickY),      false, LOT_NONE },

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -719,6 +719,7 @@ void network_shutdown(bool sendLeaving, bool exiting, bool popup, bool reconnect
     cnt->stickMag = 0;
     cnt->buttonDown = 0;
     cnt->buttonPressed = 0;
+    cnt->buttonReleased = 0;
     cnt->extStickX = 0;
     cnt->extStickY = 0;
 

--- a/src/pc/network/packets/packet_player.c
+++ b/src/pc/network/packets/packet_player.c
@@ -27,6 +27,7 @@ struct PacketPlayerData {
     f32 cStickMag;
     u16 cButtonDown;
     u16 cButtonPressed;
+    u16 cButtonReleased;
     s16 cExtStickX;
     s16 cExtStickY;
 
@@ -98,6 +99,7 @@ static void read_packet_data(struct PacketPlayerData* data, struct MarioState* m
     data->cStickMag      = m->controller->stickMag;
     data->cButtonDown    = m->controller->buttonDown;
     data->cButtonPressed = m->controller->buttonPressed;
+    data->cButtonReleased = m->controller->buttonReleased;
     data->cExtStickX     = m->controller->extStickX;
     data->cExtStickY     = m->controller->extStickY;
 
@@ -162,6 +164,7 @@ static void write_packet_data(struct PacketPlayerData* data, struct MarioState* 
     m->controller->stickMag      = data->cStickMag;
     m->controller->buttonDown    = data->cButtonDown;
     m->controller->buttonPressed = data->cButtonPressed;
+    m->controller->buttonReleased = data->cButtonReleased;
     m->controller->extStickX     = data->cExtStickX;
     m->controller->extStickY     = data->cExtStickY;
 
@@ -427,12 +430,14 @@ void network_update_player(void) {
     static f32 sLastStickY = 0;
     static u32 sLastButtonDown = 0;
     static u32 sLastButtonPressed = 0;
+    static u32 sLastButtonReleased = 0;
 
     f32 stickDist = sqrtf(powf(sLastStickX - m->controller->stickX, 2) + powf(sLastStickY - m->controller->stickY, 2));
     bool shouldSend = (sTicksSinceSend > 2)
         || (sLastPlayerAction    != m->action)
         || (sLastButtonDown      != m->controller->buttonDown)
         || (sLastButtonPressed   != m->controller->buttonPressed)
+        || (sLastButtonReleased   != m->controller->buttonReleased)
         || (sLastPlayerParticles != m->particleFlags)
         || (stickDist          > 5.0f);
 
@@ -445,5 +450,6 @@ void network_update_player(void) {
     sLastStickY          = m->controller->stickY;
     sLastButtonDown      = m->controller->buttonDown;
     sLastButtonPressed   = m->controller->buttonPressed;
+    sLastButtonReleased  = m->controller->buttonReleased;
     sLastPlayerParticles = m->particleFlags;
 }


### PR DESCRIPTION
- Add the `controller.buttonReleased` flag set (was tested)

- Optimized the operation to get `controller->buttonPressed` (tested too)
from : `controller->controllerData->button & (controller->controllerData->button ^ controller->buttonDown)`
to : `(~controller->buttonDown & controller->controllerData->button)`
since doing `X AND (X XOR Y`) it's the same thing as `NOT Y AND X` but simplified