### PR TITLE
Fix dpad logic in menus

### DIFF
--- a/src/pc/djui/djui_cursor.c
+++ b/src/pc/djui/djui_cursor.c
@@ -85,8 +85,8 @@ static void djui_cursor_move_check(s8 xDir, s8 yDir, struct DjuiBase** pick, str
             if (*pick == NULL) {
                 *pick = base;
             } else {
-                f32 pickDist = djui_cursor_base_distance(*pick, xDir, yDir ? 1.0f : 2.0f);
-                f32 baseDist = djui_cursor_base_distance(base,  xDir, yDir ? 1.0f : 2.0f);
+                f32 pickDist = djui_cursor_base_distance(*pick, xDir ? 1.0f : 1.2f, yDir ? 1.0f : 2.0f);
+                f32 baseDist = djui_cursor_base_distance(base,  xDir ? 1.0f : 1.2f, yDir ? 1.0f : 2.0f);
                 if (baseDist < pickDist) { *pick = base; }
             }
         }

--- a/src/pc/djui/djui_cursor.c
+++ b/src/pc/djui/djui_cursor.c
@@ -85,8 +85,8 @@ static void djui_cursor_move_check(s8 xDir, s8 yDir, struct DjuiBase** pick, str
             if (*pick == NULL) {
                 *pick = base;
             } else {
-                f32 pickDist = djui_cursor_base_distance(*pick, xDir ? 1.0f : 2.0f, yDir ? 1.0f : 2.0f);
-                f32 baseDist = djui_cursor_base_distance(base,  xDir ? 1.0f : 2.0f, yDir ? 1.0f : 2.0f);
+                f32 pickDist = djui_cursor_base_distance(*pick, xDir, yDir ? 1.0f : 2.0f);
+                f32 baseDist = djui_cursor_base_distance(base,  xDir, yDir ? 1.0f : 2.0f);
                 if (baseDist < pickDist) { *pick = base; }
             }
         }

--- a/src/pc/djui/djui_paginated.c
+++ b/src/pc/djui/djui_paginated.c
@@ -148,7 +148,7 @@ struct DjuiPaginated* djui_paginated_create(struct DjuiBase* parent, u32 showCou
 
     djui_base_init(parent, base, djui_paginated_render, djui_paginated_destroy);
     djui_base_set_size_type(base, DJUI_SVT_RELATIVE, DJUI_SVT_ABSOLUTE);
-    djui_base_set_size(base, 1.0, bodyHeight);
+    djui_base_set_size(base, 1.0f, bodyHeight);
     djui_base_set_color(base, 0, 64, 0, 0);
     djui_base_set_alignment(base, DJUI_HALIGN_CENTER, DJUI_VALIGN_TOP);
 


### PR DESCRIPTION
Without this change, there is no way to get the cursor onto the ">" button in the public lobbies pagination without using a mouse, because the dpad/arrowkey logic skips over it strangely. Another alternative solution could be that the rules button and the back/reset buttons swap places.