### PR TITLE
IME Composition Rendering

### DIFF
--- a/src/pc/controller/controller_keyboard.c
+++ b/src/pc/controller/controller_keyboard.c
@@ -66,6 +66,10 @@ void keyboard_on_text_input(char* text) {
     djui_interactable_on_text_input(text);
 }
 
+void keyboard_on_text_editing(char* text, int cursorPos) {
+    djui_interactable_on_text_editing(text, cursorPos);
+}
+
 static void keyboard_add_binds(int mask, unsigned int *scancode) {
     for (int i = 0; i < MAX_BINDS && num_keybinds < MAX_KEYBINDS; ++i) {
         if (scancode[i] < VK_BASE_KEYBOARD + VK_SIZE) {

--- a/src/pc/controller/controller_keyboard.h
+++ b/src/pc/controller/controller_keyboard.h
@@ -42,6 +42,7 @@ bool keyboard_on_key_down(int scancode);
 bool keyboard_on_key_up(int scancode);
 void keyboard_on_all_keys_up(void);
 void keyboard_on_text_input(char* text);
+void keyboard_on_text_editing(char* text, int cursorPos);
 
 #ifdef __cplusplus
 }

--- a/src/pc/crash_handler.c
+++ b/src/pc/crash_handler.c
@@ -651,7 +651,8 @@ static void crash_handler(const int signalNum, siginfo_t *info, UNUSED ucontext_
     // In case the game crashed before the game window opened
     if (!gGfxInited) {
         gfx_init(&WAPI, &RAPI, TITLE);
-        WAPI.set_keyboard_callbacks(keyboard_on_key_down, keyboard_on_key_up, keyboard_on_all_keys_up, keyboard_on_text_input);
+        WAPI.set_keyboard_callbacks(keyboard_on_key_down, keyboard_on_key_up, keyboard_on_all_keys_up,
+            keyboard_on_text_input, keyboard_on_text_editing);
     }
     if (!gGameInited) djui_unicode_init();
 

--- a/src/pc/djui/djui_chat_box.c
+++ b/src/pc/djui/djui_chat_box.c
@@ -498,6 +498,10 @@ static void djui_chat_box_input_on_text_input(struct DjuiBase *base, char* text)
     }
 }
 
+static void djui_chat_box_input_on_text_editing(struct DjuiBase *base, char* text, int cursorPos) {
+    djui_inputbox_on_text_editing(base, text, cursorPos);
+}
+
 void djui_chat_box_toggle(void) {
     if (gDjuiChatBox == NULL) { return; }
     if (!gDjuiChatBoxFocus) { sDjuiChatBoxClearText = true; }
@@ -550,6 +554,7 @@ struct DjuiChatBox* djui_chat_box_create(void) {
     djui_base_set_alignment(ciBase, DJUI_HALIGN_LEFT, DJUI_VALIGN_BOTTOM);
     djui_interactable_hook_key(&chatInput->base, djui_chat_box_input_on_key_down, djui_inputbox_on_key_up);
     djui_interactable_hook_text_input(&chatInput->base, djui_chat_box_input_on_text_input);
+    djui_interactable_hook_text_editing(&chatInput->base, djui_chat_box_input_on_text_editing);
     chatBox->chatInput = chatInput;
 
     gDjuiChatBox = chatBox;

--- a/src/pc/djui/djui_inputbox.h
+++ b/src/pc/djui/djui_inputbox.h
@@ -11,6 +11,8 @@ struct DjuiInputbox {
     struct DjuiColor textColor;
     void (*on_enter_press)(struct DjuiInputbox*);
     void (*on_escape_press)(struct DjuiInputbox*);
+    char* imeBuffer;
+    u16 imePos;
 };
 
 void djui_inputbox_on_focus_begin(UNUSED struct DjuiBase* base);
@@ -25,5 +27,6 @@ void djui_inputbox_hook_escape_press(struct DjuiInputbox* inputbox, void (*on_es
 bool djui_inputbox_on_key_down(struct DjuiBase* base, int scancode);
 void djui_inputbox_on_key_up(struct DjuiBase* base, int scancode);
 void djui_inputbox_on_text_input(struct DjuiBase *base, char* text);
+void djui_inputbox_on_text_editing(struct DjuiBase *base, char* text, int cursorPos);
 
 struct DjuiInputbox* djui_inputbox_create(struct DjuiBase* parent, u16 bufferSize);

--- a/src/pc/djui/djui_interactable.c
+++ b/src/pc/djui/djui_interactable.c
@@ -328,6 +328,13 @@ void djui_interactable_on_text_input(char* text) {
     gInteractableFocus->interactable->on_text_input(gInteractableFocus, text);
 }
 
+void djui_interactable_on_text_editing(char* text, int cursorPos) {
+    if (gInteractableFocus == NULL) { return; }
+    if (gInteractableFocus->interactable == NULL) { return; }
+    if (gInteractableFocus->interactable->on_text_editing == NULL) { return; }
+    gInteractableFocus->interactable->on_text_editing(gInteractableFocus, text, cursorPos);
+}
+
 void djui_interactable_update_pad(void) {
     OSContPad* pad = &gInteractablePad;
 
@@ -519,6 +526,12 @@ void djui_interactable_hook_text_input(struct DjuiBase *base,
                                        void (*on_text_input)(struct DjuiBase*, char*)) {
     struct DjuiInteractable *interactable = base->interactable;
     interactable->on_text_input = on_text_input;
+}
+
+void djui_interactable_hook_text_editing(struct DjuiBase* base,
+                                       void (*on_text_editing)(struct DjuiBase*, char*, int)) {
+    struct DjuiInteractable *interactable = base->interactable;
+    interactable->on_text_editing = on_text_editing;
 }
 
 void djui_interactable_hook_enabled_change(struct DjuiBase *base,

--- a/src/pc/djui/djui_interactable.h
+++ b/src/pc/djui/djui_interactable.h
@@ -42,6 +42,7 @@ struct DjuiInteractable {
     bool (*on_key_down)(struct DjuiBase*, int scancode);
     void (*on_key_up)(struct DjuiBase*, int scancode);
     void (*on_text_input)(struct DjuiBase*, char* text);
+    void (*on_text_editing)(struct DjuiBase*, char* text, int cursorPos);
     void (*on_enabled_change)(struct DjuiBase*);
 };
 
@@ -62,6 +63,7 @@ bool djui_interactable_is_input_focus(struct DjuiBase* base);
 bool djui_interactable_on_key_down(int scancode);
 void djui_interactable_on_key_up(int scancode);
 void djui_interactable_on_text_input(char *text);
+void djui_interactable_on_text_editing(char* text, int cursorPos);
 
 void djui_interactable_update(void);
 
@@ -94,6 +96,9 @@ void djui_interactable_hook_key(struct DjuiBase* base,
 
 void djui_interactable_hook_text_input(struct DjuiBase* base,
                                        void (*on_text_input)(struct DjuiBase*, char*));
+
+void djui_interactable_hook_text_editing(struct DjuiBase* base,
+                                       void (*on_text_editing)(struct DjuiBase*, char*, int));
 
 void djui_interactable_hook_enabled_change(struct DjuiBase *base,
                                            void (*on_enabled_change)(struct DjuiBase*));

--- a/src/pc/gfx/gfx_sdl2.c
+++ b/src/pc/gfx/gfx_sdl2.c
@@ -65,6 +65,7 @@ static kb_callback_t kb_key_down = NULL;
 static kb_callback_t kb_key_up = NULL;
 static void (*kb_all_keys_up)(void) = NULL;
 static void (*kb_text_input)(char*) = NULL;
+static void (*kb_text_editing)(char*, int) = NULL;
 
 #define IS_FULLSCREEN() ((SDL_GetWindowFlags(wnd) & SDL_WINDOW_FULLSCREEN_DESKTOP) != 0)
 
@@ -211,6 +212,9 @@ static void gfx_sdl_handle_events(void) {
             case SDL_TEXTINPUT:
                 kb_text_input(event.text.text);
                 break;
+            case SDL_TEXTEDITING: //IME composition
+                kb_text_editing(event.edit.text,event.edit.start);
+                break;
             case SDL_KEYDOWN:
                 gfx_sdl_onkeydown(event.key.keysym.scancode);
                 break;
@@ -249,11 +253,14 @@ static void gfx_sdl_handle_events(void) {
     }
 }
 
-static void gfx_sdl_set_keyboard_callbacks(kb_callback_t on_key_down, kb_callback_t on_key_up, void (*on_all_keys_up)(void), void (*on_text_input)(char*)) {
+static void gfx_sdl_set_keyboard_callbacks(kb_callback_t on_key_down, kb_callback_t on_key_up,
+void (*on_all_keys_up)(void), void (*on_text_input)(char*), void (*on_text_editing)(char*, int))
+{
     kb_key_down = on_key_down;
     kb_key_up = on_key_up;
     kb_all_keys_up = on_all_keys_up;
     kb_text_input = on_text_input;
+    kb_text_editing = on_text_editing;
 }
 
 static bool gfx_sdl_start_frame(void) {

--- a/src/pc/gfx/gfx_window_manager_api.h
+++ b/src/pc/gfx/gfx_window_manager_api.h
@@ -13,7 +13,8 @@ typedef bool (*kb_callback_t)(int code);
 
 struct GfxWindowManagerAPI {
     void (*init)(const char *window_title);
-    void (*set_keyboard_callbacks)(kb_callback_t on_key_down, kb_callback_t on_key_up, void (*on_all_keys_up)(void), void (*on_text_input)(char*));
+    void (*set_keyboard_callbacks)(kb_callback_t on_key_down, kb_callback_t on_key_up, void (*on_all_keys_up)(void),
+        void (*on_text_input)(char*), void (*on_text_editing)(char*, int));
     void (*main_loop)(void (*run_one_game_iter)(void));
     void (*get_dimensions)(uint32_t *width, uint32_t *height);
     void (*handle_events)(void);

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -439,7 +439,8 @@ int main(int argc, char *argv[]) {
     // create the window almost straight away
     if (!gGfxInited) {
         gfx_init(&WAPI, &RAPI, TITLE);
-        WAPI.set_keyboard_callbacks(keyboard_on_key_down, keyboard_on_key_up, keyboard_on_all_keys_up, keyboard_on_text_input);
+        WAPI.set_keyboard_callbacks(keyboard_on_key_down, keyboard_on_key_up, keyboard_on_all_keys_up,
+            keyboard_on_text_input, keyboard_on_text_editing);
     }
 
     // render the rom setup screen


### PR DESCRIPTION
When typing in input boxes with an input method editor the text won't show up until it has been committed and sent through SDL_TEXTINPUT. This pr allows the composition text to render and moves the cursor accordingly.