### PR TITLE
replace "auto" djui scale functionality with 4x native resolution

### DIFF
--- a/src/pc/djui/djui_gfx.c
+++ b/src/pc/djui/djui_gfx.c
@@ -65,13 +65,7 @@ f32 djui_gfx_get_scale(void) {
     if (configDjuiScale == 0) { // auto
         u32 windowWidth, windowHeight;
         gfx_get_dimensions(&windowWidth, &windowHeight);
-        if (windowHeight < 768) {
-            return 0.5f;
-        } else if (windowHeight < 1440) {
-            return 1.0f;
-        } else {
-            return 1.5f;
-        }
+        return ((f32)windowHeight / (f32)SCREEN_HEIGHT) / 4.0f;
     } else {
         switch (configDjuiScale) {
             case 1:  return 0.5f;


### PR DESCRIPTION
with the djui scale set to "auto", all menu graphics will scale to the ingame resolution rather than being locked to the system
this way the menu can look consistent across all resolutions and window sizes

preview with a medium sized window:
![image](https://github.com/user-attachments/assets/4d7614d4-61cb-49fb-a6ea-d3466b235301)

preview with an extremely small window:
![image](https://github.com/user-attachments/assets/acaaa33a-52ca-4643-8c0e-60424f69b45f)