### PR TITLE
Fixed MacOS Resource Path Location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,6 @@ build-windows-visual-studio/.vs
 # misc
 todo.txt
 todo-old.txt
-
+*.DS_Store
 tools/ido5.3_compiler/usr/lib/libc.so.1
 /.vs

--- a/data/dynos.h
+++ b/data/dynos.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 #define DYNOS_VERSION           "1.0"
-#define DYNOS_EXE_FOLDER        sys_exe_path_dir()
+#define DYNOS_EXE_FOLDER        sys_resource_path()
 #define DYNOS_USER_FOLDER       fs_get_write_path("")
 #define DYNOS_RES_FOLDER        "dynos"
 #define DYNOS_PACKS_FOLDER      DYNOS_RES_FOLDER "/packs"

--- a/src/pc/djui/djui_language.c
+++ b/src/pc/djui/djui_language.c
@@ -19,7 +19,7 @@ bool djui_language_init(char* lang) {
     // construct path
     char path[SYS_MAX_PATH] = "";
     if (!lang || lang[0] == '\0') { lang = "English"; }
-    snprintf(path, SYS_MAX_PATH, "%s/lang/%s.ini", sys_exe_path_dir(), lang);
+    snprintf(path, SYS_MAX_PATH, "%s/lang/%s.ini", sys_resource_path(), lang);
 
     // load
     sLang = ini_load(path);

--- a/src/pc/djui/djui_panel_language.c
+++ b/src/pc/djui/djui_panel_language.c
@@ -94,7 +94,7 @@ void djui_panel_language_create(struct DjuiBase* caller) {
     {
         // construct lang path
         char lpath[SYS_MAX_PATH] = "";
-        snprintf(lpath, SYS_MAX_PATH, "%s/lang", sys_exe_path_dir());
+        snprintf(lpath, SYS_MAX_PATH, "%s/lang", sys_resource_path());
 
         // open directory
         struct dirent* dir = NULL;

--- a/src/pc/djui/djui_panel_player.c
+++ b/src/pc/djui/djui_panel_player.c
@@ -441,7 +441,7 @@ void djui_panel_player_create(struct DjuiBase* caller) {
         djui_selectionbox_create(body, DLANG(PLAYER, MODEL), characterChoices, CT_MAX, &configPlayerModel, djui_panel_player_value_changed);
 
         player_palettes_reset();
-        player_palettes_read(sys_exe_path_dir(), true);
+        player_palettes_read(sys_resource_path(), true);
         player_palettes_read(fs_get_write_path(PALETTES_DIRECTORY), false);
 
         char* palettePresets[MAX_PRESET_PALETTES + 1] = { DLANG(PALETTE, CUSTOM) };

--- a/src/pc/mods/mods.c
+++ b/src/pc/mods/mods.c
@@ -301,7 +301,7 @@ void mods_refresh_local(void) {
     if (hasUserPath) { mods_load(&gLocalMods, userModPath, true); }
 
     char defaultModsPath[SYS_MAX_PATH] = { 0 };
-    snprintf(defaultModsPath, SYS_MAX_PATH, "%s/%s", sys_exe_path_dir(), MOD_DIRECTORY);
+    snprintf(defaultModsPath, SYS_MAX_PATH, "%s/%s", sys_resource_path(), MOD_DIRECTORY);
     mods_load(&gLocalMods, defaultModsPath, false);
 
     // sort

--- a/src/pc/platform.c
+++ b/src/pc/platform.c
@@ -332,19 +332,19 @@ const char *sys_user_path(void) {
 
 const char *sys_resource_path(void)
 {
-    #ifdef __APPLE__ // Kinda lazy, but I don't know how to add CoreFoundation.framework
+#ifdef __APPLE__ // Kinda lazy, but I don't know how to add CoreFoundation.framework
     static char path[SYS_MAX_PATH];
     if ('\0' != path[0]) { return path; }
 
     const char *exeDir = sys_exe_path_dir();
     char *lastSeparator = strrchr(exeDir, '/');
     if (lastSeparator != NULL) {
-        const char folder[10] = "/Resources";
+        const char folder[] = "/Resources";
         size_t count = (size_t)(lastSeparator - exeDir);
         strncpy(path, exeDir, count);
-        return strcat(path, folder);
+        return strncat(path, folder, sizeof(path) - 1 - count);
     }
-    #endif
+#endif
 
     return sys_exe_path_dir();
 }

--- a/src/pc/platform.c
+++ b/src/pc/platform.c
@@ -252,6 +252,10 @@ const char *sys_user_path(void)
     return sys_windows_short_path_from_wcs(shortPath, SYS_MAX_PATH, widePath) ? shortPath : NULL;
 }
 
+const char *sys_resource_path(void) {
+    return sys_exe_path_dir();
+}
+
 const char *sys_exe_path_dir(void)
 {
     static char path[SYS_MAX_PATH];
@@ -324,6 +328,25 @@ const char *sys_user_path(void) {
     if (path[len-1] == '/' || path[len-1] == '\\') { path[len-1] = 0; }
 
     return path;
+}
+
+const char *sys_resource_path(void)
+{
+    #ifdef __APPLE__ // Kinda lazy, but I don't know how to add CoreFoundation.framework
+    static char path[SYS_MAX_PATH];
+    if ('\0' != path[0]) { return path; }
+
+    const char *exeDir = sys_exe_path_dir();
+    char *lastSeparator = strrchr(exeDir, '/');
+    if (lastSeparator != NULL) {
+        const char folder[10] = "/Resources";
+        size_t count = (size_t)(lastSeparator - exeDir);
+        strncpy(path, exeDir, count);
+        return strcat(path, folder);
+    }
+    #endif
+
+    return sys_exe_path_dir();
 }
 
 const char *sys_exe_path_dir(void) {

--- a/src/pc/platform.h
+++ b/src/pc/platform.h
@@ -20,6 +20,7 @@ bool sys_windows_short_path_from_wcs(char *destPath, size_t destSize, const wcha
 bool sys_windows_short_path_from_mbs(char* destPath, size_t destSize, const char *mbsLongPath);
 #endif
 const char *sys_user_path(void);
+const char *sys_resource_path(void);
 const char *sys_exe_path_dir(void);
 const char *sys_exe_path_file(void);
 const char *sys_file_extension(const char *fpath);


### PR DESCRIPTION
Wanted to play this with my dad so I compiled it for MacOS since we don't have many Windows computers. I noticed the path to get the mods and stuff was different from what was created by the MakeFile, so I fixed that. I also added a new function called `sys_resource_path()` in place of some `sys_exe_path_dir()` instances to grab resources like DynOS, mods, and languages. I have not tested this on a Windows 32 bit or Linux, although I assume it still works.

Side Note: When compiling for MacOS with these changes on the dev branch, `--build-id=none` in the MakeFile caused an error so I removed it to get it to compile. However, it was fine to keep in when I tested it on Windows. I don't know if it causes an error on Linux or continues compiling, but it errored on my MacOS Intel.