### PR TITLE
Makefile fix to allow building in directories with special characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -989,7 +989,7 @@ endif
 
 IS_DEV_OR_DEBUG := $(or $(filter 1,$(DEVELOPMENT)),$(filter 1,$(DEBUG)),0)
 ifeq ($(IS_DEV_OR_DEBUG),0)
-  CFLAGS += -fno-ident -fno-common -ffile-prefix-map=$(PWD)=. -D__DATE__="\"\"" -D__TIME__="\"\"" -Wno-builtin-macro-redefined
+  CFLAGS += -fno-ident -fno-common -ffile-prefix-map="$(PWD)"=. -D__DATE__="\"\"" -D__TIME__="\"\"" -Wno-builtin-macro-redefined
   LDFLAGS += -Wl,--build-id=none
 endif
 


### PR DESCRIPTION
Hello,

This PR addresses an issue with the Makefile that prevents successful compilation of sm64coopdx when the project resides in a directory containing parentheses, such as `/sm64coopdx (dev)/`. This functionality was previously supported but was inadvertently broken in recent changes.