### PR TITLE
Add get_lua_function_id(stack_depth)

### DIFF
--- a/autogen/convert_functions.py
+++ b/autogen/convert_functions.py
@@ -222,6 +222,7 @@ manual_index_documentation = """
    - [cast_graph_node](#cast_graph_node)
    - [get_uncolored_string](#get_uncolored_string)
    - [gfx_set_command](#gfx_set_command)
+   - [get_lua_function_id](#get_lua_function_id)
 
 <br />
 
@@ -707,6 +708,47 @@ gfx_set_command(gfx, "gsDPSetEnvColor(%i, %i, %i, %i)", r, g, b, a)
 
 ### Returns
 - None
+
+### C Prototype
+N/A
+
+[:arrow_up_small:](#)
+
+<br />
+
+## [get_lua_function_id](#get_lua_function_id)
+
+Returns a number that uniquely identifies a lua function that called `get_lua_function_id(stack_depth)`, or returns 0 on failure.
+
+A `stack_depth` of 0 returns an identifer for the function that called `get_lua_function_id(0)`.
+
+A `stack_depth` of 1 returns an identifier for the function that called the function that called `get_lua_function_id(1)`. etc.
+
+### Lua Example
+```lua
+function foo()
+    print('foo: ' .. get_lua_function_id(0))
+end
+
+function bar()
+    print('bar: ' .. get_lua_function_id(0))
+end
+
+local a = foo()
+local b = bar()
+
+if a == foo() and b == bar() then
+    print('it works!')
+end
+```
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| stack_depth | `number` |
+
+### Returns
+- `number`
 
 ### C Prototype
 N/A

--- a/autogen/lua_definitions/manual.lua
+++ b/autogen/lua_definitions/manual.lua
@@ -390,6 +390,16 @@ function log_to_console(message, level)
     -- ...
 end
 
+--- @param stack_depth integer The stack depth of the function to produce an identifier for
+--- @return integer
+--- Returns a unique identifier for a function, or 0 on failure.
+--- A stack_depth of 0 will return an identifer for the function that called get_lua_function_id(0).
+--- A stack_depth of 1st will return an identifer for the function that called the function that called get_lua_function_id(1).
+--- etc.
+function get_lua_function_id(stack_depth)
+    -- ...
+end
+
 --- @param index integer The index of the scroll target, should match up with the behavior param of `RM_Scroll_Texture` or `editor_Scroll_Texture`
 --- @param name string The name of the vertex buffer that should be used while scrolling the texture
 --- Registers a vertex buffer to be used for a scrolling texture. Should be used with `RM_Scroll_Texture` or `editor_Scroll_Texture`

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -25,6 +25,7 @@
    - [cast_graph_node](#cast_graph_node)
    - [get_uncolored_string](#get_uncolored_string)
    - [gfx_set_command](#gfx_set_command)
+   - [get_lua_function_id](#get_lua_function_id)
 
 <br />
 
@@ -2607,6 +2608,47 @@ gfx_set_command(gfx, "gsDPSetEnvColor(%i, %i, %i, %i)", r, g, b, a)
 
 ### Returns
 - None
+
+### C Prototype
+N/A
+
+[:arrow_up_small:](#)
+
+<br />
+
+## [get_lua_function_id](#get_lua_function_id)
+
+Returns a number that uniquely identifies a lua function that called `get_lua_function_id(stack_depth)`, or returns 0 on failure.
+
+A `stack_depth` of 0 returns an identifer for the function that called `get_lua_function_id(0)`.
+
+A `stack_depth` of 1 returns an identifier for the function that called the function that called `get_lua_function_id(1)`. etc.
+
+### Lua Example
+```lua
+function foo()
+    print('foo: ' .. get_lua_function_id(0))
+end
+
+function bar()
+    print('bar: ' .. get_lua_function_id(0))
+end
+
+local a = foo()
+local b = bar()
+
+if a == foo() and b == bar() then
+    print('it works!')
+end
+```
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| stack_depth | `number` |
+
+### Returns
+- `number`
 
 ### C Prototype
 N/A

--- a/src/pc/lua/smlua_functions.c
+++ b/src/pc/lua/smlua_functions.c
@@ -154,6 +154,27 @@ int smlua_func_table_deepcopy(lua_State *L) {
  // misc //
 //////////
 
+static int smlua_func_get_lua_function_id(lua_State *L) {
+    // get the depth
+    lua_Integer depth = luaL_checkinteger(L, 1);
+    if (depth < 0) { depth = 0; }
+
+    // attempt to get the stack frame and function
+    lua_Debug ar;
+    if (lua_getstack(L, (int)(depth + 1), &ar) == 0 || lua_getinfo (L, "f", &ar) == 0) {
+        lua_pushinteger(L, 0);
+        return 1;
+    }
+
+    // target function is on top, pop it
+    void *func_ptr = (void*)lua_topointer(L, -1);
+    lua_pop(L, 1);
+
+    // return the value as an integer
+    lua_pushinteger(L, (lua_Integer)(uintptr_t)func_ptr);
+    return 1;
+}
+
 int smlua_func_init_mario_after_warp(lua_State* L) {
     if (network_player_connected_count() >= 2) {
         LOG_LUA_LINE("init_mario_after_warp() can only be used in singleplayer");
@@ -1012,6 +1033,7 @@ void smlua_bind_functions(void) {
     // misc
     smlua_bind_function(L, "table_copy", smlua_func_table_copy);
     smlua_bind_function(L, "table_deepcopy", smlua_func_table_deepcopy);
+    smlua_bind_function(L, "get_lua_function_id", smlua_func_get_lua_function_id);
     smlua_bind_function(L, "init_mario_after_warp", smlua_func_init_mario_after_warp);
     smlua_bind_function(L, "initiate_warp", smlua_func_initiate_warp);
     smlua_bind_function(L, "network_init_object", smlua_func_network_init_object);


### PR DESCRIPTION
Returns a number that uniquely identifies a lua function that called get_lua_function_id(stack_depth), or returns 0 on failure.

A stack_depth of 0 returns an identifer for the function that called get_lua_function_id(0).

A stack_depth of 1 returns an identifier for the function that called the function that called `get_lua_function_id(1)`. etc.