### PR TITLE
Change misleading GraphNodeSwitchCase field label "numCases"

### DIFF
--- a/actors/number/geo.inc.c
+++ b/actors/number/geo.inc.c
@@ -33,7 +33,7 @@ Gfx *geo_num3_switch(s32 callContext, struct GraphNode *node, UNUSED void *conte
         s32 number = ((struct Object *) gCurGraphNodeObject)->oBehParams2ndByte;
         struct GraphNodeSwitchCase *switchCase = (struct GraphNodeSwitchCase *) node;
         s32 numMin, numMax, numDiv;
-        switch (switchCase->numCases) {
+        switch (switchCase->parameter) {
             case 0: numMin =   0; numMax =   9; numDiv =   1; break;
             case 1: numMin =  10; numMax =  99; numDiv =  10; break;
             case 2: numMin =  10; numMax =  99; numDiv =   1; break;

--- a/autogen/convert_structs.py
+++ b/autogen/convert_structs.py
@@ -128,7 +128,7 @@ override_field_immutable = {
     "GraphNodeObject": [ "angle", "animInfo", "cameraToObject", "node", "pos", "prevAngle", "prevPos", "prevScale", "prevScaleTimestamp", "prevShadowPos", "prevShadowPosTimestamp", "prevThrowMatrix", "prevThrowMatrixTimestamp", "prevTimestamp", "scale", "shadowPos", "sharedChild", "skipInterpolationTimestamp", "throwMatrixPrev", "unk4C", ],
     "GraphNodeObjectParent": [ "sharedChild" ],
     "GraphNodePerspective": [ "unused" ],
-    "GraphNodeSwitchCase": [ "fnNode", "numCases", "unused" ],
+    "GraphNodeSwitchCase": [ "fnNode", "unused" ],
     "ObjectWarpNode": [ "next "],
     "Animation": [ "length" ],
     "AnimationTable": [ "count" ],

--- a/autogen/lua_definitions/structs.lua
+++ b/autogen/lua_definitions/structs.lua
@@ -974,7 +974,7 @@
 
 --- @class GraphNodeSwitchCase
 --- @field public fnNode FnGraphNode
---- @field public numCases integer
+--- @field public parameter integer
 --- @field public selectedCase integer
 --- @field public unused integer
 

--- a/docs/lua/structs.md
+++ b/docs/lua/structs.md
@@ -1489,7 +1489,7 @@
 | Field | Type | Access |
 | ----- | ---- | ------ |
 | fnNode | [FnGraphNode](structs.md#FnGraphNode) | read-only |
-| numCases | `integer` | read-only |
+| parameter | `integer` |  |
 | selectedCase | `integer` |  |
 | unused | `integer` | read-only |
 

--- a/include/geo_commands.h
+++ b/include/geo_commands.h
@@ -154,7 +154,7 @@ enum SkyBackgroundParams {
 /**
  * 0x0E: Create switch-case scene graph node
  *   0x01: unused
- *   0x02: s16 numCases
+ *   0x02: s16 parameter
  *   0x04: GraphNodeFunc caseSelectorFunc
  */
 #define GEO_SWITCH_CASE(count, function) \

--- a/src/engine/geo_layout.c
+++ b/src/engine/geo_layout.c
@@ -342,7 +342,7 @@ void geo_layout_cmd_node_switch_case(void) {
 
     graphNode =
         init_graph_node_switch_case(gGraphNodePool, NULL,
-                                    cur_geo_cmd_s16(0x02), // case which is initially selected
+                                    cur_geo_cmd_s16(0x02), // parameter used by switch func
                                     0,
                                     (GraphNodeFunc) cur_geo_cmd_ptr(0x04), // case update function
                                     0);
@@ -800,7 +800,7 @@ void geo_layout_cmd_node_switch_case_ext(void) {
 
     graphNode = init_graph_node_switch_case(
         gGraphNodePool, NULL,
-        cur_geo_cmd_s16(0x02), // num cases
+        cur_geo_cmd_s16(0x02), // parameter used by switch func
         0,
         (GraphNodeFunc) geo_process_lua_function,
         0

--- a/src/engine/graph_node.c
+++ b/src/engine/graph_node.c
@@ -169,7 +169,7 @@ struct GraphNodeLevelOfDetail *init_graph_node_render_range(struct DynamicPool *
  */
 struct GraphNodeSwitchCase *init_graph_node_switch_case(struct DynamicPool *pool,
                                                         struct GraphNodeSwitchCase *graphNode,
-                                                        s16 numCases, s16 selectedCase,
+                                                        s16 parameter, s16 selectedCase,
                                                         GraphNodeFunc nodeFunc, s32 unused) {
     if (pool != NULL) {
         graphNode = dynamic_pool_alloc(pool, sizeof(struct GraphNodeSwitchCase));
@@ -177,7 +177,7 @@ struct GraphNodeSwitchCase *init_graph_node_switch_case(struct DynamicPool *pool
 
     if (graphNode != NULL) {
         init_scene_graph_node_links(&graphNode->fnNode.node, GRAPH_NODE_TYPE_SWITCH_CASE);
-        graphNode->numCases = numCases;
+        graphNode->parameter = parameter;
         graphNode->selectedCase = selectedCase;
         graphNode->fnNode.func = nodeFunc;
         graphNode->unused = unused;

--- a/src/engine/graph_node.h
+++ b/src/engine/graph_node.h
@@ -175,7 +175,7 @@ struct GraphNodeSwitchCase
 {
     /*0x00*/ struct FnGraphNode fnNode;
     /*0x18*/ s32 unused;
-    /*0x1C*/ s16 numCases;
+    /*0x1C*/ s16 parameter;
     /*0x1E*/ s16 selectedCase;
 };
 
@@ -397,7 +397,7 @@ struct GraphNodeMasterList *init_graph_node_master_list(struct DynamicPool *pool
 struct GraphNodeLevelOfDetail *init_graph_node_render_range(struct DynamicPool *pool, struct GraphNodeLevelOfDetail *graphNode,
                                                             s16 minDistance, s16 maxDistance);
 struct GraphNodeSwitchCase *init_graph_node_switch_case(struct DynamicPool *pool, struct GraphNodeSwitchCase *graphNode,
-                                                        s16 numCases, s16 selectedCase, GraphNodeFunc nodeFunc, s32 unused);
+                                                        s16 parameter, s16 selectedCase, GraphNodeFunc nodeFunc, s32 unused);
 struct GraphNodeCamera *init_graph_node_camera(struct DynamicPool *pool, struct GraphNodeCamera *graphNode,
                                                f32 *pos, f32 *focus, GraphNodeFunc func, s32 mode);
 struct GraphNodeTranslationRotation *init_graph_node_translation_rotation(struct DynamicPool *pool, struct GraphNodeTranslationRotation *graphNode,

--- a/src/game/mario_misc.c
+++ b/src/game/mario_misc.c
@@ -401,7 +401,7 @@ Gfx* geo_switch_mario_eyes(s32 callContext, struct GraphNode* node, UNUSED Mat4*
 
     if (callContext == GEO_CONTEXT_RENDER) {
         if (bodyState->eyeState == 0) {
-            blinkFrame = ((switchCase->numCases * 32 + (gAreaUpdateCounter + geo_get_processing_object_index() * 32)) >> 1) & 0x1F;
+            blinkFrame = ((switchCase->parameter * 32 + (gAreaUpdateCounter + geo_get_processing_object_index() * 32)) >> 1) & 0x1F;
             if (blinkFrame < 7) {
                 switchCase->selectedCase = gMarioBlinkAnimation[blinkFrame];
             }
@@ -511,7 +511,7 @@ Gfx* geo_switch_mario_hand(s32 callContext, struct GraphNode* node, UNUSED Mat4*
             switchCase->selectedCase = ((bodyState->action & ACT_FLAG_SWIMMING_OR_FLYING) != 0);
         }
         else {
-            if (switchCase->numCases == 0) {
+            if (switchCase->parameter == 0) {
                 switchCase->selectedCase =
                     (bodyState->handState < 5) ? bodyState->handState : MARIO_HAND_OPEN;
             }

--- a/src/game/object_helpers.c
+++ b/src/game/object_helpers.c
@@ -172,9 +172,9 @@ Gfx *geo_switch_anim_state(s32 callContext, struct GraphNode *node) {
             obj = gCurGraphNodeHeldObject->objNode;
         }
 
-        // if the case is greater than the number of cases, set to 0 to avoid overflowing
+        // if the case is greater than the number of anim states, set to 0 to avoid overflowing
         // the switch.
-        if (obj->oAnimState >= switchCase->numCases) {
+        if (obj->oAnimState >= switchCase->parameter) {
             obj->oAnimState = 0;
         }
 

--- a/src/pc/lua/smlua_cobject_autogen.c
+++ b/src/pc/lua/smlua_cobject_autogen.c
@@ -1229,7 +1229,7 @@ static struct LuaObjectField sGraphNodeStartFields[LUA_GRAPH_NODE_START_FIELD_CO
 #define LUA_GRAPH_NODE_SWITCH_CASE_FIELD_COUNT 4
 static struct LuaObjectField sGraphNodeSwitchCaseFields[LUA_GRAPH_NODE_SWITCH_CASE_FIELD_COUNT] = {
     { "fnNode",       LVT_COBJECT, offsetof(struct GraphNodeSwitchCase, fnNode),       true,  LOT_FNGRAPHNODE, 1, sizeof(struct FnGraphNode) },
-    { "numCases",     LVT_S16,     offsetof(struct GraphNodeSwitchCase, numCases),     true,  LOT_NONE,        1, sizeof(s16)                },
+    { "parameter",    LVT_S16,     offsetof(struct GraphNodeSwitchCase, parameter),    false, LOT_NONE,        1, sizeof(s16)                },
     { "selectedCase", LVT_S16,     offsetof(struct GraphNodeSwitchCase, selectedCase), false, LOT_NONE,        1, sizeof(s16)                },
     { "unused",       LVT_S32,     offsetof(struct GraphNodeSwitchCase, unused),       true,  LOT_NONE,        1, sizeof(s32)                },
 };


### PR DESCRIPTION
tl;dr the `numCases` field is in fact not actually the number of cases nor is it supposed to be

> This is an absolutely game destroying bug. Super Mario 64 Coop Deluxe is unplayable as long as this remains in the source code on GitHub.com. A field of the GraphNodeSwitchCase structure has **_incorrectly_** been named as `numCases`. Personally, this has thrown off my spiritual energy completely and I have lost all will to continue working on Super Mario 64 Coop Deluxe Super Mario Lua Scripting mods. Until this is fixed, I cannot continue to pursue this career.

Should be fine to merge because this field is both used incorrectly by Fast64 and labelled completely wrong in all versions of decomp so we can safely assume zero mods use it right now.

Pretty sure there is only one instance in the game where this field was actually used for "number of cases" and from looking at the function it was more likely supposed to be "number of anim states" (the relevant comment has been adjusted). 

- gave it a more ambiguous (but fitting) name because it can be used for basically anything
  - i actually took the name from another graph node with (probably) similar functionality
- made it mutable for modders

Will consider a follow up PR to Fast64 (they think its "default case" because of [yet another misleading comment about the same field](https://github.com/kermeow/sm64coopdx/blob/7b3d51d32b140ff6a71ec12a708893c577f7e488/src/engine/geo_layout.c#L345)) if I'm not lazy or nobody else wants to...

**This PR does not introduce an actual numCases functionality, it only amends a mistake in naming passed down from decomp.**

_looking at how it's used, this probably should've been spotted by decomp_