### PR TITLE
Fixed a bug with the [CS] VL-Tone & Cjes Luigi mod

### DIFF
--- a/mods/char-select-cjes-and-vl/a-constants.lua
+++ b/mods/char-select-cjes-and-vl/a-constants.lua
@@ -4,7 +4,7 @@ if not _G.charSelectExists then
         if not first then
             first = true
             play_sound(SOUND_MENU_CAMERA_BUZZ, gGlobalSoundSource)
-            djui_chat_message_create("\\#ffffa0\\Extra Characters requires Character Select to be enabled.\nPlease rehost with it enabled.")
+            djui_chat_message_create("\\#ffffa0\\[CS] VL-Tone & Cjes Luigi requires Character Select to be enabled.\nPlease rehost with it enabled.")
         end
     end)
     return


### PR DESCRIPTION
Fixed a bug with the [CS] VL-Tone & Cjes Luigi mod, when it's enabled without the Character Select mod also enabled, it would send a wrong error message that says: 'Extra Characters requires Character Select to be enabled.', instead of '[CS] VL-Tone & Cjes Luigi requires Character Select to be enabled.'