### PR TITLE
Fixed empty keyboard bind names on DXGI

### DIFF
--- a/src/pc/controller/controller_bind_mapping.c
+++ b/src/pc/controller/controller_bind_mapping.c
@@ -145,13 +145,20 @@ const char* translate_bind_to_name(int bind) {
     if (sc == 0) { return name; }
 
 #ifdef HAVE_SDL2
-    const char* sname = SDL_GetKeyName(SDL_GetKeyFromScancode(sc));
-    if (strlen(sname) <= 9) { return sname; }
+    const char* sc_name = SDL_GetScancodeName(sc);
+    SDL_Keycode kc = SDL_GetKeyFromScancode(sc);
+    if (kc != 0) {
+        const char* kc_name = SDL_GetKeyName(kc);
+        if ((*kc_name & 0x80) == 0) { sc_name = kc_name; }
+    }
 
-    char* space = strchr(sname, ' ');
-    if (space == NULL) { return sname; }
+    if (*sc_name == '\0') { return name; }
+    if (strlen(sc_name) <= 9) { return sc_name; }
 
-    snprintf(name, 10, "%c%s", sname[0], (space + 1));
+    char* space = strchr(sc_name, ' ');
+    if (space == NULL) { return sc_name; }
+
+    snprintf(name, 10, "%c%s", sc_name[0], (space + 1));
 #endif
     return name;
 }

--- a/src/pc/controller/controller_sdl2.c
+++ b/src/pc/controller/controller_sdl2.c
@@ -108,6 +108,11 @@ static void controller_sdl_init(void) {
         return;
     }
 
+#ifdef WAPI_DXGI
+    extern void WIN_UpdateKeymap(void);
+    WIN_UpdateKeymap();
+#endif
+
     haptics_enabled = (SDL_InitSubSystem(SDL_INIT_HAPTIC) == 0);
 
     // try loading an external gamecontroller mapping file


### PR DESCRIPTION
Since `SDL_Init(SDL_INIT_VIDEO)` was NOT called on the DirectX version, `SDL_GetKeyFromScancode(SDL_Scancode)` returned zero for all possible keyboard binds enumerated in `translate_bind_to_name(int)`.

Addded a call to `WIN_UpdateKeymap()` (Windows Video API from SDL2) in `controller_sdl_init()`.

Added a fallback code to use `SDL_GetScancodeName()` (which references a static list of names based on the US QWERTY layout), in case `SDL_GetKeyName()` return an empty (or unrepresetable with ASCII) string.
