### PR TITLE
Fix DJUI text rendering with MSAA

### DIFF
--- a/src/pc/djui/djui_gfx.c
+++ b/src/pc/djui/djui_gfx.c
@@ -131,11 +131,13 @@ void djui_gfx_render_texture_tile(const u8* texture, u32 w, u32 h, u32 bitSize, 
     }
 
     f32 aspect = tileH ? ((f32)tileW / (f32)tileH) : 1;
+    f32 halfPxX = 1024.0f / (f32)w;
+    f32 halfPxY = 1024.0f / (f32)h;
     // I don't know why adding 1 to all of the UVs seems to fix rendering, but it does...
-    vtx[0] = (Vtx) {{{ 0,          -1, 0 }, 0, { ( tileX          * 2048.0f) / (f32)w, ((tileY + tileH) * 2048.0f) / (f32)h }, { 0xff, 0xff, 0xff, 0xff }}};
-    vtx[1] = (Vtx) {{{ 1 * aspect, -1, 0 }, 0, { ((tileX + tileW) * 2048.0f) / (f32)w, ((tileY + tileH) * 2048.0f) / (f32)h }, { 0xff, 0xff, 0xff, 0xff }}};
-    vtx[2] = (Vtx) {{{ 1 * aspect,  0, 0 }, 0, { ((tileX + tileW) * 2048.0f) / (f32)w, ( tileY          * 2048.0f) / (f32)h }, { 0xff, 0xff, 0xff, 0xff }}};
-    vtx[3] = (Vtx) {{{ 0,           0, 0 }, 0, { ( tileX          * 2048.0f) / (f32)w, ( tileY          * 2048.0f) / (f32)h }, { 0xff, 0xff, 0xff, 0xff }}};
+    vtx[0] = (Vtx) {{{ 0,          -1, 0 }, 0, { ( tileX          * 2048.0f) / (f32)w - halfPxX, ((tileY + tileH) * 2048.0f) / (f32)h - halfPxY }, { 0xff, 0xff, 0xff, 0xff }}};
+    vtx[1] = (Vtx) {{{ 1 * aspect, -1, 0 }, 0, { ((tileX + tileW) * 2048.0f) / (f32)w - halfPxX, ((tileY + tileH) * 2048.0f) / (f32)h - halfPxY }, { 0xff, 0xff, 0xff, 0xff }}};
+    vtx[2] = (Vtx) {{{ 1 * aspect,  0, 0 }, 0, { ((tileX + tileW) * 2048.0f) / (f32)w - halfPxX, ( tileY          * 2048.0f) / (f32)h - halfPxY }, { 0xff, 0xff, 0xff, 0xff }}};
+    vtx[3] = (Vtx) {{{ 0,           0, 0 }, 0, { ( tileX          * 2048.0f) / (f32)w - halfPxX, ( tileY          * 2048.0f) / (f32)h - halfPxY }, { 0xff, 0xff, 0xff, 0xff }}};
 
     gSPClearGeometryMode(gDisplayListHead++, G_LIGHTING);
     gDPSetCombineMode(gDisplayListHead++, G_CC_FADEA, G_CC_FADEA);


### PR DESCRIPTION
The texture coordinates for the text were off by half of a texel, causing some antialiasing samples to sample past the edge of the character in the atlas.

Before:
![sm64coopdx_nrXFLkKMXU](https://github.com/user-attachments/assets/9f6cba64-8253-4b5c-aaf7-a4d96a19ee95)

After:
![sm64coopdx_MW2gk5OHnd](https://github.com/user-attachments/assets/ccbe9af6-f2c3-41ea-b3e2-11fc8d3362df)
