### PR TITLE
Fix low damage jump kicks

### DIFF
--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -1507,7 +1507,7 @@ u32 interact_player_pvp(struct MarioState* attacker, struct MarioState* victim) 
     // see if it was an attack
     u32 interaction = determine_interaction(attacker, cVictim->marioObj);
     // Specfically override jump kicks to prevent low damage and low knockback kicks
-    if (interaction & INT_HIT_FROM_BELOW && attacker->action == ACT_JUMP_KICK) { interaction = INT_KICK; }
+    if (attacker->action == ACT_JUMP_KICK) { interaction = INT_KICK; }
     // Allow rollouts to attack
     else if (PLAYER_IN_ROLLOUT_FLIP(attacker)) { interaction = INT_HIT_FROM_BELOW; }
     if (!(interaction & INT_ANY_ATTACK) || (interaction & INT_HIT_FROM_ABOVE) || !passes_pvp_interaction_checks(attacker, cVictim)) {


### PR DESCRIPTION
When speedkicking into a player with high enough speed, `INT_FAST_ATTACK_OR_SHELL` is what's returned and my previous fix did not account for that.