### PR TITLE
Don't use default VAO

### DIFF
--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -709,8 +709,10 @@ static void gfx_opengl_init(void) {
     
     glBindBuffer(GL_ARRAY_BUFFER, opengl_vbo);
 
-    glGenVertexArrays(1, &opengl_vao);
-    glBindVertexArray(opengl_vao);
+    if (vmajor >= 3 && !is_es) {
+        glGenVertexArrays(1, &opengl_vao);
+        glBindVertexArray(opengl_vao);
+    }
     
     glDepthFunc(GL_LEQUAL);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -67,6 +67,7 @@ static struct ShaderProgram shader_program_pool[CC_MAX_SHADERS];
 static uint8_t shader_program_pool_size = 0;
 static uint8_t shader_program_pool_index = 0;
 static GLuint opengl_vbo;
+static GLuint opengl_vao;
 
 static int tex_cache_size = 0;
 static int num_textures = 0;
@@ -707,6 +708,9 @@ static void gfx_opengl_init(void) {
     glGenBuffers(1, &opengl_vbo);
     
     glBindBuffer(GL_ARRAY_BUFFER, opengl_vbo);
+
+    glGenVertexArrays(1, &opengl_vao);
+    glBindVertexArray(opengl_vao);
     
     glDepthFunc(GL_LEQUAL);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);


### PR DESCRIPTION
Since the SDL2 backend isn't specifying any target OpenGL version or profile, it's possible for the system to pick a 3.2+ core profile, which would break rendering since that requires explicitly creating and binding a VAO. This might fix black screen issues for some people.