### PR TITLE
Stop the gameplay from advancing a single frame on the pause screen in singleplayer

### DIFF
--- a/src/pc/network/network_utils.c
+++ b/src/pc/network/network_utils.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include "network_utils.h"
+#include "game/camera.h"
 #include "game/level_update.h"
 #include "game/mario_misc.h"
 #include "pc/mods/mods.h"
@@ -54,7 +55,8 @@ const char* network_get_player_text_color_string(u8 localIndex) {
 
 extern s16 gMenuMode;
 bool network_check_singleplayer_pause(void) {
-    return gMenuMode != -1 && network_player_connected_count() == 1 && mods_get_all_pausable() && !gDjuiInPlayerMenu;
+    return ((gMenuMode != -1) || (gCameraMovementFlags & CAM_MOVE_PAUSE_SCREEN)) &&
+        !gDjuiInPlayerMenu && network_player_connected_count() == 1 && mods_get_all_pausable();
 }
 
 const char* network_discord_id_from_local_index(u8 localIndex) {


### PR DESCRIPTION
Addresses the issue: https://github.com/coop-deluxe/sm64coopdx/issues/564

`network_check_singleplayer_pause()` now returns `true` for the moment when player wants to pause in singleplayer, and the pause screen should be displayed on the next frame -- when `pressed_pause()` in `play_mode_normal()` returned `true`, but `play_mode_paused()` was not called yet to change `gMenuMode`.

---

### Technical details (code flow before the bugfix)

First, this code executed when player presses START and pausing is allowed:
https://github.com/coop-deluxe/sm64coopdx/blob/f85b8419afc6266ac0af22c5723eebe3effa1f7d/src/game/level_update.c#L1318-L1323

Then, the game enters 2nd game loop iteration.

Now, `network_check_singleplayer_pause()` still returns `FALSE`, because `(gMenuMode == (-1))`:
https://github.com/coop-deluxe/sm64coopdx/blob/f85b8419afc6266ac0af22c5723eebe3effa1f7d/src/pc/network/network_utils.c#L56-L58

And when this code in `update_level()` is reached, the game executes:
(1) `changeLevel = play_mode_normal();`
(2) `sCurrPlayMode` has not changed from `PLAY_MODE_PAUSED`
(3) `changeLevel = play_mode_paused();`
(4) `{ set_menu_mode(RENDER_PAUSE_SCREEN); }`
https://github.com/coop-deluxe/sm64coopdx/blob/f85b8419afc6266ac0af22c5723eebe3effa1f7d/src/game/level_update.c#L1702-L1710

(normally this is so that the gameplay continues, while the pause screen is rendered in multiplayer, or when one of the loaded mods has property `pausable: false`)

---
