### PR TITLE
Expose utf8 library

### DIFF
--- a/src/pc/lua/smlua.c
+++ b/src/pc/lua/smlua.c
@@ -297,7 +297,7 @@ void smlua_init(void) {
     luaL_requiref(L, "string", luaopen_string, 1);
     luaL_requiref(L, "table", luaopen_table, 1);
     luaL_requiref(L, "coroutine", luaopen_coroutine, 1);
-    // luaopen_utf8(L);
+    luaL_requiref(L, "utf8", luaopen_utf8, 1);
 
     smlua_bind_hooks();
     smlua_bind_cobject();


### PR DESCRIPTION
Exposes the built-in utf8 library.

```lua
local str = "áéíóú"

-- without utf8 library
for p, c in str:gmatch("()([%z\1-\127\194-\244][\128-\191]*)") do
  print(string.format("Byte position: %d, Character: %s", p, c))
end

print()

-- with utf8 library (better)
for p, c in utf8.codes(str) do
    local ch = utf8.char(c)
    print(string.format("Byte position: %d, Character: %s", p, ch))
end
```