### PR TITLE
duplicate every instance of a display list

### DIFF
--- a/data/dynos.c.h
+++ b/data/dynos.c.h
@@ -79,6 +79,7 @@ struct GraphNode* dynos_model_load_dl(u32* aId, enum ModelPool aModelPool, u8 aL
 struct GraphNode* dynos_model_store_geo(u32* aId, enum ModelPool aModelPool, void* aAsset, struct GraphNode* aGraphNode);
 struct GraphNode* dynos_model_get_geo(u32 aId);
 void dynos_model_overwrite_slot(u32 srcSlot, u32 dstSlot);
+Gfx *dynos_model_duplicate_displaylist(Gfx* gfx);
 u32 dynos_model_get_id_from_asset(void* aAsset);
 u32 dynos_model_get_id_from_graph_node(struct GraphNode* aGraphNode);
 void dynos_model_clear_pool(enum ModelPool aModelPool);

--- a/data/dynos.cpp.h
+++ b/data/dynos.cpp.h
@@ -972,6 +972,7 @@ struct GraphNode* DynOS_Model_GetGeo(u32 aId);
 u32 DynOS_Model_GetIdFromAsset(void* asset);
 u32 DynOS_Model_GetIdFromGraphNode(struct GraphNode* aNode);
 void DynOS_Model_OverwriteSlot(u32 srcSlot, u32 dstSlot);
+Gfx *DynOS_Model_Duplicate_DisplayList(Gfx* aGfx);
 void DynOS_Model_ClearPool(enum ModelPool aModelPool);
 
 //

--- a/data/dynos_c.cpp
+++ b/data/dynos_c.cpp
@@ -270,6 +270,10 @@ void dynos_model_overwrite_slot(u32 srcSlot, u32 dstSlot) {
     DynOS_Model_OverwriteSlot(srcSlot, dstSlot);
 }
 
+Gfx *dynos_model_duplicate_displaylist(Gfx* gfx) {
+    return DynOS_Model_Duplicate_DisplayList(gfx);
+}
+
 // -- other -- //
 
 void dynos_mod_shutdown(void) {

--- a/src/engine/display_list.c
+++ b/src/engine/display_list.c
@@ -1,0 +1,25 @@
+#include "display_list.h"
+
+// Get the size of a display list by iterating
+// until gsSPEndDisplayList or gsSPBranchList is found
+u32 gfx_get_size(const Gfx* gfx) {
+    for (u16 i = 0;;) {
+        u32 op = (gfx + i)->words.w0 >> 24;
+        u8 cmdSize = 1;
+        switch (op) {
+            case G_DL:
+                if (C0(gfx + i, 16, 1) == G_DL_NOPUSH) { return i + 1; } // For displaylists that end with branches (jumps)
+                break;
+            case G_ENDDL:
+                return i + 1;
+            case G_TEXRECT:
+            case G_TEXRECTFLIP:
+                cmdSize = 3;
+                break;
+            case G_FILLRECT:
+                cmdSize = 2;
+                break;
+        }
+        i += cmdSize;
+    }
+}

--- a/src/engine/display_list.c
+++ b/src/engine/display_list.c
@@ -3,9 +3,9 @@
 // Get the size of a display list by iterating
 // until gsSPEndDisplayList or gsSPBranchList is found
 u32 gfx_get_size(const Gfx* gfx) {
-    for (u16 i = 0;;) {
+    for (u32 i = 0;;) {
         u32 op = (gfx + i)->words.w0 >> 24;
-        u8 cmdSize = 1;
+        u32 cmdSize = 1;
         switch (op) {
             case G_DL:
                 if (C0(gfx + i, 16, 1) == G_DL_NOPUSH) { return i + 1; } // For displaylists that end with branches (jumps)

--- a/src/engine/display_list.h
+++ b/src/engine/display_list.h
@@ -1,0 +1,5 @@
+#include <PR/gbi.h>
+
+#define C0(cmd, pos, width) (((cmd)->words.w0 >> (pos)) & ((1U << width) - 1))
+
+u32 gfx_get_size(const Gfx* gfx);

--- a/src/engine/graph_node.c
+++ b/src/engine/graph_node.c
@@ -235,7 +235,7 @@ init_graph_node_translation_rotation(struct DynamicPool *pool,
         vec3s_copy(graphNode->translation, translation);
         vec3s_copy(graphNode->rotation, rotation);
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
-        graphNode->displayList = displayList;
+        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
     }
 
     return graphNode;
@@ -257,7 +257,7 @@ struct GraphNodeTranslation *init_graph_node_translation(struct DynamicPool *poo
 
         vec3s_copy(graphNode->translation, translation);
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
-        graphNode->displayList = displayList;
+        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
     }
 
     return graphNode;
@@ -278,7 +278,7 @@ struct GraphNodeRotation *init_graph_node_rotation(struct DynamicPool *pool,
         init_scene_graph_node_links(&graphNode->node, GRAPH_NODE_TYPE_ROTATION);
         vec3s_copy(graphNode->rotation, rotation);
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
-        graphNode->displayList = displayList;
+        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
     }
 
     return graphNode;
@@ -299,7 +299,7 @@ struct GraphNodeScale *init_graph_node_scale(struct DynamicPool *pool,
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
         graphNode->scale = scale;
         graphNode->prevScale = scale;
-        graphNode->displayList = displayList;
+        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
     }
 
     return graphNode;
@@ -369,7 +369,7 @@ struct GraphNodeAnimatedPart *init_graph_node_animated_part(struct DynamicPool *
         init_scene_graph_node_links(&graphNode->node, GRAPH_NODE_TYPE_ANIMATED_PART);
         vec3s_copy(graphNode->translation, translation);
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
-        graphNode->displayList = displayList;
+        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
     }
 
     return graphNode;
@@ -390,7 +390,7 @@ struct GraphNodeBillboard *init_graph_node_billboard(struct DynamicPool *pool,
         init_scene_graph_node_links(&graphNode->node, GRAPH_NODE_TYPE_BILLBOARD);
         vec3s_copy(graphNode->translation, translation);
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
-        graphNode->displayList = displayList;
+        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
     }
 
     return graphNode;
@@ -409,7 +409,7 @@ struct GraphNodeDisplayList *init_graph_node_display_list(struct DynamicPool *po
     if (graphNode != NULL) {
         init_scene_graph_node_links(&graphNode->node, GRAPH_NODE_TYPE_DISPLAY_LIST);
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
-        graphNode->displayList = displayList;
+        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
     }
 
     return graphNode;

--- a/src/pc/lua/utils/smlua_gfx_utils.c
+++ b/src/pc/lua/utils/smlua_gfx_utils.c
@@ -3,6 +3,7 @@
 #include "game/rendering_graph_node.h"
 #include "game/skybox.h"
 #include "geo_commands.h"
+#include "engine/display_list.h"
 
 void set_override_fov(f32 fov) {
     gOverrideFOV = fov;
@@ -109,8 +110,6 @@ void set_skybox_color(u8 index, u8 value) {
 
 ///
 
-#define C0(pos, width) ((cmd->words.w0 >> (pos)) & ((1U << width) - 1))
-
 // Assumes the current microcode is Fast3DEX2 Extended (default for pc port)
 void gfx_parse(Gfx* cmd, LuaFunction func) {
     if (!cmd) { return; }
@@ -121,7 +120,7 @@ void gfx_parse(Gfx* cmd, LuaFunction func) {
         u32 op = cmd->words.w0 >> 24;
         switch (op) {
             case G_DL:
-                if (C0(16, 1) == 0) {
+                if (C0(cmd, 16, 1) == G_DL_PUSH) {
                     gfx_parse((Gfx *) cmd->words.w1, func);
                 } else {
                     cmd = (Gfx *) cmd->words.w1;
@@ -160,7 +159,7 @@ Vtx *gfx_get_vtx(Gfx* cmd, u16 offset) {
     if (op != G_VTX) { return NULL; }
     if (cmd->words.w1 == 0) { return NULL; }
 
-    u16 numVertices = C0(12, 8);
+    u16 numVertices = C0(cmd, 12, 8);
     if (offset >= numVertices) { return NULL; }
 
     return &((Vtx *) cmd->words.w1)[offset];


### PR DESCRIPTION
This is to fix a crash caused by writing to read-only memory, if a mod tries to modify a display list from vanilla sm64.
it also makes sure that modifications to display lists are unique to the display list it was applied to
This is attempt 2, now as a pull request.
It now recursively duplicates display lists and vertices referenced by other display lists.
Its now done inside dynos to make sure things are only freed when they need to be.