### PR TITLE
Fixed clipboard (text copy & paste) implementation

### DIFF
--- a/src/pc/gfx/gfx_dummy.c
+++ b/src/pc/gfx/gfx_dummy.c
@@ -113,7 +113,7 @@ static void gfx_dummy_wm_start_text_input(void) {
 static void gfx_dummy_wm_stop_text_input(void) {
 }
 
-static void gfx_dummy_wm_set_clipboard_text(UNUSED char* text) {
+static void gfx_dummy_wm_set_clipboard_text(UNUSED const char* text) {
 }
 
 static void gfx_dummy_wm_set_cursor_visible(UNUSED bool visible) {

--- a/src/pc/gfx/gfx_sdl1.c
+++ b/src/pc/gfx/gfx_sdl1.c
@@ -211,8 +211,8 @@ static bool gfx_sdl_has_focus(void) {
 
 static void gfx_sdl_start_text_input(void) { return; }
 static void gfx_sdl_stop_text_input(void) { return; }
-static char* gfx_sdl_get_clipboard_text(void) { return NULL; }
-static void gfx_sdl_set_clipboard_text(char* text) { return; }
+static char* gfx_sdl_get_clipboard_text(void) { return ""; }
+static void gfx_sdl_set_clipboard_text(UNUSED const char* text) { return; }
 static void gfx_sdl_set_cursor_visible(bool visible) { SDL_ShowCursor(visible ? SDL_ENABLE : SDL_DISABLE); }
 
 struct GfxWindowManagerAPI gfx_sdl = {

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -304,8 +304,19 @@ static bool gfx_sdl_has_focus(void) {
 
 static void gfx_sdl_start_text_input(void) { SDL_StartTextInput(); }
 static void gfx_sdl_stop_text_input(void) { SDL_StopTextInput(); }
-static char* gfx_sdl_get_clipboard_text(void) { return SDL_GetClipboardText(); }
-static void gfx_sdl_set_clipboard_text(char* text) { SDL_SetClipboardText(text); }
+
+static char* gfx_sdl_get_clipboard_text(void) {
+    static char clipboard_buf[WAPI_CLIPBOARD_BUFSIZ];
+
+    char* text = SDL_GetClipboardText();
+    strncpy(clipboard_buf, text, WAPI_CLIPBOARD_BUFSIZ - 1);
+    SDL_free(text);
+
+    clipboard_buf[WAPI_CLIPBOARD_BUFSIZ - 1] = '\0';
+    return clipboard_buf;
+}
+
+static void gfx_sdl_set_clipboard_text(const char* text) { SDL_SetClipboardText(text); }
 static void gfx_sdl_set_cursor_visible(bool visible) { SDL_ShowCursor(visible ? SDL_ENABLE : SDL_DISABLE); }
 
 struct GfxWindowManagerAPI gfx_sdl = {

--- a/src/pc/gfx/gfx_window_manager_api.h
+++ b/src/pc/gfx/gfx_window_manager_api.h
@@ -7,6 +7,8 @@
 // special value for window position that signifies centered position
 #define WAPI_WIN_CENTERPOS 0xFFFFFFFF
 
+#define WAPI_CLIPBOARD_BUFSIZ 1024
+
 typedef bool (*kb_callback_t)(int code);
 
 struct GfxWindowManagerAPI {
@@ -23,7 +25,7 @@ struct GfxWindowManagerAPI {
     void (*start_text_input)(void);
     void (*stop_text_input)(void);
     char* (*get_clipboard_text)(void);
-    void (*set_clipboard_text)(char*);
+    void (*set_clipboard_text)(const char*);
     void (*set_cursor_visible)(bool);
     void (*delay)(unsigned int ms);
     int  (*get_max_msaa)(void);


### PR DESCRIPTION
This pull request addresses the following issues:

---

### 1. "SDL_GetClipboardText" memory leak

In case of failure, `SDL_GetClipboardText()` returns a `SDL_strdup("")` value, so that the result is never `NULL` and must always be freed by user application. This memory leak is hardly noticeable in-game, unless one would simulate it with the following code to watch the memory usage:

```c
static char* gfx_sdl_get_clipboard_text(void) {
    while (!0) { SDL_GetClipboardText(); }
    return "";
}
```

reference: https://wiki.libsdl.org/SDL2/SDL_GetClipboardText

---

### 2. "gfx_dxgi_get_clipboard_text" returning a NULL pointer

In cases where clipboard data cannot be converted to text on Windows - for example, when user copies some image and the clipboard is filled with bitmap data - the `GetClipboardData(CF_TEXT)` call returns `NULL`, which is later passed to functions like `djui_interactable_on_text_input()` and `strlen()`.

---

### 3. "SetClipboardData" and "GetClipboardData" assuming wrong text encoding.

The sm64coopdx engine assumes UTF-8 encoding for most textual data, same with the SDL2 API. However, to ensure no data is lost while copying text in the DirectX version, the values must be converted from UTF-8 to UTF-16LE encoding. The `CF_TEXT` type assumes an ANSI encoding, and some text copied this way could be broken when trying to paste it to other application, like chat or notepad.

Additionally, the game should not access the clipboard memory once `CloseClipboard()` has been called, so I added static clipboard text buffers with sufficient size to hold UTF-8 text.

references:
https://learn.microsoft.com/en-us/windows/win32/dataxchg/standard-clipboard-formats
https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getclipboarddata

---
