### PR TITLE
Fix apply_platform_displacement

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -5361,6 +5361,13 @@ function mario_update_wall(m, wcd)
     -- ...
 end
 
+--- @param o Object
+--- @return MarioState
+--- Gets the MarioState corresponding to the provided object if the object is a Mario object
+function get_mario_state_from_object(o)
+    -- ...
+end
+
 --- @param m MarioState
 --- @param frame1 integer
 --- @param frame2 integer
@@ -8734,10 +8741,10 @@ function set_object_respawn_info_bits(obj, bits)
     -- ...
 end
 
---- @param playerIndex integer
+--- @param o Object
 --- @param platform Object
---- Apply one frame of platform rotation to Mario (player index) or an object (-1) using the given platform
-function apply_platform_displacement(playerIndex, platform)
+--- Apply one frame of platform rotation to the object using the given platform
+function apply_platform_displacement(o, platform)
     -- ...
 end
 

--- a/docs/lua/functions-4.md
+++ b/docs/lua/functions-4.md
@@ -1253,6 +1253,29 @@ Updates Mario's wall information based on wall collisions (`WallCollisionData`).
 
 <br />
 
+## [get_mario_state_from_object](#get_mario_state_from_object)
+
+### Description
+Gets the MarioState corresponding to the provided object if the object is a Mario object
+
+### Lua Example
+`local MarioStateValue = get_mario_state_from_object(o)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| o | [Object](structs.md#Object) |
+
+### Returns
+[MarioState](structs.md#MarioState)
+
+### C Prototype
+`struct MarioState *get_mario_state_from_object(struct Object *o);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ---
 # functions from mario_actions_airborne.c
 

--- a/docs/lua/functions-5.md
+++ b/docs/lua/functions-5.md
@@ -5548,22 +5548,22 @@ Runs an OR operator on the `obj`'s respawn info with `bits` << 8. If `bits` is 0
 ## [apply_platform_displacement](#apply_platform_displacement)
 
 ### Description
-Apply one frame of platform rotation to Mario (player index) or an object (-1) using the given platform
+Apply one frame of platform rotation to the object using the given platform
 
 ### Lua Example
-`apply_platform_displacement(playerIndex, platform)`
+`apply_platform_displacement(o, platform)`
 
 ### Parameters
 | Field | Type |
 | ----- | ---- |
-| playerIndex | `integer` |
+| o | [Object](structs.md#Object) |
 | platform | [Object](structs.md#Object) |
 
 ### Returns
 - None
 
 ### C Prototype
-`void apply_platform_displacement(u32 playerIndex, struct Object *platform);`
+`void apply_platform_displacement(struct Object *o, struct Object *platform);`
 
 [:arrow_up_small:](#)
 

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -1023,6 +1023,7 @@
    - [init_single_mario](functions-4.md#init_single_mario)
    - [set_mario_particle_flags](functions-4.md#set_mario_particle_flags)
    - [mario_update_wall](functions-4.md#mario_update_wall)
+   - [get_mario_state_from_object](functions-4.md#get_mario_state_from_object)
 
 <br />
 

--- a/src/game/behaviors/bowser.inc.c
+++ b/src/game/behaviors/bowser.inc.c
@@ -1206,7 +1206,7 @@ void bowser_free_update(void) {
     struct Object *platform;
     UNUSED f32 floorHeight;
     if ((platform = o->platform) != NULL)
-        apply_platform_displacement((u32)-1, platform);
+        apply_platform_displacement(o, platform);
     o->oBowserUnk10E = 0;
 
     cur_obj_update_floor_and_walls();

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -2392,3 +2392,14 @@ void mario_update_wall(struct MarioState* m, struct WallCollisionData* wcd) {
                   m->wall->normal.z);
     }
 }
+
+struct MarioState *get_mario_state_from_object(struct Object *o) {
+    if (!o) { return NULL; }
+    for (s32 i = 0; i != MAX_PLAYERS; ++i) {
+        struct MarioState *m = &gMarioStates[i];
+        if (m->marioObj == o) {
+            return m;
+        }
+    }
+    return NULL;
+}

--- a/src/game/mario.h
+++ b/src/game/mario.h
@@ -300,4 +300,9 @@ Updates Mario's wall information based on wall collisions (`WallCollisionData`).
 |descriptionEnd| */
 void mario_update_wall(struct MarioState* m, struct WallCollisionData* wcd);
 
+/* |description|
+Gets the MarioState corresponding to the provided object if the object is a Mario object
+|descriptionEnd| */
+struct MarioState *get_mario_state_from_object(struct Object *o);
+
 #endif // MARIO_H

--- a/src/game/platform_displacement.h
+++ b/src/game/platform_displacement.h
@@ -9,8 +9,8 @@ void update_mario_platform(void);
 void get_mario_pos(struct MarioState* m, f32 *x, f32 *y, f32 *z);
 void set_mario_pos(struct MarioState* m, f32 x, f32 y, f32 z);
 
-/* |description|Apply one frame of platform rotation to Mario (player index) or an object (-1) using the given platform|descriptionEnd| */
-void apply_platform_displacement(u32 playerIndex, struct Object *platform);
+/* |description|Apply one frame of platform rotation to the object using the given platform|descriptionEnd| */
+void apply_platform_displacement(struct Object *o, struct Object *platform);
 
 void apply_mario_platform_displacement(void);
 #ifndef VERSION_JP

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -16549,6 +16549,24 @@ int smlua_func_mario_update_wall(lua_State* L) {
     return 1;
 }
 
+int smlua_func_get_mario_state_from_object(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 1) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "get_mario_state_from_object", 1, top);
+        return 0;
+    }
+
+    if (lua_isnil(L, 1)) { return 0; }
+    struct Object* o = (struct Object*)smlua_to_cobject(L, 1, LOT_OBJECT);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "get_mario_state_from_object"); return 0; }
+
+    smlua_push_object(L, LOT_MARIOSTATE, get_mario_state_from_object(o), NULL);
+
+    return 1;
+}
+
   //////////////////////////////
  // mario_actions_airborne.c //
 //////////////////////////////
@@ -27532,13 +27550,14 @@ int smlua_func_apply_platform_displacement(lua_State* L) {
         return 0;
     }
 
-    u32 playerIndex = smlua_to_integer(L, 1);
+    if (lua_isnil(L, 1)) { return 0; }
+    struct Object* o = (struct Object*)smlua_to_cobject(L, 1, LOT_OBJECT);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "apply_platform_displacement"); return 0; }
     if (lua_isnil(L, 2)) { return 0; }
     struct Object* platform = (struct Object*)smlua_to_cobject(L, 2, LOT_OBJECT);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "apply_platform_displacement"); return 0; }
 
-    apply_platform_displacement(playerIndex, platform);
+    apply_platform_displacement(o, platform);
 
     return 1;
 }
@@ -34877,6 +34896,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "init_single_mario", smlua_func_init_single_mario);
     smlua_bind_function(L, "set_mario_particle_flags", smlua_func_set_mario_particle_flags);
     smlua_bind_function(L, "mario_update_wall", smlua_func_mario_update_wall);
+    smlua_bind_function(L, "get_mario_state_from_object", smlua_func_get_mario_state_from_object);
 
     // mario_actions_airborne.c
     smlua_bind_function(L, "play_flip_sounds", smlua_func_play_flip_sounds);


### PR DESCRIPTION
Fix buffer overflow and out-of-bounds vulnerabilities with apply_platform_displacement
Takes an object instead of an index as an input to not limit its use to MarioStates and gCurrentObject
Also adds `get_mario_state_from_object`
