### PR TITLE
type checking for dynos gfx symbol parsing

### DIFF
--- a/data/dynos_bin_gfx.cpp
+++ b/data/dynos_bin_gfx.cpp
@@ -9,6 +9,27 @@ extern "C" {
 #include "include/macros.h"
 }
 
+#define GFX_PARAM_TYPE_INT 'i'
+#define GFX_PARAM_TYPE_STR 's'
+#define GFX_PARAM_TYPE_PTR 'p'
+#define GFX_PARAM_TYPE_VTX 'v'
+#define GFX_PARAM_TYPE_TEX 't'
+#define GFX_PARAM_TYPE_GFX 'g'
+
+#define GFX_PARAM_TYPE_IS_POINTER(paramType) ( \
+    paramType == GFX_PARAM_TYPE_PTR || \
+    paramType == GFX_PARAM_TYPE_VTX || \
+    paramType == GFX_PARAM_TYPE_TEX || \
+    paramType == GFX_PARAM_TYPE_GFX    \
+)
+
+#define GFX_PARAM_TYPE_IS_INT_OR_CONSTANT(paramType) ( \
+    paramType == GFX_PARAM_TYPE_INT || \
+    paramType == GFX_PARAM_TYPE_STR    \
+)
+
+typedef char GfxParamType;
+
 static std::map<std::string, std::pair<Gfx *, u32>> sGfxCommandCache;
 static char *sGfxCommandErrorMsg = NULL;
 static u32 sGfxCommandErrorSize = 0;
@@ -426,16 +447,14 @@ s64 DynOS_Gfx_ParseGfxConstants(const String& _Arg, bool* found) {
     return 0;
 }
 
