### PR TITLE
reset permanent model duplicates on session reset

### DIFF
--- a/data/dynos.c.h
+++ b/data/dynos.c.h
@@ -79,7 +79,7 @@ struct GraphNode* dynos_model_load_dl(u32* aId, enum ModelPool aModelPool, u8 aL
 struct GraphNode* dynos_model_store_geo(u32* aId, enum ModelPool aModelPool, void* aAsset, struct GraphNode* aGraphNode);
 struct GraphNode* dynos_model_get_geo(u32 aId);
 void dynos_model_overwrite_slot(u32 srcSlot, u32 dstSlot);
-Gfx *dynos_model_duplicate_displaylist(Gfx* gfx);
+void dynos_model_duplicate_displaylist(Gfx *gfx, Gfx **outGfx);
 u32 dynos_model_get_id_from_asset(void* aAsset);
 u32 dynos_model_get_id_from_graph_node(struct GraphNode* aGraphNode);
 void dynos_model_clear_pool(enum ModelPool aModelPool);

--- a/data/dynos.cpp.h
+++ b/data/dynos.cpp.h
@@ -972,7 +972,7 @@ struct GraphNode* DynOS_Model_GetGeo(u32 aId);
 u32 DynOS_Model_GetIdFromAsset(void* asset);
 u32 DynOS_Model_GetIdFromGraphNode(struct GraphNode* aNode);
 void DynOS_Model_OverwriteSlot(u32 srcSlot, u32 dstSlot);
-Gfx *DynOS_Model_Duplicate_DisplayList(Gfx* aGfx);
+Gfx *DynOS_Model_Duplicate_DisplayList(Gfx *aGfx, Gfx **outGfx);
 void DynOS_Model_ClearPool(enum ModelPool aModelPool);
 
 //

--- a/data/dynos_c.cpp
+++ b/data/dynos_c.cpp
@@ -270,8 +270,8 @@ void dynos_model_overwrite_slot(u32 srcSlot, u32 dstSlot) {
     DynOS_Model_OverwriteSlot(srcSlot, dstSlot);
 }
 
-Gfx *dynos_model_duplicate_displaylist(Gfx* gfx) {
-    return DynOS_Model_Duplicate_DisplayList(gfx);
+void dynos_model_duplicate_displaylist(Gfx* gfx, Gfx **outGfx) {
+    DynOS_Model_Duplicate_DisplayList(gfx, outGfx);
 }
 
 // -- other -- //

--- a/src/engine/graph_node.c
+++ b/src/engine/graph_node.c
@@ -235,7 +235,7 @@ init_graph_node_translation_rotation(struct DynamicPool *pool,
         vec3s_copy(graphNode->translation, translation);
         vec3s_copy(graphNode->rotation, rotation);
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
-        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
+        dynos_model_duplicate_displaylist(displayList, &graphNode->displayList);
     }
 
     return graphNode;
@@ -257,7 +257,7 @@ struct GraphNodeTranslation *init_graph_node_translation(struct DynamicPool *poo
 
         vec3s_copy(graphNode->translation, translation);
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
-        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
+        dynos_model_duplicate_displaylist(displayList, &graphNode->displayList);
     }
 
     return graphNode;
@@ -278,7 +278,7 @@ struct GraphNodeRotation *init_graph_node_rotation(struct DynamicPool *pool,
         init_scene_graph_node_links(&graphNode->node, GRAPH_NODE_TYPE_ROTATION);
         vec3s_copy(graphNode->rotation, rotation);
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
-        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
+        dynos_model_duplicate_displaylist(displayList, &graphNode->displayList);
     }
 
     return graphNode;
@@ -299,7 +299,7 @@ struct GraphNodeScale *init_graph_node_scale(struct DynamicPool *pool,
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
         graphNode->scale = scale;
         graphNode->prevScale = scale;
-        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
+        dynos_model_duplicate_displaylist(displayList, &graphNode->displayList);
     }
 
     return graphNode;
@@ -369,7 +369,7 @@ struct GraphNodeAnimatedPart *init_graph_node_animated_part(struct DynamicPool *
         init_scene_graph_node_links(&graphNode->node, GRAPH_NODE_TYPE_ANIMATED_PART);
         vec3s_copy(graphNode->translation, translation);
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
-        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
+        dynos_model_duplicate_displaylist(displayList, &graphNode->displayList);
     }
 
     return graphNode;
@@ -390,7 +390,7 @@ struct GraphNodeBillboard *init_graph_node_billboard(struct DynamicPool *pool,
         init_scene_graph_node_links(&graphNode->node, GRAPH_NODE_TYPE_BILLBOARD);
         vec3s_copy(graphNode->translation, translation);
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
-        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
+        dynos_model_duplicate_displaylist(displayList, &graphNode->displayList);
     }
 
     return graphNode;
@@ -409,7 +409,7 @@ struct GraphNodeDisplayList *init_graph_node_display_list(struct DynamicPool *po
     if (graphNode != NULL) {
         init_scene_graph_node_links(&graphNode->node, GRAPH_NODE_TYPE_DISPLAY_LIST);
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
-        graphNode->displayList = dynos_model_duplicate_displaylist(displayList);
+        dynos_model_duplicate_displaylist(displayList, &graphNode->displayList);
     }
 
     return graphNode;

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -665,9 +665,9 @@ void network_shutdown(bool sendLeaving, bool exiting, bool popup, bool reconnect
         gNetworkType = NT_NONE;
     }
 
-    dynos_model_clear_pool(MODEL_POOL_SESSION);
-
     if (exiting) { return; }
+
+    dynos_model_clear_pool(MODEL_POOL_SESSION);
 
     // reset other stuff
     extern u8* gOverrideEeprom;


### PR DESCRIPTION
fixes this
![image](https://github.com/user-attachments/assets/282f7360-d4c6-4645-9e7b-5216a8937e7f)

it feels like I implemented this in a hacky way so please do let me know if you can see a cleaner way.

The issue is that a mod can edit the display list of a permanent model, and it never gets reset when the session ends.
To fix this, we store a pointer to all the duplicates of a permanent model, and just copy the memory from the original display list, and swap the pointers to child display lists or vertices.