### PR TITLE
Revert romhack camera changes

### DIFF
--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -12275,13 +12275,13 @@ void mode_rom_hack_camera(struct Camera *c) {
 
     // look left
     if (gMarioStates[0].controller->buttonPressed & L_CBUTTONS) {
-        sRomHackYaw -= DEGREES(45) * (camera_config_is_x_inverted() ? -1 : 1);
+        sRomHackYaw += DEGREES(45) * (camera_config_is_x_inverted() ? -1 : 1);
         play_sound_cbutton_side();
     }
 
     // look right
     if (gMarioStates[0].controller->buttonPressed & R_CBUTTONS) {
-        sRomHackYaw += DEGREES(45) * (camera_config_is_x_inverted() ? -1 : 1);
+        sRomHackYaw -= DEGREES(45) * (camera_config_is_x_inverted() ? -1 : 1);
         play_sound_cbutton_side();
     }
 


### PR DESCRIPTION
In my honest opinion, this should have never been changed. Doing this forces the x axis to invert itself upon entering a custom level. 

Think about it like this, imagine playing flood/Flood Expanded and you enter one of the custom levels, when trying to move your camera you realize it has suddenly been inverted and you end up failing because of your camera controls. 

We shouldn't be forced to go to the camera options and enable/disable the `invert x` option each time we enter/leave a level.