### PR TITLE
Fix issues in PR #359 relating to incorrect handling of miscellaneous data types

### DIFF
--- a/src/engine/math_util.h
+++ b/src/engine/math_util.h
@@ -44,22 +44,22 @@ f32 coss(s16 sm64Angle);
 
 // Generic macros help the inline functions be noted in autodoc while retaining original functionality
 #define min(a, b) _Generic((a), \
-    f32: minf, \
-    s16: min, \
-    default: (a < b ? a : b) \
-)(a, b)
+    f32: minf(a, b), \
+    s16: (min)(a, b), \
+    default: ((a) < (b) ? (a) : (b)) \
+)
 
 #define max(a, b) _Generic((a), \
-    f32: maxf, \
-    s16: max, \
-    default: (a > b ? a : b) \
-)(a, b)
+    f32: maxf(a, b), \
+    s16: (max)(a, b), \
+    default: ((a) > (b) ? (a) : (b)) \
+)
 
 #define sqr(x) _Generic((x), \
-    f32: sqrf, \
-    s16: sqr, \
-    default: (x*x) \
-)(x)
+    f32: sqrf(x), \
+    s16: (sqr)(x), \
+    default: ((x) * (x)) \
+)
 
 #if defined(__clang__) || defined(__GNUC__)
 

--- a/src/engine/math_util.h
+++ b/src/engine/math_util.h
@@ -42,19 +42,23 @@ s16 sqr(s16 x);
 f32 sins(s16 sm64Angle);
 f32 coss(s16 sm64Angle);
 
+// Generic macros help the inline functions be noted in autodoc while retaining original functionality
 #define min(a, b) _Generic((a), \
     f32: minf, \
-    default: min \
+    s16: min, \
+    default: (a < b ? a : b) \
 )(a, b)
 
 #define max(a, b) _Generic((a), \
     f32: maxf, \
-    default: max \
+    s16: max, \
+    default: (a > b ? a : b) \
 )(a, b)
 
 #define sqr(x) _Generic((x), \
     f32: sqrf, \
-    default: sqr \
+    s16: sqr, \
+    default: (x*x) \
 )(x)
 
 #if defined(__clang__) || defined(__GNUC__)


### PR DESCRIPTION
Hello,

This patch fixes issues with type handling introduced in [PR #359](https://github.com/coop-deluxe/sm64coopdx/pull/359), specifically addressing incorrect handling of types like `size_t`. The previous commit did not account for these types in the `_Generic` macros, leading to problems during runtime. This update corrects the macros to properly handle these types, resolving the issues introduced earlier by my previous PR.
