### PR TITLE
Improve romhack camera Y axis smoothness

### DIFF
--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -12336,10 +12336,10 @@ void mode_rom_hack_camera(struct Camera *c) {
 
     // figure out desired position
     f32 desiredDist = sRomHackZoom ? 900 : 1400;
-    f32 desiredHeight = sRomHackZoom ? 350 : 500;
+    f32 desiredHeight = sRomHackZoom ? 300 : 450;
     f32* mPos = &gMarioStates[0].pos[0];
     pos[0] = mPos[0] + coss(sRomHackYaw) * desiredDist;
-    pos[1] = mPos[1] + desiredHeight;
+    pos[1] =  pos[1] + desiredHeight;
     pos[2] = mPos[2] + sins(sRomHackYaw) * desiredDist;
 
     // Move camera down for hangable ceilings
@@ -12380,9 +12380,14 @@ void mode_rom_hack_camera(struct Camera *c) {
     }
 
     // tween
-    oldPos[0] = oldPos[0];
     c->pos[0] = c->pos[0] * 0.6 + oldPos[0] * 0.4;
-    c->pos[1] = c->pos[1] * 0.6 + oldPos[1] * 0.4;
+    {
+        f32 approachRate = 20.0f;
+        f32 goalHeight = c->pos[1];
+        approachRate += ABS(oldPos[1] - goalHeight) / 20;
+        c->pos[1] = oldPos[1];
+        approach_camera_height(c, goalHeight, approachRate);
+    }
     c->pos[2] = c->pos[2] * 0.6 + oldPos[2] * 0.4;
 
     // update HUD


### PR DESCRIPTION
This patch improves "default" romhack camera Y axis smoothness. Camera behaves similarly to HackerSM64 parallel lakitu camera.