### PR TITLE
Add gfx_set_texture_image for lua

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -9245,8 +9245,18 @@ end
 --- @param Ab1 integer
 --- @param Ac1 integer
 --- @param Ad1 integer
---- Sets the display list combine mode.
+--- Sets the display list combine mode. you can fill this function with G_CCMUX_* and G_ACMUX_* constants
 function gfx_set_combine_lerp(gfx, a0, b0, c0, d0, Aa0, Ab0, Ac0, Ad0, a1, b1, c1, d1, Aa1, Ab1, Ac1, Ad1)
+    -- ...
+end
+
+--- @param gfx Pointer_Gfx
+--- @param format integer
+--- @param size integer
+--- @param width integer
+--- @param texture Pointer_integer
+--- Sets the display list texture image. Pass in textureInfo.texture as `texture`
+function gfx_set_texture_image(gfx, format, size, width, texture)
     -- ...
 end
 

--- a/docs/lua/functions-5.md
+++ b/docs/lua/functions-5.md
@@ -7890,7 +7890,7 @@ Traverses a display list. Takes a Lua function as a parameter, which is called b
 ## [gfx_set_combine_lerp](#gfx_set_combine_lerp)
 
 ### Description
-Sets the display list combine mode.
+Sets the display list combine mode. you can fill this function with G_CCMUX_* and G_ACMUX_* constants
 
 ### Lua Example
 `gfx_set_combine_lerp(gfx, a0, b0, c0, d0, Aa0, Ab0, Ac0, Ad0, a1, b1, c1, d1, Aa1, Ab1, Ac1, Ad1)`
@@ -7921,6 +7921,33 @@ Sets the display list combine mode.
 
 ### C Prototype
 `void gfx_set_combine_lerp(Gfx* gfx, u32 a0, u32 b0, u32 c0, u32 d0, u32 Aa0, u32 Ab0, u32 Ac0, u32 Ad0, u32 a1, u32 b1, u32 c1, u32 d1,	u32 Aa1, u32 Ab1, u32 Ac1, u32 Ad1);`
