### PR TITLE
Use proper controller names in settings

### DIFF
--- a/src/pc/djui/djui_panel_controls.c
+++ b/src/pc/djui/djui_panel_controls.c
@@ -52,14 +52,7 @@ void djui_panel_controls_create(struct DjuiBase* caller) {
                     // Then we can append the number so it fits in the slot
 
                     // Should we look into making scrolling text for this?
-                    if (strlen(gamepadChoices[i]) > 9) {
-                        strncpy(newName, gamepadChoices[i], 9);
-                        newName[9] = '\0';
-                        strcat(newName, "...");
-                        snprintf(newName, sizeof(newName), "%s (%d)", newName, count);
-                    } else {
-                        snprintf(newName, sizeof(newName), "%s (%d)", gamepadChoices[i], count);
-                    }
+                    snprintf(newName, sizeof(newName), "%.9s... (%d)", gamepadChoices[i], count);
                     
                     // Remove the old string and replace it with the new one
                     free(gamepadChoices[i]);

--- a/src/pc/djui/djui_panel_controls.c
+++ b/src/pc/djui/djui_panel_controls.c
@@ -25,34 +25,55 @@ void djui_panel_controls_create(struct DjuiBase* caller) {
         djui_checkbox_create(body, DLANG(MISC, USE_STANDARD_KEY_BINDINGS_CHAT), &configUseStandardKeyBindingsChat, NULL);
 
 #ifdef HAVE_SDL2
-    int numJoys = SDL_NumJoysticks();
-    if (numJoys == 0) { numJoys = 1; }
-    if (numJoys > 10) { numJoys = 10; }
-    char* gamepadChoices[numJoys];
-    for (int i = 0; i < numJoys; i++) {
-        const char* joystickName = SDL_JoystickNameForIndex(i);
-        if (joystickName == NULL) {
-        joystickName = "Unknown";
+        int numJoys = SDL_NumJoysticks();
+        if (numJoys == 0) { numJoys = 1; }
+        if (numJoys > 10) { numJoys = 10; }
+
+        char* gamepadChoices[numJoys];
+
+        // Get the names of all connected gamepads, if none is provided, use "Unknown"
+        for (int i = 0; i < numJoys; i++) {
+            const char* joystickName = SDL_JoystickNameForIndex(i);
+            if (joystickName == NULL) {
+                joystickName = "Unknown";
+            }
+            gamepadChoices[i] = strdup(joystickName);
         }
-        gamepadChoices[i] = strdup(joystickName);
-    }
-    djui_selectionbox_create(body, DLANG(CONTROLS, GAMEPAD), gamepadChoices, numJoys, &configGamepadNumber, NULL);
-    for (int i = 0; i < numJoys; i++) {
-        free(gamepadChoices[i]);
-    }
-    // Check for repeated names and append a number if necessary
-    for (int i = 0; i < numJoys; i++) {
-        int count = 1;
-        for (int j = 0; j < i; j++) {
-            if (strcmp(gamepadChoices[i], gamepadChoices[j]) == 0) {
-                count++;
-                char newName[256];
-                snprintf(newName, sizeof(newName), "%s (%d)", gamepadChoices[i], count);
-                free(gamepadChoices[i]);
-                gamepadChoices[i] = strdup(newName);
+
+        // Check for repeated names and append a number if necessary
+        for (int i = 0; i < numJoys; i++) {
+            int count = 1;
+            for (int j = 0; j < i; j++) {
+                if (strcmp(gamepadChoices[i], gamepadChoices[j]) == 0) {
+                    count++;
+                    char newName[256];
+                    
+                    // If the name is bigger than 12 characters, we need to truncate it first
+                    // Then we can append the number so it fits in the slot
+
+                    // Should we look into making scrolling text for this?
+                    if (strlen(gamepadChoices[i]) > 12) {
+                        strncpy(newName, gamepadChoices[i], 12);
+                        newName[12] = '\0';
+                        snprintf(newName, sizeof(newName), "%s (%d)", newName, count);
+                    } else {
+                        snprintf(newName, sizeof(newName), "%s (%d)", gamepadChoices[i], count);
+                    }
+                    
+                    // Remove the old string and replace it with the new one
+                    free(gamepadChoices[i]);
+                    gamepadChoices[i] = strdup(newName);
+                }
             }
         }
-    }
+
+        // Create the button
+        djui_selectionbox_create(body, DLANG(CONTROLS, GAMEPAD), gamepadChoices, numJoys, &configGamepadNumber, NULL);
+
+        // Free the memory we don't need anymore
+        for (int i = 0; i < numJoys; i++) {
+            free(gamepadChoices[i]);
+        }
 #endif
 
         djui_slider_create(body, DLANG(CONTROLS, DEADZONE), &configStickDeadzone, 0, 100, djui_panel_controls_value_change);

--- a/src/pc/djui/djui_panel_controls.c
+++ b/src/pc/djui/djui_panel_controls.c
@@ -52,9 +52,10 @@ void djui_panel_controls_create(struct DjuiBase* caller) {
                     // Then we can append the number so it fits in the slot
 
                     // Should we look into making scrolling text for this?
-                    if (strlen(gamepadChoices[i]) > 12) {
-                        strncpy(newName, gamepadChoices[i], 12);
-                        newName[12] = '\0';
+                    if (strlen(gamepadChoices[i]) > 9) {
+                        strncpy(newName, gamepadChoices[i], 9);
+                        newName[9] = '\0';
+                        strcat(newName, "...");
                         snprintf(newName, sizeof(newName), "%s (%d)", newName, count);
                     } else {
                         snprintf(newName, sizeof(newName), "%s (%d)", gamepadChoices[i], count);

--- a/src/pc/djui/djui_panel_controls.c
+++ b/src/pc/djui/djui_panel_controls.c
@@ -48,7 +48,7 @@ void djui_panel_controls_create(struct DjuiBase* caller) {
                     count++;
                     char newName[256];
                     
-                    // If the name is bigger than 12 characters, we need to truncate it first
+                    // If the name is bigger than 9 characters, we need to truncate it first
                     // Then we can append the number so it fits in the slot
 
                     // Should we look into making scrolling text for this?

--- a/src/pc/djui/djui_panel_controls.c
+++ b/src/pc/djui/djui_panel_controls.c
@@ -52,7 +52,11 @@ void djui_panel_controls_create(struct DjuiBase* caller) {
                     // Then we can append the number so it fits in the slot
 
                     // Should we look into making scrolling text for this?
-                    snprintf(newName, sizeof(newName), "%.9s... (%d)", gamepadChoices[i], count);
+                    if (strlen(gamepadChoices[i]) > 9) {
+                        snprintf(newName, sizeof(newName), "%.9s... (%d)", gamepadChoices[i], count);
+                    } else {
+                        snprintf(newName, sizeof(newName), "%s (%d)", gamepadChoices[i], count);
+                    }
                     
                     // Remove the old string and replace it with the new one
                     free(gamepadChoices[i]);


### PR DESCRIPTION
Make the controller names show up in the selection box instead of things like 0, 1, etc... Now it will show names like "PS4 Controller", if provided by SDL2.