-static s64 ParseGfxSymbolArg(GfxData* aGfxData, DataNode<Gfx>* aNode, u64* pTokenIndex, const char *aPrefix, const char type) {
+static s64 ParseGfxSymbolArg(GfxData* aGfxData, DataNode<Gfx>* aNode, u64* pTokenIndex, const char *aPrefix, const GfxParamType aParamType) {
     assert(aPrefix != NULL);
     if (pTokenIndex != NULL) { CHECK_TOKEN_INDEX(*pTokenIndex, 0); }
     String _Token = (pTokenIndex != NULL ? aNode->mTokens[(*pTokenIndex)++] : "");
     String _Arg("%s%s", aPrefix, _Token.begin());
-    bool isPtrType = (type == 'p' || type == 't' || type == 'g' || type == 'v');
-    bool isIntOrConstant = (type == 's' || type == 'i'); // Allow strings as constants for integer parameters
 
     // Integers
-    if (isIntOrConstant) {
+    if (GFX_PARAM_TYPE_IS_INT_OR_CONSTANT(aParamType)) {
         bool integerFound = false;
         s64 integerValue = DynOS_Misc_ParseInteger(_Arg, &integerFound);
         if (integerFound) {
@@ -450,7 +469,14 @@ static s64 ParseGfxSymbolArg(GfxData* aGfxData, DataNode<Gfx>* aNode, u64* pToke
     }
 
     // Pointers
-    if (isPtrType) {
+    if (GFX_PARAM_TYPE_IS_POINTER(aParamType)) {
+
+        // NULL pointer
+        if (_Arg == "NULL") {
+            return (s64) NULL;
+        }
+
+        // Raw pointers
         for (auto& _Node : aGfxData->mRawPointers) {
             if (_Arg == _Node->mName) {
                 return (s64) _Node->mData;
@@ -467,7 +493,7 @@ static s64 ParseGfxSymbolArg(GfxData* aGfxData, DataNode<Gfx>* aNode, u64* pToke
     }
 
     // Lights
-    if (type == 'p') {
+    if (aParamType == GFX_PARAM_TYPE_PTR) {
         for (auto& _Node : aGfxData->mLights) {
             // Light pointer
             if (_Arg == _Node->mName) {
@@ -489,7 +515,7 @@ static s64 ParseGfxSymbolArg(GfxData* aGfxData, DataNode<Gfx>* aNode, u64* pToke
     }
 
     // Textures
-    if (type == 't') {
+    if (aParamType == GFX_PARAM_TYPE_TEX) {
         for (auto& _Node : aGfxData->mTextures) {
             if (_Arg == _Node->mName) {
                 return (s64) DynOS_Tex_Parse(aGfxData, _Node);
@@ -498,7 +524,7 @@ static s64 ParseGfxSymbolArg(GfxData* aGfxData, DataNode<Gfx>* aNode, u64* pToke
     }
 
     // Vertex arrays
-    if (type == 'v') {
+    if (aParamType == GFX_PARAM_TYPE_VTX) {
         for (auto& _Node : aGfxData->mVertices) {
             if (_Arg == _Node->mName) {
                 auto base = DynOS_Vtx_Parse(aGfxData, _Node)->mData;
@@ -512,7 +538,7 @@ static s64 ParseGfxSymbolArg(GfxData* aGfxData, DataNode<Gfx>* aNode, u64* pToke
     }
 
     // Display lists
-    if (type == 'g') {
+    if (aParamType == GFX_PARAM_TYPE_GFX) {
         for (auto& _Node : aGfxData->mDisplayLists) {
             if (_Arg == _Node->mName) {
                 return (s64) DynOS_Gfx_Parse(aGfxData, _Node);
@@ -520,7 +546,7 @@ static s64 ParseGfxSymbolArg(GfxData* aGfxData, DataNode<Gfx>* aNode, u64* pToke
         }
     }
 
-    if (type == 'p') {
+    if (aParamType == GFX_PARAM_TYPE_PTR) {
         for (auto& _Node : aGfxData->mLight0s) {
             // Light pointer
             if (_Arg == _Node->mName) {
@@ -574,7 +600,7 @@ static s64 ParseGfxSymbolArg(GfxData* aGfxData, DataNode<Gfx>* aNode, u64* pToke
     }
 
     // Built-in textures
-    if (type == 't') {
+    if (aParamType == GFX_PARAM_TYPE_TEX) {
         auto builtinTex = DynOS_Builtin_Tex_GetFromName(_Arg.begin());
         if (builtinTex != NULL) {
             return (s64)builtinTex;
@@ -582,7 +608,7 @@ static s64 ParseGfxSymbolArg(GfxData* aGfxData, DataNode<Gfx>* aNode, u64* pToke
     }
 
     // Recursive descent parsing
-    if (isIntOrConstant) {
+    if (GFX_PARAM_TYPE_IS_INT_OR_CONSTANT(aParamType)) {
         bool rdSuccess = false;
         s64 rdValue = DynOS_RecursiveDescent_Parse(_Arg.begin(), &rdSuccess, DynOS_Gfx_ParseGfxConstants);
         if (rdSuccess) {
@@ -590,21 +616,16 @@ static s64 ParseGfxSymbolArg(GfxData* aGfxData, DataNode<Gfx>* aNode, u64* pToke
         }
     }
 
-    // Allow NULL for pointer types
-    if (isPtrType && _Arg == "NULL") {
-        return (s64) NULL;
-    }
-
     // Unknown
     PrintDataErrorGfx("  ERROR: Unknown gfx arg: %s", _Arg.begin());
     return 0;
 }
 
-#define gfx_arg_with_suffix(argname, suffix, type)                                                  \
+#define gfx_arg_with_suffix(argname, suffix, paramtype)                                             \
     CHECK_TOKEN_INDEX(aTokenIndex,);                                                                \
     const String& argname##_token = aNode->mTokens[aTokenIndex];                                    \
     String _Token##suffix = String("%s%s", argname##_token.begin(), #suffix);                       \
-    s64 argname = ParseGfxSymbolArg(aGfxData, aNode, NULL, _Token##suffix.begin(), type);           \
+    s64 argname = ParseGfxSymbolArg(aGfxData, aNode, NULL, _Token##suffix.begin(), paramtype);      \
 
 #define STR_VALUE_2(...) #__VA_ARGS__
 #define STR_VALUE(...) STR_VALUE_2(__VA_ARGS__)
@@ -692,7 +713,7 @@ static Array<s64> ParseGfxSetCombineMode(GfxData* aGfxData, DataNode<Gfx>* aNode
         if (i == n || _Buffer[i] == ' ' || _Buffer[i] == '\t' || _Buffer[i] == ',') {
             if (_Token.Length() != 0) {
                 String _Arg("%s%s", (_Args.Count() < 4 ? "G_CCMUX_" : "G_ACMUX_"), _Token.begin());
-                _Args.Add(ParseGfxSymbolArg(aGfxData, aNode, NULL, _Arg.begin(), 'i'));
+                _Args.Add(ParseGfxSymbolArg(aGfxData, aNode, NULL, _Arg.begin(), GFX_PARAM_TYPE_INT));
                 _Token.Clear();
             }
         } else {
@@ -743,12 +764,12 @@ static void ParseGfxSymbol(GfxData* aGfxData, DataNode<Gfx>* aNode, Gfx*& aHead,
 
     // Simple symbols
     // Uses macro iterators to dynamically handle the correct number of parameters
-#define HANDLE_PARAM(paramNum) s64 _Arg##paramNum = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", types[paramNum - 1]);
+#define HANDLE_PARAM(paramNum) s64 _Arg##paramNum = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", paramTypes[paramNum - 1]);
 #define GET_ARG(paramNum) _Arg##paramNum
 #define CALL_SYMB(symb, ...) symb(__VA_ARGS__)
 #define define_gfx_symbol(symb, params, addPtr, ...)                \
 if (_Symbol == #symb) {                                             \
-    static const char types[] = { __VA_ARGS__ };                    \
+    static const GfxParamType paramTypes[] = { __VA_ARGS__ };       \
     REPEAT(HANDLE_PARAM, params);                                   \
     if (addPtr) { aGfxData->mPointerList.Add(aHead); }              \
     Gfx _Gfx[] = { CALL_SYMB(symb, LIST_ARGS(GET_ARG, params)) };   \
@@ -766,32 +787,32 @@ if (_Symbol == #symb) {                                             \
 
     // Special symbols
     if (_Symbol == "gsSPTexture") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
         gSPTexture(aHead++, _Arg0, _Arg1, _Arg2, _Arg3, _Arg4);
         return;
     }
     if (_Symbol == "gsSPSetGeometryMode") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
         gSPSetGeometryMode(aHead++, _Arg0);
         return;
     }
     if (_Symbol == "gsSPClearGeometryMode") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
         gSPClearGeometryMode(aHead++, _Arg0);
         return;
     }
     if (_Symbol == "gsSPDisplayList") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'g');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_GFX);
         aGfxData->mPointerList.Add(aHead);
         gSPDisplayList(aHead++, _Arg0);
         return;
     }
     if (_Symbol == "gsSPBranchList") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'g');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_GFX);
         aGfxData->mPointerList.Add(aHead);
         gSPBranchList(aHead++, _Arg0);
         return;
@@ -817,7 +838,7 @@ if (_Symbol == #symb) {                                             \
 
     // Complex symbols
     if (_Symbol == "gsSPSetLights0") {
-        Lights0 *_Light = (Lights0 *) ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'p');
+        Lights0 *_Light = (Lights0 *) ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_PTR);
         gSPNumLights(aHead++, NUMLIGHTS_0);
         aGfxData->mPointerList.Add(aHead);
         gSPLight(aHead++, &_Light->l[0], 1);
@@ -826,7 +847,7 @@ if (_Symbol == #symb) {                                             \
         return;
     }
     if (_Symbol == "gsSPSetLights1") {
-        Lights1 *_Light = (Lights1 *) ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'p');
+        Lights1 *_Light = (Lights1 *) ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_PTR);
         gSPNumLights(aHead++, NUMLIGHTS_1);
         aGfxData->mPointerList.Add(aHead);
         gSPLight(aHead++, &_Light->l[0], 1);
@@ -845,22 +866,22 @@ if (_Symbol == #symb) {                                             \
         return;
     }
     if (_Symbol == "gsDPSetCombineLERP") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", 'i');
-        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", 'i');
-        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", 'i');
-        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", 'i');
-        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", 'i');
-        s64 _Arg5 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", 'i');
-        s64 _Arg6 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", 'i');
-        s64 _Arg7 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", 'i');
-        s64 _Arg8 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", 'i');
-        s64 _Arg9 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", 'i');
-        s64 _ArgA = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", 'i');
-        s64 _ArgB = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", 'i');
-        s64 _ArgC = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", 'i');
-        s64 _ArgD = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", 'i');
-        s64 _ArgE = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", 'i');
-        s64 _ArgF = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", 'i');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", GFX_PARAM_TYPE_INT);
+        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", GFX_PARAM_TYPE_INT);
+        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", GFX_PARAM_TYPE_INT);
+        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", GFX_PARAM_TYPE_INT);
+        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", GFX_PARAM_TYPE_INT);
+        s64 _Arg5 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", GFX_PARAM_TYPE_INT);
+        s64 _Arg6 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", GFX_PARAM_TYPE_INT);
+        s64 _Arg7 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", GFX_PARAM_TYPE_INT);
+        s64 _Arg8 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", GFX_PARAM_TYPE_INT);
+        s64 _Arg9 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", GFX_PARAM_TYPE_INT);
+        s64 _ArgA = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", GFX_PARAM_TYPE_INT);
+        s64 _ArgB = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_CCMUX_", GFX_PARAM_TYPE_INT);
+        s64 _ArgC = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", GFX_PARAM_TYPE_INT);
+        s64 _ArgD = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", GFX_PARAM_TYPE_INT);
+        s64 _ArgE = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", GFX_PARAM_TYPE_INT);
+        s64 _ArgF = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "G_ACMUX_", GFX_PARAM_TYPE_INT);
         Gfx _Gfx = {{
             _SHIFTL(G_SETCOMBINE, 24, 8) | _SHIFTL(GCCc0w0(_Arg0, _Arg2, _Arg4, _Arg6) | GCCc1w0(_Arg8, _ArgA), 0, 24),
             (u32) (GCCc0w1(_Arg1, _Arg3, _Arg5, _Arg7) | GCCc1w1(_Arg9, _ArgC, _ArgE, _ArgB, _ArgD, _ArgF))
@@ -871,70 +892,70 @@ if (_Symbol == #symb) {                                             \
 
     // TexData symbols
     if (_Symbol == "gsDPSetTextureImage") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 't');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_TEX);
         UpdateTextureInfo(aGfxData, &_Arg3, (s32) _Arg0, (s32) _Arg1, -1, -1);
         aGfxData->mPointerList.Add(aHead);
         gDPSetTextureImage(aHead++, _Arg0, _Arg1, _Arg2, _Arg3);
         return;
     }
     if (_Symbol == "gsDPSetTile") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg5 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg6 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg7 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg8 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg9 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _ArgA = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _ArgB = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg5 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg6 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg7 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg8 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg9 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _ArgA = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _ArgB = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
         UpdateTextureInfo(aGfxData, NULL, (s32) _Arg0, (s32) _Arg1, -1, -1);
         gDPSetTile(aHead++, _Arg0, _Arg1, _Arg2, _Arg3, _Arg4, _Arg5, _Arg6, _Arg7, _Arg8, _Arg9, _ArgA, _ArgB);
         return;
     }
     if (_Symbol == "gsDPLoadTile") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
         UpdateTextureInfo(aGfxData, NULL, -1, -1, (s32) (_Arg3 >> G_TEXTURE_IMAGE_FRAC) + 1, (s32) (_Arg4 >> G_TEXTURE_IMAGE_FRAC) + 1);
         gDPLoadTile(aHead++, _Arg0, _Arg1, _Arg2, _Arg3, _Arg4);
         return;
     }
     if (_Symbol == "gsDPSetTileSize") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
         UpdateTextureInfo(aGfxData, NULL, -1, -1, (s32) (_Arg3 >> G_TEXTURE_IMAGE_FRAC) + 1, (s32) (_Arg4 >> G_TEXTURE_IMAGE_FRAC) + 1);
         gDPSetTileSize(aHead++, _Arg0, _Arg1, _Arg2, _Arg3, _Arg4);
         return;
     }
     if (_Symbol == "gsDPLoadTextureBlock") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 't');
-        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        gfx_arg_with_suffix(arg2_0, _LOAD_BLOCK, 'i');
-        gfx_arg_with_suffix(arg2_1, _INCR, 'i');
-        gfx_arg_with_suffix(arg2_2, _SHIFT, 'i');
-        gfx_arg_with_suffix(arg2_3, _BYTES, 'i');
-        gfx_arg_with_suffix(arg2_4, _LINE_BYTES, 'i');
-        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg5 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg6 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg7 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg8 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg9 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _ArgA = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _ArgB = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_TEX);
+        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        gfx_arg_with_suffix(arg2_0, _LOAD_BLOCK, GFX_PARAM_TYPE_INT);
+        gfx_arg_with_suffix(arg2_1, _INCR, GFX_PARAM_TYPE_INT);
+        gfx_arg_with_suffix(arg2_2, _SHIFT, GFX_PARAM_TYPE_INT);
+        gfx_arg_with_suffix(arg2_3, _BYTES, GFX_PARAM_TYPE_INT);
+        gfx_arg_with_suffix(arg2_4, _LINE_BYTES, GFX_PARAM_TYPE_INT);
+        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg5 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg6 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg7 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg8 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg9 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _ArgA = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _ArgB = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
         UpdateTextureInfo(aGfxData, &_Arg0, (s32) _Arg1, (s32) _Arg2, (s32) _Arg3, (s32) _Arg4);
 
         aGfxData->mPointerList.Add(aHead);
@@ -948,16 +969,16 @@ if (_Symbol == #symb) {                                             \
         return;
     }
     if (_Symbol == "gsDPLoadTLUTCmd") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
         SetCurrentTextureAsPalette(aGfxData);
 
         gDPLoadTLUTCmd(aHead++, _Arg0, _Arg1);
         return;
     }
     if (_Symbol == "gsDPLoadTLUT_pal16") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
         UpdateTextureInfo(aGfxData, &_Arg1, G_IM_FMT_RGBA, G_IM_SIZ_16b, -1, -1);
         SetCurrentTextureAsPalette(aGfxData);
 
@@ -971,7 +992,7 @@ if (_Symbol == #symb) {                                             \
         return;
     }
     if (_Symbol == "gsDPLoadTLUT_pal256") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
         UpdateTextureInfo(aGfxData, &_Arg0, G_IM_FMT_RGBA, G_IM_SIZ_16b, -1, -1);
         SetCurrentTextureAsPalette(aGfxData);
 
@@ -985,17 +1006,17 @@ if (_Symbol == #symb) {                                             \
         return;
     }
     if (_Symbol == "gsDPLoadTextureBlock_4b") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 't');
-        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg5 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg6 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg7 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg8 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg9 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _ArgA = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_TEX);
+        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg2 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg3 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg4 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg5 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg6 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg7 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg8 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg9 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _ArgA = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
         UpdateTextureInfo(aGfxData, &_Arg0, (s32) _Arg1, G_IM_SIZ_4b, (s32) _Arg2, (s32) _Arg3);
 
         aGfxData->mPointerList.Add(aHead);
@@ -1009,8 +1030,8 @@ if (_Symbol == #symb) {                                             \
         return;
     }
     if (_Symbol == "gsSPLightColor") {
-        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
-        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", 'i');
+        s64 _Arg0 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
+        s64 _Arg1 = ParseGfxSymbolArg(aGfxData, aNode, &aTokenIndex, "", GFX_PARAM_TYPE_INT);
         // due to the function taking in the variable name instead of the actual value
         // as a parameter, we need to do this. LIGHT_1 to LIGHT_8 go from actual 1-8
         // where as G_MWO_a*/G_MWO_b* are hex numbers without a linear pattern of
@@ -1157,7 +1178,7 @@ static String ResolveParam(lua_State *L, GfxData *aGfxData, u32 paramIndex, char
     switch (paramType) {
 
         // Integer
-        case 'i': return ConvertParam<s64>(
+        case GFX_PARAM_TYPE_INT: return ConvertParam<s64>(
             L, aGfxData, paramIndex,
             "integer",
             [] (lua_State *L, u32 paramIndex) { return smlua_to_integer(L, paramIndex); },
@@ -1165,7 +1186,7 @@ static String ResolveParam(lua_State *L, GfxData *aGfxData, u32 paramIndex, char
         );
 
         // String
-        case 's': return ConvertParam<const char *>(
+        case GFX_PARAM_TYPE_STR: return ConvertParam<const char *>(
             L, aGfxData, paramIndex,
             "string",
             [] (lua_State *L, u32 paramIndex) { return smlua_to_string(L, paramIndex); },
@@ -1173,7 +1194,7 @@ static String ResolveParam(lua_State *L, GfxData *aGfxData, u32 paramIndex, char
         );
 
         // Vtx pointer
-        case 'v': return ConvertParam<Vtx *>(
+        case GFX_PARAM_TYPE_VTX: return ConvertParam<Vtx *>(
             L, aGfxData, paramIndex,
             "Vtx pointer",
             [] (lua_State *L, u32 paramIndex) { return (Vtx *) smlua_to_cobject(L, paramIndex, LOT_VTX); },
@@ -1181,7 +1202,7 @@ static String ResolveParam(lua_State *L, GfxData *aGfxData, u32 paramIndex, char
         );
 
         // Texture pointer
-        case 't': return ConvertParam<Texture *>(
+        case GFX_PARAM_TYPE_TEX: return ConvertParam<Texture *>(
             L, aGfxData, paramIndex,
             "Texture pointer",
             [] (lua_State *L, u32 paramIndex) { return (Texture *) smlua_to_cpointer(L, paramIndex, LVT_U8_P); },
@@ -1189,32 +1210,27 @@ static String ResolveParam(lua_State *L, GfxData *aGfxData, u32 paramIndex, char
         );
 
         // Gfx pointer
-        case 'g': return ConvertParam<Gfx *>(
+        case GFX_PARAM_TYPE_GFX: return ConvertParam<Gfx *>(
             L, aGfxData, paramIndex,
             "Gfx pointer",
             [] (lua_State *L, u32 paramIndex) { return (Gfx *) smlua_to_cobject(L, paramIndex, LOT_GFX); },
             [&aGfxData] (Gfx *gfx) { return CreateRawPointerDataNode(aGfxData, gfx); }
         );
-
-        // Unimplemented pointer type
-        case 'p': {
-            PrintDataErrorGfx("  ERROR: Unimplemented pointer type: '%c'", paramType);
-            return "";
-        }
     }
     PrintDataErrorGfx("  ERROR: Unknown parameter type: '%c'", paramType);
     return "";
 }
 
-struct ParamInfo {
+struct GfxParamInfo {
     u8 count;
-    char types[];
+    const GfxParamType *types;
 };
 
-static struct ParamInfo *get_gfx_command_param_data(const char *command) {
-#define define_gfx_symbol(symb, params, addPtr, ...)                                                            \
-    static struct ParamInfo info_##symb = { .count = params, .types = { __VA_ARGS__ } };                        \
-    static_assert(COUNT_ARGS(__VA_ARGS__) == (params + 1), "Parameter count does not match for gfx command.");  \
+static const struct GfxParamInfo *GetGfxParamInfo(const char *command) {
+#define define_gfx_symbol(symb, params, addPtr, ...)                                                    \
+    static const GfxParamType types_##symb[] = { __VA_ARGS__ };                                         \
+    static struct GfxParamInfo info_##symb = { .count = params, .types = types_##symb };                \
+    static_assert(sizeof(types_##symb) == params, "Parameter count does not match for gfx command.");   \
     if (!strncmp(#symb, command, strlen(#symb))) { return &info_##symb; }
 #define define_gfx_symbol_manual(...) define_gfx_symbol(__VA_ARGS__)
 #include "gfx_symbols.h"
@@ -1224,37 +1240,39 @@ static struct ParamInfo *get_gfx_command_param_data(const char *command) {
 }
 
 static std::string ResolveGfxCommand(lua_State *L, GfxData *aGfxData, const char *command) {
-    struct ParamInfo *paramInfo = get_gfx_command_param_data(command);
+    const struct GfxParamInfo *paramInfo = GetGfxParamInfo(command);
     if (!paramInfo) { PrintDataErrorGfx("  ERROR: Unknown gfx command: %s", command); return ""; }
 
     // Count parameters
-    u16 count = 0;
+    // Find the position of each % to retrieve the correct expected type from the command paramInfo
+    u8 paramPos[paramInfo->count] = { 0 };
+    u8 paramPosIndex = 0;
+    u8 paramCount = 1;
     bool inBrackets = false;
     for (const char* str = command; *str; str++) {
         if (*str == '(') { inBrackets = true; }
         if (*str == ')') { inBrackets = false; }
-        if (*str == ',' && inBrackets) { count++; }
+        if (*str == ',' && inBrackets) { paramCount++; }
+        if (*str == '%' && paramPosIndex < paramInfo->count) { paramPos[paramPosIndex++] = paramCount - 1; }
     }
-    count++;
-
-    if (count != paramInfo->count) {
-        PrintDataErrorGfx("  ERROR: Incorrect parameter count. Got %d, expected %d.", count, paramInfo->count);
+    if (paramCount != paramInfo->count) {
+        PrintDataErrorGfx("  ERROR: Incorrect parameter count. Got %d, expected %d.", paramCount, paramInfo->count);
         return "";
     }
 
     std::string output;
-    u8 paramNum = 0;
     for (u32 paramIndex = 3; *command; command++) {
         char c = *command;
         if (c == '%') {
-            char paramType = *(++command);
-            char expectedType = paramInfo->types[paramNum];
-            if (expectedType == 'p') {
-                PrintDataErrorGfx("  ERROR: Gfx macro has unsupported type, this macro is not useable.");
+            u8 paramNum = paramPos[paramIndex - 3];
+            const GfxParamType paramType = *(++command);
+            const GfxParamType expectedType = paramInfo->types[paramNum];
+            if (expectedType == GFX_PARAM_TYPE_PTR) {
+                PrintDataErrorGfx("  ERROR: Gfx macro has unsupported type, this macro is not usable");
                 return "";
             }
             if (expectedType != paramType &&
-                (expectedType != 'i' || paramType == 's' || paramType == 'i') // Allow strings as constants for integer parameters
+                (expectedType != GFX_PARAM_TYPE_INT || !GFX_PARAM_TYPE_IS_INT_OR_CONSTANT(paramType)) // Allow strings as constants for integer parameters
             ) {
                 PrintDataErrorGfx("  ERROR: Unexpected value type for parameter %d. Got '%c', expected '%c'", paramNum, paramType, expectedType);
                 return "";
@@ -1264,7 +1282,6 @@ static std::string ResolveGfxCommand(lua_State *L, GfxData *aGfxData, const char
                 return "";
             }
             output.append(value.begin());
-            ++paramNum;
         } else {
             output += c;
         }

--- a/data/dynos_bin_gfx.cpp
+++ b/data/dynos_bin_gfx.cpp
@@ -472,7 +472,7 @@ static s64 ParseGfxSymbolArg(GfxData* aGfxData, DataNode<Gfx>* aNode, u64* pToke
     if (GFX_PARAM_TYPE_IS_POINTER(aParamType)) {
 
         // NULL pointer
-        if (_Arg == "NULL") {
+        if (_Arg == "NULL" || _Arg == "0") {
             return (s64) NULL;
         }
 

--- a/include/gfx_symbols.h
+++ b/include/gfx_symbols.h
@@ -1,44 +1,78 @@
-// To use this macro, define `define_gfx_symbol` before including this file.
+/*
+Both define_gfx_symbol and define_gfx_symbol_manual have the same parameters.
+1 - Gfx command name
+2 - The number of parameters the command should take
+3 - Whether or not DynOS should store an internal pointer to this command.
+All parameters after are a single character representing the type
+that parameter should have in the gfx command, specifically for use in gfx_set_command.
+Types:
+i - integer
+v - Vtx pointer
+t - Texture pointer
+g - Gfx pointer
+p - Undefined pointer type
+*/
 
 define_gfx_symbol(gsDPFullSync, 0, false);
 define_gfx_symbol(gsDPTileSync, 0, false);
 define_gfx_symbol(gsDPPipeSync, 0, false);
 define_gfx_symbol(gsDPLoadSync, 0, false);
 define_gfx_symbol(gsDPNoOp, 0, false);
-define_gfx_symbol(gsDPNoOpTag, 1, false);
-define_gfx_symbol(gsDPSetCycleType, 1, false);
-define_gfx_symbol(gsSPLight, 2, true);
-define_gfx_symbol(gsSPVertex, 3, true);
-define_gfx_symbol(gsSP1Triangle, 4, false);
-define_gfx_symbol(gsSP2Triangles, 8, false);
-define_gfx_symbol(gsSPNumLights, 1, false);
-define_gfx_symbol(gsDPSetDepthSource, 1, false);
-define_gfx_symbol(gsDPSetTextureLUT, 1, false);
-define_gfx_symbol(gsDPLoadBlock, 5, false);
-define_gfx_symbol(gsDPSetRenderMode, 2, false);
-define_gfx_symbol(gsSPGeometryMode, 2, false);
-define_gfx_symbol(gsSPGeometryModeSetFirst, 2, false);
-define_gfx_symbol(gsDPSetPrimColor, 6, false);
-define_gfx_symbol(gsDPSetEnvColor, 4, false);
-define_gfx_symbol(gsDPSetFogColor, 4, false);
-define_gfx_symbol(gsSPFogPosition, 2, false);
-define_gfx_symbol(gsDPSetAlphaCompare, 1, false);
-define_gfx_symbol(gsDPSetTextureFilter, 1, false);
-define_gfx_symbol(gsDPSetTexturePersp, 1, false);
-define_gfx_symbol(gsDPSetTextureLOD, 1, false);
-define_gfx_symbol(gsDPSetTextureConvert, 1, false);
-define_gfx_symbol(gsSPCullDisplayList, 2, false);
-define_gfx_symbol(gsDPSetAlphaDither, 1, false);
-define_gfx_symbol(gsDPSetCombineKey, 1, false);
-define_gfx_symbol(gsDPPipelineMode, 1, false);
-define_gfx_symbol(gsSPSetOtherMode, 4, false);
-define_gfx_symbol(gsDPSetTextureDetail, 1, false);
-define_gfx_symbol(gsDPSetColorDither, 1, false);
-define_gfx_symbol(gsDPSetPrimDepth, 2, false);
-define_gfx_symbol(gsDPSetBlendColor, 4, false);
-define_gfx_symbol(gsSPCopyLightEXT, 2, false);
-define_gfx_symbol(gsSPCopyLightsPlayerPart, 1, false);
-define_gfx_symbol(gsSPFogFactor, 2, false);
-define_gfx_symbol(gsMoveWd, 3, false);
-define_gfx_symbol(gsSPLoadGeometryMode, 1, false);
-define_gfx_symbol(gsSPVertexNonGlobal, 3, true);
+define_gfx_symbol(gsDPNoOpTag, 1, false, 'i');
+define_gfx_symbol(gsDPSetCycleType, 1, false, 'i');
+define_gfx_symbol(gsSPLight, 2, true, 'p', 'i');
+define_gfx_symbol(gsSPVertex, 3, true, 'v', 'i', 'i');
+define_gfx_symbol(gsSP1Triangle, 4, false, 'i', 'i', 'i', 'i');
+define_gfx_symbol(gsSP2Triangles, 8, false, 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i');
+define_gfx_symbol(gsSPNumLights, 1, false, 'i');
+define_gfx_symbol(gsDPSetDepthSource, 1, false, 'i');
+define_gfx_symbol(gsDPSetTextureLUT, 1, false, 'i');
+define_gfx_symbol(gsDPLoadBlock, 5, false, 'i', 'i', 'i', 'i', 'i');
+define_gfx_symbol(gsDPSetRenderMode, 2, false, 'i', 'i');
+define_gfx_symbol(gsSPGeometryMode, 2, false, 'i', 'i');
+define_gfx_symbol(gsSPGeometryModeSetFirst, 2, false, 'i', 'i');
+define_gfx_symbol(gsDPSetPrimColor, 6, false, 'i', 'i', 'i', 'i', 'i', 'i');
+define_gfx_symbol(gsDPSetEnvColor, 4, false, 'i', 'i', 'i', 'i');
+define_gfx_symbol(gsDPSetFogColor, 4, false, 'i', 'i', 'i', 'i');
+define_gfx_symbol(gsSPFogPosition, 2, false, 'i', 'i');
+define_gfx_symbol(gsDPSetAlphaCompare, 1, false, 'i');
+define_gfx_symbol(gsDPSetTextureFilter, 1, false, 'i');
+define_gfx_symbol(gsDPSetTexturePersp, 1, false, 'i');
+define_gfx_symbol(gsDPSetTextureLOD, 1, false, 'i');
+define_gfx_symbol(gsDPSetTextureConvert, 1, false, 'i');
+define_gfx_symbol(gsSPCullDisplayList, 2, false, 'i', 'i');
+define_gfx_symbol(gsDPSetAlphaDither, 1, false, 'i');
+define_gfx_symbol(gsDPSetCombineKey, 1, false, 'i');
+define_gfx_symbol(gsDPPipelineMode, 1, false, 'i');
+define_gfx_symbol(gsSPSetOtherMode, 4, false, 'i', 'i', 'i', 'i');
+define_gfx_symbol(gsDPSetTextureDetail, 1, false, 'i');
+define_gfx_symbol(gsDPSetColorDither, 1, false, 'i');
+define_gfx_symbol(gsDPSetPrimDepth, 2, false, 'i', 'i');
+define_gfx_symbol(gsDPSetBlendColor, 4, false, 'i', 'i', 'i', 'i');
+define_gfx_symbol(gsSPCopyLightEXT, 2, false, 'i', 'i');
+define_gfx_symbol(gsSPCopyLightsPlayerPart, 1, false, 'i');
+define_gfx_symbol(gsSPFogFactor, 2, false, 'i', 'i');
+define_gfx_symbol(gsMoveWd, 3, false, 'i', 'i', 'i');
+define_gfx_symbol(gsSPLoadGeometryMode, 1, false, 'i');
+define_gfx_symbol(gsSPVertexNonGlobal, 3, true, 'v', 'i', 'i');
+
+define_gfx_symbol_manual(gsSPTexture, 5, false, 'i', 'i', 'i', 'i', 'i');
+define_gfx_symbol_manual(gsSPSetGeometryMode, 1, false, 'i');
+define_gfx_symbol_manual(gsSPClearGeometryMode, 1, false, 'i');
+define_gfx_symbol_manual(gsSPDisplayList, 1, true, 'g');
+define_gfx_symbol_manual(gsSPBranchList, 1, true, 'g');
+define_gfx_symbol_manual(gsSPEndDisplayList, 0, false);
+define_gfx_symbol_manual(gsSPSetLights0, 1, true, 'p');
+define_gfx_symbol_manual(gsSPSetLights1, 1, true, 'p');
+define_gfx_symbol_manual(gsDPSetCombineMode, 2, false, 'i', 'i');
+define_gfx_symbol_manual(gsDPSetCombineLERP, 16, false, 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i');
+define_gfx_symbol_manual(gsDPSetTextureImage, 4, false, 'i', 'i', 'i', 't');
+define_gfx_symbol_manual(gsDPSetTile, 12, false, 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i');
+define_gfx_symbol_manual(gsDPLoadTile, 5, false, 'i', 'i', 'i', 'i', 'i');
+define_gfx_symbol_manual(gsDPSetTileSize, 5, false, 'i', 'i', 'i', 'i', 'i');
+define_gfx_symbol_manual(gsDPLoadTextureBlock, 12, true, 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i');
+define_gfx_symbol_manual(gsDPLoadTLUTCmd, 2, false, 'i', 'i');
+define_gfx_symbol_manual(gsDPLoadTLUT_pal16, 2, true, 'i', 'i');
+define_gfx_symbol_manual(gsDPLoadTLUT_pal256, 1, true, 'i');
+define_gfx_symbol_manual(gsDPLoadTextureBlock_4b, 11, true, 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i');
+define_gfx_symbol_manual(gsSPLightColor, 2, false, 'i', 'i');

--- a/include/gfx_symbols.h
+++ b/include/gfx_symbols.h
@@ -3,14 +3,14 @@ Both define_gfx_symbol and define_gfx_symbol_manual have the same parameters.
 1 - Gfx command name
 2 - The number of parameters the command should take
 3 - Whether or not DynOS should store an internal pointer to this command.
-All parameters after are a single character representing the type
-that parameter should have in the gfx command, specifically for use in gfx_set_command.
+All parameters after are representing the type that parameter should have in the gfx command, specifically for use in gfx_set_command.
 Types:
-i - integer
-v - Vtx pointer
-t - Texture pointer
-g - Gfx pointer
-p - Undefined pointer type
+GFX_PARAM_TYPE_INT - integer
+GFX_PARAM_TYPE_STR - string
+GFX_PARAM_TYPE_PTR - Undefined pointer type
+GFX_PARAM_TYPE_VTX - Vtx pointer
+GFX_PARAM_TYPE_TEX - Texture pointer
+GFX_PARAM_TYPE_GFX - Gfx pointer
 */
 
 define_gfx_symbol(gsDPFullSync, 0, false);
@@ -18,61 +18,61 @@ define_gfx_symbol(gsDPTileSync, 0, false);
 define_gfx_symbol(gsDPPipeSync, 0, false);
 define_gfx_symbol(gsDPLoadSync, 0, false);
 define_gfx_symbol(gsDPNoOp, 0, false);
-define_gfx_symbol(gsDPNoOpTag, 1, false, 'i');
-define_gfx_symbol(gsDPSetCycleType, 1, false, 'i');
-define_gfx_symbol(gsSPLight, 2, true, 'p', 'i');
-define_gfx_symbol(gsSPVertex, 3, true, 'v', 'i', 'i');
-define_gfx_symbol(gsSP1Triangle, 4, false, 'i', 'i', 'i', 'i');
-define_gfx_symbol(gsSP2Triangles, 8, false, 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i');
-define_gfx_symbol(gsSPNumLights, 1, false, 'i');
-define_gfx_symbol(gsDPSetDepthSource, 1, false, 'i');
-define_gfx_symbol(gsDPSetTextureLUT, 1, false, 'i');
-define_gfx_symbol(gsDPLoadBlock, 5, false, 'i', 'i', 'i', 'i', 'i');
-define_gfx_symbol(gsDPSetRenderMode, 2, false, 'i', 'i');
-define_gfx_symbol(gsSPGeometryMode, 2, false, 'i', 'i');
-define_gfx_symbol(gsSPGeometryModeSetFirst, 2, false, 'i', 'i');
-define_gfx_symbol(gsDPSetPrimColor, 6, false, 'i', 'i', 'i', 'i', 'i', 'i');
-define_gfx_symbol(gsDPSetEnvColor, 4, false, 'i', 'i', 'i', 'i');
-define_gfx_symbol(gsDPSetFogColor, 4, false, 'i', 'i', 'i', 'i');
-define_gfx_symbol(gsSPFogPosition, 2, false, 'i', 'i');
-define_gfx_symbol(gsDPSetAlphaCompare, 1, false, 'i');
-define_gfx_symbol(gsDPSetTextureFilter, 1, false, 'i');
-define_gfx_symbol(gsDPSetTexturePersp, 1, false, 'i');
-define_gfx_symbol(gsDPSetTextureLOD, 1, false, 'i');
-define_gfx_symbol(gsDPSetTextureConvert, 1, false, 'i');
-define_gfx_symbol(gsSPCullDisplayList, 2, false, 'i', 'i');
-define_gfx_symbol(gsDPSetAlphaDither, 1, false, 'i');
-define_gfx_symbol(gsDPSetCombineKey, 1, false, 'i');
-define_gfx_symbol(gsDPPipelineMode, 1, false, 'i');
-define_gfx_symbol(gsSPSetOtherMode, 4, false, 'i', 'i', 'i', 'i');
-define_gfx_symbol(gsDPSetTextureDetail, 1, false, 'i');
-define_gfx_symbol(gsDPSetColorDither, 1, false, 'i');
-define_gfx_symbol(gsDPSetPrimDepth, 2, false, 'i', 'i');
-define_gfx_symbol(gsDPSetBlendColor, 4, false, 'i', 'i', 'i', 'i');
-define_gfx_symbol(gsSPCopyLightEXT, 2, false, 'i', 'i');
-define_gfx_symbol(gsSPCopyLightsPlayerPart, 1, false, 'i');
-define_gfx_symbol(gsSPFogFactor, 2, false, 'i', 'i');
-define_gfx_symbol(gsMoveWd, 3, false, 'i', 'i', 'i');
-define_gfx_symbol(gsSPLoadGeometryMode, 1, false, 'i');
-define_gfx_symbol(gsSPVertexNonGlobal, 3, true, 'v', 'i', 'i');
+define_gfx_symbol(gsDPNoOpTag, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetCycleType, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSPLight, 2, true, GFX_PARAM_TYPE_PTR, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSPVertex, 3, true, GFX_PARAM_TYPE_VTX, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSP1Triangle, 4, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSP2Triangles, 8, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSPNumLights, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetDepthSource, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetTextureLUT, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPLoadBlock, 5, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetRenderMode, 2, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSPGeometryMode, 2, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSPGeometryModeSetFirst, 2, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetPrimColor, 6, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetEnvColor, 4, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetFogColor, 4, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSPFogPosition, 2, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetAlphaCompare, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetTextureFilter, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetTexturePersp, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetTextureLOD, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetTextureConvert, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSPCullDisplayList, 2, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetAlphaDither, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetCombineKey, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPPipelineMode, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSPSetOtherMode, 4, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetTextureDetail, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetColorDither, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetPrimDepth, 2, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsDPSetBlendColor, 4, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSPCopyLightEXT, 2, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSPCopyLightsPlayerPart, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSPFogFactor, 2, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsMoveWd, 3, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSPLoadGeometryMode, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol(gsSPVertexNonGlobal, 3, true, GFX_PARAM_TYPE_VTX, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
 
-define_gfx_symbol_manual(gsSPTexture, 5, false, 'i', 'i', 'i', 'i', 'i');
-define_gfx_symbol_manual(gsSPSetGeometryMode, 1, false, 'i');
-define_gfx_symbol_manual(gsSPClearGeometryMode, 1, false, 'i');
-define_gfx_symbol_manual(gsSPDisplayList, 1, true, 'g');
-define_gfx_symbol_manual(gsSPBranchList, 1, true, 'g');
+define_gfx_symbol_manual(gsSPTexture, 5, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol_manual(gsSPSetGeometryMode, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol_manual(gsSPClearGeometryMode, 1, false, GFX_PARAM_TYPE_INT);
+define_gfx_symbol_manual(gsSPDisplayList, 1, true, GFX_PARAM_TYPE_GFX);
+define_gfx_symbol_manual(gsSPBranchList, 1, true, GFX_PARAM_TYPE_GFX);
 define_gfx_symbol_manual(gsSPEndDisplayList, 0, false);
-define_gfx_symbol_manual(gsSPSetLights0, 1, true, 'p');
-define_gfx_symbol_manual(gsSPSetLights1, 1, true, 'p');
-define_gfx_symbol_manual(gsDPSetCombineMode, 2, false, 'i', 'i');
-define_gfx_symbol_manual(gsDPSetCombineLERP, 16, false, 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i');
-define_gfx_symbol_manual(gsDPSetTextureImage, 4, false, 'i', 'i', 'i', 't');
-define_gfx_symbol_manual(gsDPSetTile, 12, false, 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i');
-define_gfx_symbol_manual(gsDPLoadTile, 5, false, 'i', 'i', 'i', 'i', 'i');
-define_gfx_symbol_manual(gsDPSetTileSize, 5, false, 'i', 'i', 'i', 'i', 'i');
-define_gfx_symbol_manual(gsDPLoadTextureBlock, 12, true, 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i');
-define_gfx_symbol_manual(gsDPLoadTLUTCmd, 2, false, 'i', 'i');
-define_gfx_symbol_manual(gsDPLoadTLUT_pal16, 2, true, 'i', 'i');
-define_gfx_symbol_manual(gsDPLoadTLUT_pal256, 1, true, 'i');
-define_gfx_symbol_manual(gsDPLoadTextureBlock_4b, 11, true, 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i', 'i');
-define_gfx_symbol_manual(gsSPLightColor, 2, false, 'i', 'i');
+define_gfx_symbol_manual(gsSPSetLights0, 1, true, GFX_PARAM_TYPE_PTR);
+define_gfx_symbol_manual(gsSPSetLights1, 1, true, GFX_PARAM_TYPE_PTR);
+define_gfx_symbol_manual(gsDPSetCombineMode, 2, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol_manual(gsDPSetCombineLERP, 16, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol_manual(gsDPSetTextureImage, 4, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_TEX);
+define_gfx_symbol_manual(gsDPSetTile, 12, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol_manual(gsDPLoadTile, 5, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol_manual(gsDPSetTileSize, 5, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol_manual(gsDPLoadTextureBlock, 12, true, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol_manual(gsDPLoadTLUTCmd, 2, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol_manual(gsDPLoadTLUT_pal16, 2, true, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol_manual(gsDPLoadTLUT_pal256, 1, true, GFX_PARAM_TYPE_INT);
+define_gfx_symbol_manual(gsDPLoadTextureBlock_4b, 11, true, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);
+define_gfx_symbol_manual(gsSPLightColor, 2, false, GFX_PARAM_TYPE_INT, GFX_PARAM_TYPE_INT);

--- a/include/macros.h
+++ b/include/macros.h
@@ -128,12 +128,4 @@
 #define LIST_ARGS_9(ACTION) LIST_ARGS_8(ACTION), ACTION(9)
 #define LIST_ARGS(ACTION, N) LIST_ARGS_##N(ACTION)
 
-// +1 indexed
-#define PP_ARG_N(  _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, \
-                   _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, N, ...) N
-#define PP_COUNT_ARGS(...) PP_ARG_N(,##__VA_ARGS__, \
-                                   20,19,18,17,16,15,14,13,12,11, \
-                                   10,9,8,7,6,5,4,3,2,1,0)
-#define COUNT_ARGS(...) PP_COUNT_ARGS(__VA_ARGS__)
-
 #endif // MACROS_H

--- a/include/macros.h
+++ b/include/macros.h
@@ -128,4 +128,12 @@
 #define LIST_ARGS_9(ACTION) LIST_ARGS_8(ACTION), ACTION(9)
 #define LIST_ARGS(ACTION, N) LIST_ARGS_##N(ACTION)
 
+// +1 indexed
+#define PP_ARG_N(  _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, \
+                   _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, N, ...) N
+#define PP_COUNT_ARGS(...) PP_ARG_N(,##__VA_ARGS__, \
+                                   20,19,18,17,16,15,14,13,12,11, \
+                                   10,9,8,7,6,5,4,3,2,1,0)
+#define COUNT_ARGS(...) PP_COUNT_ARGS(__VA_ARGS__)
+
 #endif // MACROS_H


### PR DESCRIPTION
previously, you could do things like `gsSPDisplayList(123)` to crash the game via DynOS bins or `gfx_set_command`. because it's constructing a pointer out of 123. This is just one of many issues that could be created by providing the wrong type for a gfx macro. This is a slightly hacky solution which keeps track of the types of all gfx commands that dynos supports.