### PR TITLE
Fix a linker error with macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -990,7 +990,9 @@ endif
 IS_DEV_OR_DEBUG := $(or $(filter 1,$(DEVELOPMENT)),$(filter 1,$(DEBUG)),0)
 ifeq ($(IS_DEV_OR_DEBUG),0)
   CFLAGS += -fno-ident -fno-common -ffile-prefix-map=$(PWD)=. -D__DATE__="\"\"" -D__TIME__="\"\"" -Wno-builtin-macro-redefined
-  LDFLAGS += -Wl,--build-id=none
+  ifeq ($(OSX_BUILD),0)
+    LDFLAGS += -Wl,--build-id=none
+  endif
 endif
 
 # Prevent a crash with -sopt


### PR DESCRIPTION
During the linking stage of compilation, an error is thrown as `--build-id` appears to not exist in macOS. I've simply gone ahead and removed the added ld flags if the project is being compiled on macOS. The game appears to launch and run fine with this change.