### PR TITLE
Add location label override

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -5524,6 +5524,12 @@ function network_player_set_description(np, description, r, g, b, a)
 end
 
 --- @param np NetworkPlayer
+--- @param location string
+function network_player_set_override_location(np, location)
+    -- ...
+end
+
+--- @param np NetworkPlayer
 --- @param part PlayerPart
 --- @param color Color
 function network_player_set_override_palette_color(np, part, color)

--- a/autogen/lua_definitions/structs.lua
+++ b/autogen/lua_definitions/structs.lua
@@ -1126,6 +1126,7 @@
 --- @field public modelIndex integer
 --- @field public name string
 --- @field public onRxSeqId integer
+--- @field public overrideLocation string
 --- @field public overrideModelIndex integer
 --- @field public overridePalette PlayerPalette
 --- @field public overridePaletteIndex integer

--- a/docs/lua/functions-4.md
+++ b/docs/lua/functions-4.md
@@ -1563,6 +1563,27 @@
 
 <br />
 
+## [network_player_set_override_location](#network_player_set_override_location)
+
+### Lua Example
+`network_player_set_override_location(np, location)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| np | [NetworkPlayer](structs.md#NetworkPlayer) |
+| location | `string` |
+
+### Returns
+- None
+
+### C Prototype
+`void network_player_set_override_location(struct NetworkPlayer *np, const char *location);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ## [network_player_set_override_palette_color](#network_player_set_override_palette_color)
 
 ### Lua Example

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -1216,6 +1216,7 @@
    - [network_player_is_override_palette_same](functions-4.md#network_player_is_override_palette_same)
    - [network_player_reset_override_palette](functions-4.md#network_player_reset_override_palette)
    - [network_player_set_description](functions-4.md#network_player_set_description)
+   - [network_player_set_override_location](functions-4.md#network_player_set_override_location)
    - [network_player_set_override_palette_color](functions-4.md#network_player_set_override_palette_color)
 
 <br />

--- a/docs/lua/structs.md
+++ b/docs/lua/structs.md
@@ -1544,6 +1544,7 @@
 | modelIndex | `integer` | read-only |
 | name | `string` | read-only |
 | onRxSeqId | `integer` | read-only |
+| overrideLocation | `string` | read-only |
 | overrideModelIndex | `integer` |  |
 | overridePalette | [PlayerPalette](structs.md#PlayerPalette) |  |
 | palette | [PlayerPalette](structs.md#PlayerPalette) | read-only |

--- a/src/pc/djui/djui_panel_playerlist.c
+++ b/src/pc/djui/djui_panel_playerlist.c
@@ -54,7 +54,11 @@ static void playerlist_update_row(u8 i, struct NetworkPlayer *np) {
     djui_base_set_color(&djuiTextDescriptions[i]->base, np->descriptionR, np->descriptionG, np->descriptionB, np->descriptionA);
     djui_text_set_text(djuiTextDescriptions[i], np->description);
 
-    djui_text_set_text(djuiTextLocations[i], get_level_name(np->currCourseNum, np->currLevelNum, np->currAreaIndex));
+    djui_text_set_text(djuiTextLocations[i],
+        np->overrideLocation[0] == '\0'
+          ? get_level_name(np->currCourseNum, np->currLevelNum, np->currAreaIndex)
+          : np->overrideLocation
+    );
     djui_text_set_text(djuiTextAct[i], sActNum);
 }
 

--- a/src/pc/lua/smlua_cobject_autogen.c
+++ b/src/pc/lua/smlua_cobject_autogen.c
@@ -1250,7 +1250,7 @@ static struct LuaObjectField sNametagsSettingsFields[LUA_NAMETAGS_SETTINGS_FIELD
     { "showSelfTag", LVT_BOOL, offsetof(struct NametagsSettings, showSelfTag), false, LOT_NONE },
 };
 
-#define LUA_NETWORK_PLAYER_FIELD_COUNT 31
+#define LUA_NETWORK_PLAYER_FIELD_COUNT 32
 static struct LuaObjectField sNetworkPlayerFields[LUA_NETWORK_PLAYER_FIELD_COUNT] = {
     { "connected",              LVT_BOOL,    offsetof(struct NetworkPlayer, connected),              true,  LOT_NONE          },
     { "currActNum",             LVT_S16,     offsetof(struct NetworkPlayer, currActNum),             true,  LOT_NONE          },
@@ -1275,6 +1275,7 @@ static struct LuaObjectField sNetworkPlayerFields[LUA_NETWORK_PLAYER_FIELD_COUNT
     { "modelIndex",             LVT_U8,      offsetof(struct NetworkPlayer, modelIndex),             true,  LOT_NONE          },
     { "name",                   LVT_STRING,  offsetof(struct NetworkPlayer, name),                   true,  LOT_NONE          },
     { "onRxSeqId",              LVT_U8,      offsetof(struct NetworkPlayer, onRxSeqId),              true,  LOT_NONE          },
+    { "overrideLocation",       LVT_STRING,  offsetof(struct NetworkPlayer, overrideLocation),       true,  LOT_NONE          },
     { "overrideModelIndex",     LVT_U8,      offsetof(struct NetworkPlayer, overrideModelIndex),     false, LOT_NONE          },
     { "overridePalette",        LVT_COBJECT, offsetof(struct NetworkPlayer, overridePalette),        false, LOT_PLAYERPALETTE },
     { "overridePaletteIndex",   LVT_U8,      offsetof(struct NetworkPlayer, overridePaletteIndex),   false, LOT_NONE          },

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -21120,6 +21120,25 @@ int smlua_func_network_player_set_description(lua_State* L) {
     return 1;
 }
 
+int smlua_func_network_player_set_override_location(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 2) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "network_player_set_override_location", 2, top);
+        return 0;
+    }
+
+    struct NetworkPlayer* np = (struct NetworkPlayer*)smlua_to_cobject(L, 1, LOT_NETWORKPLAYER);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "network_player_set_override_location"); return 0; }
+    const char* location = smlua_to_string(L, 2);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "network_player_set_override_location"); return 0; }
+
+    network_player_set_override_location(np, location);
+
+    return 1;
+}
+
 int smlua_func_network_player_set_override_palette_color(lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -34416,6 +34435,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "network_player_is_override_palette_same", smlua_func_network_player_is_override_palette_same);
     smlua_bind_function(L, "network_player_reset_override_palette", smlua_func_network_player_reset_override_palette);
     smlua_bind_function(L, "network_player_set_description", smlua_func_network_player_set_description);
+    smlua_bind_function(L, "network_player_set_override_location", smlua_func_network_player_set_override_location);
     smlua_bind_function(L, "network_player_set_override_palette_color", smlua_func_network_player_set_override_palette_color);
 
     // network_utils.h

--- a/src/pc/network/network_player.c
+++ b/src/pc/network/network_player.c
@@ -74,6 +74,16 @@ void network_player_set_description(struct NetworkPlayer *np, const char *descri
     np->descriptionA = a;
 }
 
+void network_player_set_override_location(struct NetworkPlayer *np, const char *location) {
+    if (np == NULL) { return; }
+
+    if (location != NULL) {
+        snprintf(np->overrideLocation, 256, "%s", location);
+    } else {
+        np->overrideLocation[0] = '\0';
+    }
+}
+
 struct NetworkPlayer *network_player_from_global_index(u8 globalIndex) {
     for (s32 i = 0; i < MAX_PLAYERS; i++) {
         if (!gNetworkPlayers[i].connected) { continue; }

--- a/src/pc/network/network_player.h
+++ b/src/pc/network/network_player.h
@@ -52,6 +52,8 @@ struct NetworkPlayer {
     u8 descriptionB;
     u8 descriptionA;
 
+    char overrideLocation[256];
+
     u8 overrideModelIndex;
     struct PlayerPalette overridePalette;
 
@@ -75,6 +77,7 @@ void network_player_update_model(u8 localIndex);
 bool network_player_any_connected(void);
 u8 network_player_connected_count(void);
 void network_player_set_description(struct NetworkPlayer* np, const char* description, u8 r, u8 g, u8 b, u8 a);
+void network_player_set_override_location(struct NetworkPlayer *np, const char *location);
 
 struct NetworkPlayer* network_player_from_global_index(u8 globalIndex);
 struct NetworkPlayer* get_network_player_from_level(s16 courseNum, s16 actNum, s16 levelNum);


### PR DESCRIPTION
Allows mods to change the playerlist location label, even when level names are hardcoded.

## `network_player_set_override_location`
Takes a `NetworkPlayer` and a `string`. Leaving the string empty will clear the override.
#
New `NetworkPlayer` field added: `overrideLocation`