### PR TITLE
Use virtual-key names instead of physical-key names in the binds menu

### DIFF
--- a/src/pc/controller/controller_bind_mapping.c
+++ b/src/pc/controller/controller_bind_mapping.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #ifdef HAVE_SDL2
 #include <SDL2/SDL.h>
-#else 
+#else
 #ifdef HAVE_SDL
 
 #include <SDL/SDL.h>
@@ -145,7 +145,7 @@ const char* translate_bind_to_name(int bind) {
     if (sc == 0) { return name; }
 
 #ifdef HAVE_SDL2
-    const char* sname = SDL_GetScancodeName(sc);
+    const char* sname = SDL_GetKeyName(SDL_GetKeyFromScancode(sc));
     if (strlen(sname) <= 9) { return sname; }
 
     char* space = strchr(sname, ' ');


### PR DESCRIPTION
This changes `SDL_GetScancodeName(scancode)` to `SDL_GetKeyName(SDL_GetKeyFromScancode(scancode))`, so that the keyboard binding names make more sense on keyboard layouts different from US QWERTY.

The physical keys stay unchanged between configurations, only the display name changes:
| QWERTY | QWERTZ | AZERTY |
| --- | --- | --- |
| q | q | a |
| w | w | z |
| y | z | y |
| a | a | q |
| z | y | w |

## Examples from the controls menu:
![sm64coopdx_key_names_01](https://github.com/user-attachments/assets/ffb44314-657f-4f66-801d-db346b47d4dc)
![sm64coopdx_key_names_02](https://github.com/user-attachments/assets/2e83245b-58ef-4beb-8275-4668e7dcb925)
![sm64coopdx_key_names_03](https://github.com/user-attachments/assets/38a3c06c-c3e9-4ffd-bd0a-26057dedcc12)
