### PR TITLE
New config option: Skip DynOS binary file generation on startup

### DIFF
--- a/data/dynos_gfx_init.cpp
+++ b/data/dynos_gfx_init.cpp
@@ -4,6 +4,8 @@ extern "C" {
 }
 
 void DynOS_Gfx_GeneratePacks(const char* directory) {
+    if (configSkipPackGeneration) { return; }
+    
     LOADING_SCREEN_MUTEX(
         loading_screen_reset_progress_bar();
         snprintf(gCurrLoadingSegment.str, 256, "Generating DynOS Packs In Path:\n\\#808080\\%s", directory);

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -188,6 +188,7 @@ unsigned int configDjuiScale                      = 0;
 // other
 unsigned int configRulesVersion                   = 0;
 bool         configCompressOnStartup              = false;
+bool         configSkipPackGeneration             = false;
 
 // secrets
 bool configExCoopTheme = false;
@@ -319,6 +320,7 @@ static const struct ConfigOption options[] = {
     // other
     {.name = "rules_version",                  .type = CONFIG_TYPE_UINT,   .uintValue   = &configRulesVersion},
     {.name = "compress_on_startup",            .type = CONFIG_TYPE_BOOL,   .boolValue   = &configCompressOnStartup},
+    {.name = "skip_pack_generation",           .type = CONFIG_TYPE_BOOL,   .boolValue   = &configSkipPackGeneration},
 };
 
 struct SecretConfigOption {

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -137,6 +137,7 @@ extern unsigned int configDjuiScale;
 // other
 extern unsigned int configRulesVersion;
 extern bool         configCompressOnStartup;
+extern bool         configSkipPackGeneration;
 
 // secrets
 extern bool configExCoopTheme;


### PR DESCRIPTION
it is off by default, but the common player may want to turn it on to improve loading times