### PR TITLE
GitHub Actions for macOS

### DIFF
--- a/.github/workflows/build-coop.yaml
+++ b/.github/workflows/build-coop.yaml
@@ -26,6 +26,7 @@ jobs:
               with:
                 name: sm64coopdx-ubuntu
                 path: ./build/us_pc/sm64coopdx
+
     build-windows:
         if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[build]') }}
         runs-on: windows-latest
@@ -63,3 +64,47 @@ jobs:
               with:
                 name: sm64coopdx-windows
                 path: ./build/us_pc/sm64coopdx.exe
+
+    build-macos-arm:
+        if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[build]') }}
+        runs-on: macos-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Install dependencies (ARM)
+              run: |
+                /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+                brew install make mingw-w64 gcc sdl2 pkg-config glew glfw3 libusb audiofile coreutils
+
+            - name: Build the game (ARM)
+              run: |
+                gmake OSX_BUILD=1 -j$(sysctl -n hw.ncpu)
+
+            - name: Upload artifact (ARM)
+              uses: actions/upload-artifact@v4
+              with:
+                name: sm64coopdx-macos-arm
+                path: ./build/us_pc/sm64coopdx.app
+
+    build-macos-intel:
+        if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[build]') }}
+        runs-on: macos-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Install dependencies (Intel)
+              run: |
+                /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+                brew install make mingw-w64 gcc@9 sdl2 pkg-config glew glfw3 libusb audiofile coreutils
+
+            - name: Build the game (Intel)
+              run: |
+                gmake OSX_BUILD=1 -j$(sysctl -n hw.ncpu)
+
+            - name: Upload artifact (Intel)
+              uses: actions/upload-artifact@v4
+              with:
+                name: sm64coopdx-macos-intel
+                path: ./build/us_pc/sm64coopdx.app

--- a/.github/workflows/build-coop.yaml
+++ b/.github/workflows/build-coop.yaml
@@ -89,7 +89,7 @@ jobs:
 
     build-macos-intel:
         if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[build]') }}
-        runs-on: macos-latest
+        runs-on: macos-13
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4

--- a/.github/workflows/build-coop.yaml
+++ b/.github/workflows/build-coop.yaml
@@ -75,7 +75,7 @@ jobs:
             - name: Install dependencies
               run: |
                 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-                brew install make mingw-w64 gcc sdl2 pkg-config glew glfw3 libusb audiofile coreutils
+                brew install make mingw-w64 gcc sdl2 pkg-config glew glfw3 libusb coreutils
 
             - name: Build the game
               run: |
@@ -97,7 +97,7 @@ jobs:
             - name: Install dependencies
               run: |
                 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-                brew install make mingw-w64 gcc@9 sdl2 pkg-config glew glfw3 libusb audiofile coreutils
+                brew install make mingw-w64 gcc@9 sdl2 pkg-config glew glfw3 libusb coreutils
 
             - name: Build the game
               run: |

--- a/.github/workflows/build-coop.yaml
+++ b/.github/workflows/build-coop.yaml
@@ -81,11 +81,19 @@ jobs:
               run: |
                 gmake OSX_BUILD=1 -j$(sysctl -n hw.ncpu)
 
+            - name: Remove quarantine attribute
+              run: xattr -cr ./build/us_pc/sm64coopdx.app
+
+            - name: Zip the .app bundle
+              run: |
+                cd ./build/us_pc
+                zip -r sm64coopdx-macos-arm.zip sm64coopdx.app
+            
             - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:
                 name: sm64coopdx-macos-arm
-                path: ./build/us_pc/sm64coopdx.app
+                path: ./build/us_pc/sm64coopdx-macos-arm.zip
 
     build-macos-intel:
         if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[build]') }}
@@ -103,8 +111,16 @@ jobs:
               run: |
                 gmake OSX_BUILD=1 -j$(sysctl -n hw.ncpu)
 
+            - name: Remove quarantine attribute
+              run: xattr -cr ./build/us_pc/sm64coopdx.app
+
+            - name: Zip the .app bundle
+              run: |
+                cd ./build/us_pc
+                zip -r sm64coopdx-macos-intel.zip sm64coopdx.app
+            
             - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:
                 name: sm64coopdx-macos-intel
-                path: ./build/us_pc/sm64coopdx.app
+                path: ./build/us_pc/sm64coopdx-macos-intel.zip

--- a/.github/workflows/build-coop.yaml
+++ b/.github/workflows/build-coop.yaml
@@ -72,16 +72,16 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
 
-            - name: Install dependencies (ARM)
+            - name: Install dependencies
               run: |
                 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
                 brew install make mingw-w64 gcc sdl2 pkg-config glew glfw3 libusb audiofile coreutils
 
-            - name: Build the game (ARM)
+            - name: Build the game
               run: |
                 gmake OSX_BUILD=1 -j$(sysctl -n hw.ncpu)
 
-            - name: Upload artifact (ARM)
+            - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:
                 name: sm64coopdx-macos-arm
@@ -94,16 +94,16 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v4
 
-            - name: Install dependencies (Intel)
+            - name: Install dependencies
               run: |
                 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
                 brew install make mingw-w64 gcc@9 sdl2 pkg-config glew glfw3 libusb audiofile coreutils
 
-            - name: Build the game (Intel)
+            - name: Build the game
               run: |
                 gmake OSX_BUILD=1 -j$(sysctl -n hw.ncpu)
 
-            - name: Upload artifact (Intel)
+            - name: Upload artifact
               uses: actions/upload-artifact@v4
               with:
                 name: sm64coopdx-macos-intel

--- a/.github/workflows/build-coop.yaml
+++ b/.github/workflows/build-coop.yaml
@@ -81,8 +81,9 @@ jobs:
               run: |
                 gmake OSX_BUILD=1 -j$(sysctl -n hw.ncpu)
 
-            - name: Remove quarantine attribute
-              run: xattr -cr ./build/us_pc/sm64coopdx.app
+            - name: Code sign the app (Ad-Hoc)
+              run: |
+                codesign --force --deep --sign - ./build/us_pc/sm64coopdx.app
 
             - name: Zip the .app bundle
               run: |
@@ -111,8 +112,9 @@ jobs:
               run: |
                 gmake OSX_BUILD=1 -j$(sysctl -n hw.ncpu)
 
-            - name: Remove quarantine attribute
-              run: xattr -cr ./build/us_pc/sm64coopdx.app
+            - name: Code sign the app (Ad-Hoc)
+              run: |
+                codesign --force --deep --sign - ./build/us_pc/sm64coopdx.app
 
             - name: Zip the .app bundle
               run: |


### PR DESCRIPTION
Intel min ver is 13, arm is whatever GitHub Actions has it at (I believe 14, 15 experimental). Ad-hoc code signing is in place, so the executable is launch able. Zips it all up as intended, and runs appropriately :)