### PR TITLE
Synchronize instructions in `network_init()` (server) with `network_receive_join()` (client)

### DIFF
--- a/src/pc/djui/djui_panel_host_message.c
+++ b/src/pc/djui/djui_panel_host_message.c
@@ -2,7 +2,6 @@
 #include "djui.h"
 #include "djui_panel.h"
 #include "djui_panel_menu.h"
-#include "djui_panel_modlist.h"
 #include "pc/network/network.h"
 #include "pc/utils/misc.h"
 #include "pc/configfile.h"
@@ -29,11 +28,6 @@ void djui_panel_do_host(bool reconnecting, bool playSound) {
     network_set_system(configNetworkSystem);
 
     network_init(NT_SERVER, reconnecting);
-    djui_panel_modlist_create(NULL);
-    fake_lvl_init_from_save_file();
-
-    extern s16 gChangeLevelTransition;
-    gChangeLevelTransition = gLevelValues.entryLevel;
 
     if (gMarioState->marioObj) vec3f_copy(gMarioState->marioObj->header.gfx.cameraToObject, gGlobalSoundSource);
     if (playSound) { gDelayedInitSound = CHAR_SOUND_OKEY_DOKEY; }

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -11,6 +11,7 @@
 #include "pc/configfile.h"
 #include "pc/djui/djui.h"
 #include "pc/djui/djui_panel.h"
+#include "pc/djui/djui_panel_modlist.h"
 #include "pc/djui/djui_hud_utils.h"
 #include "pc/djui/djui_panel_main.h"
 #include "pc/utils/misc.h"
@@ -158,24 +159,26 @@ bool network_init(enum NetworkType inNetworkType, bool reconnecting) {
     gNetworkType = inNetworkType;
 
     if (gNetworkType == NT_SERVER) {
-        extern s16 gCurrSaveFileNum;
-        gCurrSaveFileNum = configHostSaveSlot;
-
-        mods_activate(&gLocalMods);
-        smlua_init();
-
-        dynos_behavior_hook_all_custom_behaviors();
-
-        network_player_connected(NPT_LOCAL, 0, configPlayerModel, &configPlayerPalette, configPlayerName, get_local_discord_id());
         extern u8* gOverrideEeprom;
         gOverrideEeprom = NULL;
 
-        if (gCurrLevelNum != (s16)gLevelValues.entryLevel) {
-            extern s16 gChangeLevelTransition;
-            gChangeLevelTransition = gLevelValues.entryLevel;
-        }
+        extern s16 gCurrSaveFileNum;
+        gCurrSaveFileNum = configHostSaveSlot;
+
+        network_player_connected(NPT_LOCAL, 0, configPlayerModel, &configPlayerPalette, configPlayerName, get_local_discord_id());
 
         djui_chat_box_create();
+        djui_panel_shutdown();
+
+        fake_lvl_init_from_save_file();
+
+        mods_activate(&gLocalMods);
+        djui_panel_modlist_create(NULL);
+        smlua_init();
+        dynos_behavior_hook_all_custom_behaviors();
+
+        extern s16 gChangeLevelTransition;
+        gChangeLevelTransition = gLevelValues.entryLevel;
     }
 
     configfile_save(configfile_name());

--- a/src/pc/network/packets/packet_join.c
+++ b/src/pc/network/packets/packet_join.c
@@ -15,7 +15,6 @@
 #include "pc/djui/djui.h"
 #include "pc/djui/djui_panel.h"
 #include "pc/djui/djui_panel_modlist.h"
-#include "pc/djui/djui_panel_playerlist.h"
 #include "pc/djui/djui_panel_menu.h"
 #include "pc/djui/djui_panel_join_message.h"
 #include "pc/utils/string_builder.h"


### PR DESCRIPTION
Synchronizes the order of operations when a new game starts:
- `network_player_connected(NPT_LOCAL, ...)` called before `smlua_init()`
  - so that, for example, `gNetworkPlayers[0]` has valid fields then Lua scripts are initialized
  - previously, `gNetworkPlayers[0]` was empty on the server side
- `djui_chat_box_create()` called before `smlua_init()`
  - allows `djui_chat_message_create()` to be called when Lua mod is initialized, or in `HOOK_ON_MODS_LOADED`
  - previously it would only work on the client side, because server-side chat-box was created after loading all mod files
- `gChangeLevelTransition` was set twice for no reason
  - first conditionally in `network_init(NT_SERVER)`
  - then unconditionally in `djui_panel_do_host()`
 