### PR TITLE
Fix obj_get_model_id_extended returning wrong model ids

### DIFF
--- a/src/pc/lua/utils/smlua_model_utils.c
+++ b/src/pc/lua/utils/smlua_model_utils.c
@@ -504,12 +504,22 @@ u16 smlua_model_util_load(enum ModelExtendedId extId) {
     return (u16)id;
 }
 
+static void smlua_model_util_unregister_model_id(u32 id, struct ModelUtilsInfo *models, u32 count) {
+    for (u32 i = 0; i < count; i++) {
+        struct ModelUtilsInfo *m = &models[i];
+        if (m->loadedId == id) {
+            m->loadedId = UNLOADED_ID;
+        }
+    }
+}
+
 // Links the regular model id created by DynOS to our models list
 void smlua_model_util_register_model_id(u32 id, const void *asset) {
     if (id < VANILLA_ID_END) {
         for (u32 i = 0; i < E_MODEL_MAX; i++) {
             struct ModelUtilsInfo* m = &sModels[i];
             if (m->asset == asset) {
+                smlua_model_util_unregister_model_id(id, sModels, E_MODEL_MAX);
                 m->loadedId = id;
                 return;
             }
@@ -518,6 +528,7 @@ void smlua_model_util_register_model_id(u32 id, const void *asset) {
         for (u32 i = 0; i < sCustomModelsCount; i++) {
             struct ModelUtilsInfo* m = &sCustomModels[i];
             if (m->asset == asset) {
+                smlua_model_util_unregister_model_id(id, sCustomModels, sCustomModelsCount);
                 m->loadedId = id;
                 return;
             }


### PR DESCRIPTION
`obj_get_model_id_extended` can sometimes return a wrong extended model id, depending on what was loaded before.
For example, if you set the main menu to LLL, then enter CCM, all penguin objects will incorrectly return `E_MODEL_BULLY_BOSS` (instead of `E_MODEL_PENGUIN`)

The cause is not clear, but it seems that if two loaded vanilla models have the same vanilla id (`MODEL_PENGUIN` and `MODEL_BULLY_BOSS` have the same id of 0x57), the lowest `E_MODEL_` value is returned, regardless of the actual model (`E_MODEL_BULLY_BOSS` is 81, `E_MODEL_PENGUIN` is 103).

Not a real fix. If anyone has some knowledge about how the model loaded ids work, please take a look at this issue.
