### PR TITLE
Fix camera reset bug

### DIFF
--- a/src/game/bettercamera.inc.h
+++ b/src/game/bettercamera.inc.h
@@ -122,12 +122,12 @@ s16 newcam_saved_defmode = -1;
 extern bool gDjuiInMainMenu;
 
 ///This is called at every level initialisation.
-void newcam_init(struct Camera *c, u8 softResetted) {
+void newcam_init(struct Camera *c, u8 isSoftReset) {
     newcam_tilt = 1500;
     newcam_yaw = -c->yaw+0x4000; //Mario and the camera's yaw have this offset between them.
     newcam_mode = NC_MODE_NORMAL;
     ///This here will dictate what modes the camera will start in at the beginning of a level. Below are some examples.
-    if (!softResetted) {
+    if (!isSoftReset) {
         switch (gCurrLevelNum) {
             case LEVEL_BITDW: newcam_yaw = 0x4000; /*newcam_mode = NC_MODE_8D;*/ newcam_tilt = 4000; break;
             case LEVEL_BITFS: newcam_yaw = 0x4000; /*newcam_mode = NC_MODE_8D;*/ newcam_tilt = 4000; break;

--- a/src/game/bettercamera.inc.h
+++ b/src/game/bettercamera.inc.h
@@ -122,26 +122,28 @@ s16 newcam_saved_defmode = -1;
 extern bool gDjuiInMainMenu;
 
 ///This is called at every level initialisation.
-void newcam_init(struct Camera *c, UNUSED u8 dv) {
+void newcam_init(struct Camera *c, u8 softResetted) {
     newcam_tilt = 1500;
     newcam_yaw = -c->yaw+0x4000; //Mario and the camera's yaw have this offset between them.
     newcam_mode = NC_MODE_NORMAL;
     ///This here will dictate what modes the camera will start in at the beginning of a level. Below are some examples.
-    switch (gCurrLevelNum) {
-        case LEVEL_BITDW: newcam_yaw = 0x4000; /*newcam_mode = NC_MODE_8D;*/ newcam_tilt = 4000; break;
-        case LEVEL_BITFS: newcam_yaw = 0x4000; /*newcam_mode = NC_MODE_8D;*/ newcam_tilt = 4000; break;
-        case LEVEL_BITS: newcam_yaw = 0x4000; /*newcam_mode = NC_MODE_8D;*/ newcam_tilt = 4000; break;
-        case LEVEL_WF: newcam_yaw = 0x4000; newcam_tilt = 2000; break;
-        case LEVEL_RR: newcam_yaw = 0x6000; newcam_tilt = 2000; break;
-        case LEVEL_CCM: if (gCurrAreaIndex == 1) {newcam_yaw = -0x4000; newcam_tilt = 2000; } else newcam_mode = NC_MODE_SLIDE; break;
-        case LEVEL_WDW: newcam_yaw = 0x2000; newcam_tilt = 3000; break;
-        case 27: newcam_mode = NC_MODE_SLIDE; break;
-        case LEVEL_TTM: if (gCurrAreaIndex == 2) newcam_mode = NC_MODE_SLIDE; break;
-    }
+    if (!softResetted) {
+        switch (gCurrLevelNum) {
+            case LEVEL_BITDW: newcam_yaw = 0x4000; /*newcam_mode = NC_MODE_8D;*/ newcam_tilt = 4000; break;
+            case LEVEL_BITFS: newcam_yaw = 0x4000; /*newcam_mode = NC_MODE_8D;*/ newcam_tilt = 4000; break;
+            case LEVEL_BITS: newcam_yaw = 0x4000; /*newcam_mode = NC_MODE_8D;*/ newcam_tilt = 4000; break;
+            case LEVEL_WF: newcam_yaw = 0x4000; newcam_tilt = 2000; break;
+            case LEVEL_RR: newcam_yaw = 0x6000; newcam_tilt = 2000; break;
+            case LEVEL_CCM: if (gCurrAreaIndex == 1) {newcam_yaw = -0x4000; newcam_tilt = 2000; } else newcam_mode = NC_MODE_SLIDE; break;
+            case LEVEL_WDW: newcam_yaw = 0x2000; newcam_tilt = 3000; break;
+            case 27: newcam_mode = NC_MODE_SLIDE; break;
+            case LEVEL_TTM: if (gCurrAreaIndex == 2) newcam_mode = NC_MODE_SLIDE; break;
+        }
 
-    // clear these out when entering a new level to prevent "camera mode buffering"
-    newcam_saved_defmode = -1;
-    newcam_saved_mode = -1;
+        // clear these out when entering a new level to prevent "camera mode buffering"
+        newcam_saved_defmode = -1;
+        newcam_saved_mode = -1;
+    }
 
     // this will be set in init_settings() if enabled
     newcam_active = 0;

--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -3449,7 +3449,6 @@ void reset_camera(struct Camera *c) {
 
     if (gFirstPersonCamera.enabled) {
         gFirstPersonCamera.yaw = gMarioStates[0].faceAngle[1] + 0x8000;
-        set_mario_action(&gMarioStates[0], ACT_IDLE, 0);
     }
 }
 
@@ -3634,9 +3633,7 @@ void init_camera(struct Camera *c) {
     newcam_init(c, sSoftResettingCamera);
     newcam_init_settings();
 
-    if (sSoftResettingCamera) {
-        sSoftResettingCamera = FALSE;
-    }
+    sSoftResettingCamera = FALSE;
 }
 
 /**

--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -3449,6 +3449,7 @@ void reset_camera(struct Camera *c) {
 
     if (gFirstPersonCamera.enabled) {
         gFirstPersonCamera.yaw = gMarioStates[0].faceAngle[1] + 0x8000;
+        set_mario_action(&gMarioStates[0], ACT_IDLE, 0);
     }
 }
 
@@ -3506,103 +3507,106 @@ void init_camera(struct Camera *c) {
     marioOffset[2] = 400.f;
 
     // Set the camera's starting position or start a cutscene for certain levels
-    switch (gCurrLevelNum) {
-        case LEVEL_BOWSER_1:
+    if (!sSoftResettingCamera) {
+        switch (gCurrLevelNum) {
+            case LEVEL_BOWSER_1:
 #ifndef VERSION_JP
-            if (gCurrDemoInput == NULL) {
+                if (gCurrDemoInput == NULL) {
+                    // Make sure Bowser is in a state that we'd start speaking to him in.
+                    obj = find_object_with_behavior(bhvBowser);
+                    if (obj != NULL && obj->oAction != 5) { break; }
+
+                    start_cutscene(c, CUTSCENE_ENTER_BOWSER_ARENA);
+                } else if (gSecondCameraFocus != NULL) {
+                    gSecondCameraFocus->oBowserUnk88 = 2;
+                }
+#else
                 // Make sure Bowser is in a state that we'd start speaking to him in.
                 obj = find_object_with_behavior(bhvBowser);
                 if (obj != NULL && obj->oAction != 5) { break; }
 
                 start_cutscene(c, CUTSCENE_ENTER_BOWSER_ARENA);
-            } else if (gSecondCameraFocus != NULL) {
-                gSecondCameraFocus->oBowserUnk88 = 2;
-            }
-#else
-            // Make sure Bowser is in a state that we'd start speaking to him in.
-            obj = find_object_with_behavior(bhvBowser);
-            if (obj != NULL && obj->oAction != 5) { break; }
-
-            start_cutscene(c, CUTSCENE_ENTER_BOWSER_ARENA);
 #endif
-            break;
-        case LEVEL_BOWSER_2:
-            // Make sure Bowser is in a state that we'd start speaking to him in.
-            obj = find_object_with_behavior(bhvBowser);
-            if (obj != NULL && obj->oAction != 5) { break; }
+                break;
+            case LEVEL_BOWSER_2:
+                // Make sure Bowser is in a state that we'd start speaking to him in.
+                obj = find_object_with_behavior(bhvBowser);
+                if (obj != NULL && obj->oAction != 5) { break; }
 
-            start_cutscene(c, CUTSCENE_ENTER_BOWSER_ARENA);
-            break;
-        case LEVEL_BOWSER_3:
-            // Make sure Bowser is in a state that we'd start speaking to him in.
-            obj = find_object_with_behavior(bhvBowser);
-            if (obj != NULL && obj->oAction != 5) { break; }
+                start_cutscene(c, CUTSCENE_ENTER_BOWSER_ARENA);
+                break;
+            case LEVEL_BOWSER_3:
+                // Make sure Bowser is in a state that we'd start speaking to him in.
+                obj = find_object_with_behavior(bhvBowser);
+                if (obj != NULL && obj->oAction != 5) { break; }
 
-            start_cutscene(c, CUTSCENE_ENTER_BOWSER_ARENA);
-            break;
+                start_cutscene(c, CUTSCENE_ENTER_BOWSER_ARENA);
+                break;
 
-        //! Hardcoded position checks determine which cutscene to play when Mario enters castle grounds.
-        case LEVEL_CASTLE_GROUNDS:
-            if (is_within_100_units_of_mario(-1328.f, 260.f, 4664.f) != 1) {
-                marioOffset[0] = -400.f;
-                marioOffset[2] = -800.f;
-            }
-            if (is_within_100_units_of_mario(-6901.f, 2376.f, -6509.f) == 1) {
-                start_cutscene(c, CUTSCENE_EXIT_WATERFALL);
-            }
-            if (is_within_100_units_of_mario(5408.f, 4500.f, 3637.f) == 1) {
-                start_cutscene(c, CUTSCENE_EXIT_FALL_WMOTR);
-            }
-            gLakituState.mode = CAMERA_MODE_FREE_ROAM;
-            break;
-        case LEVEL_SA:
-            marioOffset[2] = 200.f;
-            break;
-        case LEVEL_CASTLE_COURTYARD:
-            marioOffset[2] = -300.f;
-            break;
-        case LEVEL_LLL:
-            gCameraMovementFlags |= CAM_MOVE_ZOOMED_OUT;
-            break;
-        case LEVEL_CASTLE:
-            marioOffset[2] = 150.f;
-            break;
-        case LEVEL_RR:
-            vec3f_set(sFixedModeBasePosition, -2985.f, 478.f, -5568.f);
-            break;
-    }
-    if ((c->mode == CAMERA_MODE_8_DIRECTIONS) || c->mode == CAMERA_MODE_ROM_HACK) {
-        gCameraMovementFlags |= CAM_MOVE_ZOOMED_OUT;
-    }
-    switch (gCurrLevelArea) {
-        case AREA_SSL_EYEROK:
-            vec3f_set(marioOffset, 0.f, 500.f, -100.f);
-            break;
-        case AREA_CCM_SLIDE:
-            marioOffset[2] = -300.f;
-            break;
-        case AREA_THI_WIGGLER:
-            marioOffset[2] = -300.f;
-            break;
-        case AREA_SL_IGLOO:
-            marioOffset[2] = -300.f;
-            break;
-        case AREA_SL_OUTSIDE:
-            if (is_within_100_units_of_mario(257.f, 2150.f, 1399.f) == 1) {
+            //! Hardcoded position checks determine which cutscene to play when Mario enters castle grounds.
+            case LEVEL_CASTLE_GROUNDS:
+                if (is_within_100_units_of_mario(-1328.f, 260.f, 4664.f) != 1) {
+                    marioOffset[0] = -400.f;
+                    marioOffset[2] = -800.f;
+                }
+                if (is_within_100_units_of_mario(-6901.f, 2376.f, -6509.f) == 1) {
+                    start_cutscene(c, CUTSCENE_EXIT_WATERFALL);
+                }
+                if (is_within_100_units_of_mario(5408.f, 4500.f, 3637.f) == 1) {
+                    start_cutscene(c, CUTSCENE_EXIT_FALL_WMOTR);
+                }
+                gLakituState.mode = CAMERA_MODE_FREE_ROAM;
+                break;
+            case LEVEL_SA:
+                marioOffset[2] = 200.f;
+                break;
+            case LEVEL_CASTLE_COURTYARD:
                 marioOffset[2] = -300.f;
-            }
-            break;
-        case AREA_CCM_OUTSIDE:
+                break;
+            case LEVEL_LLL:
+                gCameraMovementFlags |= CAM_MOVE_ZOOMED_OUT;
+                break;
+            case LEVEL_CASTLE:
+                marioOffset[2] = 150.f;
+                break;
+            case LEVEL_RR:
+                vec3f_set(sFixedModeBasePosition, -2985.f, 478.f, -5568.f);
+                break;
+        }
+
+        if ((c->mode == CAMERA_MODE_8_DIRECTIONS) || c->mode == CAMERA_MODE_ROM_HACK) {
             gCameraMovementFlags |= CAM_MOVE_ZOOMED_OUT;
-            break;
-        case AREA_TTM_OUTSIDE:
-            gLakituState.mode = CAMERA_MODE_RADIAL;
-            break;
+        }
+
+        switch (gCurrLevelArea) {
+            case AREA_SSL_EYEROK:
+                vec3f_set(marioOffset, 0.f, 500.f, -100.f);
+                break;
+            case AREA_CCM_SLIDE:
+                marioOffset[2] = -300.f;
+                break;
+            case AREA_THI_WIGGLER:
+                marioOffset[2] = -300.f;
+                break;
+            case AREA_SL_IGLOO:
+                marioOffset[2] = -300.f;
+                break;
+            case AREA_SL_OUTSIDE:
+                if (is_within_100_units_of_mario(257.f, 2150.f, 1399.f) == 1) {
+                    marioOffset[2] = -300.f;
+                }
+                break;
+            case AREA_CCM_OUTSIDE:
+                gCameraMovementFlags |= CAM_MOVE_ZOOMED_OUT;
+                break;
+            case AREA_TTM_OUTSIDE:
+                gLakituState.mode = CAMERA_MODE_RADIAL;
+                break;
+        }
     }
 
     if (sSoftResettingCamera) {
         c->cutscene = 0;
-        sSoftResettingCamera = FALSE;
     } else {
         // Set the camera pos to marioOffset (relative to Mario), added to Mario's position
         offset_rotated(c->pos, sMarioCamState->pos, marioOffset, sMarioCamState->faceAngle);
@@ -3627,8 +3631,12 @@ void init_camera(struct Camera *c) {
     c->yaw = gLakituState.yaw;
     c->nextYaw = gLakituState.yaw;
 
-    newcam_init(c, 0);
+    newcam_init(c, sSoftResettingCamera);
     newcam_init_settings();
+
+    if (sSoftResettingCamera) {
+        sSoftResettingCamera = FALSE;
+    }
 }
 
 /**

--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -12337,6 +12337,22 @@ void mode_rom_hack_camera(struct Camera *c) {
     pos[1] = mPos[1] + desiredHeight;
     pos[2] = mPos[2] + sins(sRomHackYaw) * desiredDist;
 
+    // Move camera down for hangable ceilings
+    if (sMarioCamState->action & ACT_FLAG_HANGING) {
+        f32 marioCeilHeight = sMarioGeometry.currCeilHeight;
+        f32 marioFloorHeight = sMarioGeometry.currFloorHeight;
+
+        if (marioFloorHeight < marioCeilHeight - 400.f) {
+            marioFloorHeight = marioCeilHeight - 400.f;
+        }
+
+        f32 goalHeight = marioFloorHeight + (marioCeilHeight - marioFloorHeight) * 0.4f;
+
+        if (pos[1] - 400 > goalHeight) {
+            pos[1] -= 400;
+        }
+    }
+
     if (rom_hack_cam_can_see_mario(pos)) {
         // we can see mario, no need to adjust
         c->pos[0] = pos[0];


### PR DESCRIPTION
Fix the camera reset issue as described in issue #494. This not only fixes that particular freecam issue, but also the camera reset issues when popping from a bubble in general.