### PR TITLE
Prevent smlua_to_string crashes

### DIFF
--- a/src/pc/lua/smlua_cobject.c
+++ b/src/pc/lua/smlua_cobject.c
@@ -386,7 +386,12 @@ static int smlua__get_field(lua_State* L) {
     CObject *cobj = lua_touserdata(L, 1);
     enum LuaObjectType lot = cobj->lot;
     u64 pointer = (u64)(intptr_t) cobj->pointer;
+
     const char *key = smlua_to_string(L, 2);
+    if (!gSmLuaConvertSuccess) {
+        LOG_LUA_LINE("Tried to get a non-string field of cobject");
+        return 0;
+    }
 
     // Legacy support
     if (strcmp(key, "_pointer") == 0) {
@@ -467,7 +472,12 @@ static int smlua__set_field(lua_State* L) {
     CObject *cobj = lua_touserdata(L, 1);
     enum LuaObjectType lot = cobj->lot;
     u64 pointer = (u64)(intptr_t) cobj->pointer;
+
     const char *key = smlua_to_string(L, 2);
+    if (!gSmLuaConvertSuccess) {
+        LOG_LUA_LINE("Tried to set a non-string field of cobject");
+        return 0;
+    }
 
     if (cobj->freed) {
         LOG_LUA_LINE("_set_field on freed object");
@@ -564,6 +574,7 @@ int smlua__gc(lua_State *L) {
 static int smlua_cpointer_get(lua_State* L) {
     CPointer *cptr = lua_touserdata(L, 1);
     const char *key = smlua_to_string(L, 2);
+    if (key == NULL) { return 0; }
 
     // Legacy support
     if (strcmp(key, "_pointer") == 0) {

--- a/src/pc/lua/smlua_functions.c
+++ b/src/pc/lua/smlua_functions.c
@@ -557,6 +557,7 @@ int smlua_func_texture_override_set(lua_State* L) {
     if (!smlua_functions_valid_param_count(L, 2)) { return 0; }
 
     const char* textureName = smlua_to_string(L, 1);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("texture_override_set: Failed to convert parameter 1"); return 0; }
 
     struct TextureInfo tmpOverrideTexInfo = { 0 };
     struct TextureInfo* overrideTexInfo = &tmpOverrideTexInfo;


### PR DESCRIPTION
Validates the result of `smlua_to_string()`, as seen in other parts of sm64coopdx codebase:
```c
// (1)
{
    const char* value = smlua_to_string(L, index);
    if (!gSmLuaConvertSuccess) { LOG_LUA("..."); return 0; }  // or check if 'value' is NULL
}

// (2)
{
    if (lua_type(L, index) != LUA_TSTRING) { LOG_LUA_LINE("..."); return 0; }
    const char* value = smlua_to_string(L, index);
}
```

There were checks missing (deleted by mistake?) in `smlua__get_field()` and `smlua__set_field()`, which could cause a game crash, due to calling `strcmp(NULL, "_pointer")`.

The crash could be triggered with a Lua script like:
```lua
local m = gMarioStates[0]; print(tostring(m[0]))
-- expected a valid CObject field name (LUA_TSTRING (4)), but got a number (LUA_TNUMBER (3))
```
