### PR TITLE
Solve crashing for disconnected players

### DIFF
--- a/src/pc/djui/djui_panel_playerlist.c
+++ b/src/pc/djui/djui_panel_playerlist.c
@@ -64,8 +64,12 @@ static void playerlist_update_row(u8 i, struct NetworkPlayer *np) {
 
 void djui_panel_playerlist_on_render_pre(UNUSED struct DjuiBase* base, UNUSED bool* skipRender) {
     if (gDjuiInMainMenu || gNetworkType == NT_NONE) {
-        djui_base_set_visible(&gDjuiPlayerList->base, false);
-        djui_base_set_visible(&gDjuiModList->base, false);
+        if (gDjuiPlayerList != NULL) {
+            djui_base_set_visible(&gDjuiPlayerList->base, false);
+        }
+        if (gDjuiModList != NULL) {
+            djui_base_set_visible(&gDjuiModList->base, false);
+        }
         return;
     }
 

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -626,6 +626,11 @@ void network_update(void) {
         }
     }*/
 
+    // Kick the player back to the Main Menu if network init failed
+    if ((gNetworkType == NT_NONE) && !gDjuiInMainMenu) {
+        network_reset_reconnect_and_rehost();
+        network_shutdown(true, false, false, false);
+    }
 }
 
 void network_shutdown(bool sendLeaving, bool exiting, bool popup, bool reconnecting) {

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -144,8 +144,9 @@ bool network_init(enum NetworkType inNetworkType, bool reconnecting) {
     // initialize the network system
     gNetworkSentJoin = false;
     int rc = gNetworkSystem->initialize(inNetworkType, reconnecting);
-    if (!rc) {
+    if (!rc && inNetworkType != NT_NONE) {
         LOG_ERROR("failed to initialize network system");
+        djui_popup_create(DLANG(NOTIF, DISCONNECT_CLOSED), 2);
         return false;
     }
     if (gNetworkServerAddr != NULL) {
@@ -638,13 +639,13 @@ void network_shutdown(bool sendLeaving, bool exiting, bool popup, bool reconnect
     gNetworkSentJoin = false;
 
     network_forget_all_reliable();
-    if (gNetworkType == NT_NONE) { return; }
-    if (gNetworkSystem == NULL) { LOG_ERROR("no network system attached"); return; }
-
-    if (gNetworkPlayerLocal != NULL && sendLeaving) { network_send_leaving(gNetworkPlayerLocal->globalIndex); }
-    network_player_shutdown(popup);
-    gNetworkSystem->shutdown(reconnecting);
-
+    if (gNetworkSystem == NULL) {
+        LOG_ERROR("no network system attached");
+    } else {
+        if (gNetworkPlayerLocal != NULL && sendLeaving) { network_send_leaving(gNetworkPlayerLocal->globalIndex); }
+        network_player_shutdown(popup);
+        gNetworkSystem->shutdown(reconnecting);
+    }
     if (gNetworkServerAddr != NULL) {
         free(gNetworkServerAddr);
         gNetworkServerAddr = NULL;


### PR DESCRIPTION
This PR adresses the following issues:
- show a pop-up message (disconnected, host is down) in case `gNetworkSystem->initialize()` fails
    - for example, if IPv6 is not configured properly for "Direct Connection".
- prevent sudden crashes with empty mod list panel when `(gNetworkType == NT_NONE)`
- allow player to quit the game to main menu while `(gNetworkType == NT_NONE)`