+
+[:arrow_up_small:](#)
+
+<br />
+
+## [gfx_set_texture_image](#gfx_set_texture_image)
+
+### Description
+Sets the display list texture image. Pass in textureInfo.texture as `texture`
+
+### Lua Example
+`gfx_set_texture_image(gfx, format, size, width, texture)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| gfx | `Pointer` <`Gfx`> |
+| format | `integer` |
+| size | `integer` |
+| width | `integer` |
+| texture | `Pointer` <`integer`> |
+
+### Returns
+- None
+
+### C Prototype
+`void gfx_set_texture_image(Gfx* gfx, u32 format, u32 size, u32 width, u8* texture);`
 
 [:arrow_up_small:](#)
 

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -1710,6 +1710,7 @@
    - [gfx_get_vtx](functions-5.md#gfx_get_vtx)
    - [gfx_parse](functions-5.md#gfx_parse)
    - [gfx_set_combine_lerp](functions-5.md#gfx_set_combine_lerp)
+   - [gfx_set_texture_image](functions-5.md#gfx_set_texture_image)
    - [set_fog_color](functions-5.md#set_fog_color)
    - [set_fog_intensity](functions-5.md#set_fog_intensity)
    - [set_lighting_color](functions-5.md#set_lighting_color)

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -28438,6 +28438,31 @@ int smlua_func_gfx_set_combine_lerp(lua_State* L) {
     return 1;
 }
 
+int smlua_func_gfx_set_texture_image(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 5) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "gfx_set_texture_image", 5, top);
+        return 0;
+    }
+
+    Gfx* gfx = (Gfx*)smlua_to_cobject(L, 1, LOT_GFX);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "gfx_set_texture_image"); return 0; }
+    u32 format = smlua_to_integer(L, 2);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "gfx_set_texture_image"); return 0; }
+    u32 size = smlua_to_integer(L, 3);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "gfx_set_texture_image"); return 0; }
+    u32 width = smlua_to_integer(L, 4);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 4, "gfx_set_texture_image"); return 0; }
+    u8* texture = (u8*)smlua_to_cpointer(L, 5, LVT_U8_P);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 5, "gfx_set_texture_image"); return 0; }
+
+    gfx_set_texture_image(gfx, format, size, width, texture);
+
+    return 1;
+}
+
 int smlua_func_set_fog_color(lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -33745,6 +33770,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "gfx_get_vtx", smlua_func_gfx_get_vtx);
     smlua_bind_function(L, "gfx_parse", smlua_func_gfx_parse);
     smlua_bind_function(L, "gfx_set_combine_lerp", smlua_func_gfx_set_combine_lerp);
+    smlua_bind_function(L, "gfx_set_texture_image", smlua_func_gfx_set_texture_image);
     smlua_bind_function(L, "set_fog_color", smlua_func_set_fog_color);
     smlua_bind_function(L, "set_fog_intensity", smlua_func_set_fog_intensity);
     smlua_bind_function(L, "set_lighting_color", smlua_func_set_lighting_color);

--- a/src/pc/lua/utils/smlua_gfx_utils.c
+++ b/src/pc/lua/utils/smlua_gfx_utils.c
@@ -170,3 +170,8 @@ void gfx_set_combine_lerp(Gfx* gfx, u32 a0, u32 b0, u32 c0, u32 d0, u32 Aa0, u32
     if (!gfx) { return; }
     gDPSetCombineLERPNoString(gfx, a0, b0, c0, d0, Aa0, Ab0, Ac0, Ad0, a1, b1, c1, d1, Aa1, Ab1, Ac1, Ad1);
 }
+
+void gfx_set_texture_image(Gfx* gfx, u32 format, u32 size, u32 width, u8* texture) {
+    if (!gfx) { return; }
+    gDPSetTextureImage(gfx, format, size, width, texture);
+}

--- a/src/pc/lua/utils/smlua_gfx_utils.h
+++ b/src/pc/lua/utils/smlua_gfx_utils.h
@@ -52,7 +52,9 @@ void set_skybox_color(u8 index, u8 value);
 void gfx_parse(Gfx* cmd, LuaFunction func);
 /* |description|Gets a vertex from a display list command if it has the correct op. Intended to be used with `gfx_parse`.|descriptionEnd| */
 Vtx *gfx_get_vtx(Gfx* gfx, u16 offset);
-/* |description|Sets the display list combine mode.|descriptionEnd| */
+/* |description|Sets the display list combine mode. you can fill this function with G_CCMUX_* and G_ACMUX_* constants|descriptionEnd| */
 void gfx_set_combine_lerp(Gfx* gfx, u32 a0, u32 b0, u32 c0, u32 d0, u32 Aa0, u32 Ab0, u32 Ac0, u32 Ad0, u32 a1, u32 b1, u32 c1, u32 d1,	u32 Aa1, u32 Ab1, u32 Ac1, u32 Ad1);
+/* |description|Sets the display list texture image. Pass in textureInfo.texture as `texture`|descriptionEnd| */
+void gfx_set_texture_image(Gfx* gfx, u32 format, u32 size, u32 width, u8* texture);
 
 #endif


### PR DESCRIPTION
This PR adds gfx_set_texture_image which you can use to modify a displaylist's texture. heres an example of using it to change a texture of one material exported from fast64:

```lua
local textureToUse = nil
local dlToTexture = nil

function geo_dl_texture_image(node, matStackIndex)
    local dl = cast_graph_node(node.next).displayList
    local m = geo_get_mario_state()

    if m.action == ACT_JUMP then
        textureToUse = gTextures.mario_head.texture
    else
        textureToUse = gTextures.wario_head.texture
    end

    gfx_parse(dl, function(cmd, op)
        if (op == G_NOOP) then
            if (cmd.w1 == 69) then
                dlToTexture = cmd
                return;
            end
        end
    end)

    if dlToTexture and textureToUse then
        gfx_set_texture_image(dlToTexture, G_IM_FMT_RGBA, G_IM_SIZ_16b, 1, textureToUse)
    end
end
```

this is the material that we're modifying:
```c
Gfx mat_mario_luaTexture[] = {
	gsSPSetLights1(mat_mario_luaTexture_lights),
	gsDPPipeSync(),
	gsDPSetCombineLERP(TEXEL0, 0, SHADE, 0, 0, 0, 0, ENVIRONMENT, TEXEL0, 0, SHADE, 0, 0, 0, 0, ENVIRONMENT),
	gsDPSetAlphaDither(G_AD_NOISE),
	gsSPTexture(65535, 65535, 0, 0, 1),
	gsDPNoOpTag(69), //used to be set texture
	gsDPSetTile(G_IM_FMT_RGBA, G_IM_SIZ_16b_LOAD_BLOCK, 0, 0, 7, 0, G_TX_WRAP | G_TX_NOMIRROR, 0, 0, G_TX_WRAP | G_TX_NOMIRROR, 0, 0),
	gsDPLoadBlock(7, 0, 0, 255, 512),
	gsDPSetTile(G_IM_FMT_RGBA, G_IM_SIZ_16b, 4, 0, 0, 0, G_TX_WRAP | G_TX_NOMIRROR, 4, 0, G_TX_WRAP | G_TX_NOMIRROR, 4, 0),
	gsDPSetTileSize(0, 0, 0, 60, 60),
	gsSPEndDisplayList(),
};
```

if i didnt add the gsDPNoOpTag command, it would trigger for all materials and that would mess the thing up, so i add gsDPNoOpTag with a param of '69', i check for that in the code and store the displaylist in another variable, and use that.