### PR TITLE
Change get_game_tick_counter() to use gGlobalTimer

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -11105,7 +11105,7 @@ function texture_to_lua_table(tex)
 end
 
 --- @return integer
---- Gets the total number of game ticks since the game was launched. Wraps around at U64_MAX.
+--- Gets the total number of game ticks since the game was launched. Wraps around at U32_MAX.
 function get_game_tick_counter()
     -- ...
 end

--- a/docs/lua/functions-6.md
+++ b/docs/lua/functions-6.md
@@ -5131,7 +5131,7 @@ Converts a texture's pixels to a Lua table. Returns nil if failed. Otherwise, re
 ## [get_game_tick_counter](#get_game_tick_counter)
 
 ### Description
-Gets the total number of game ticks since the game was launched. Wraps around at U64_MAX.
+Gets the total number of game ticks since the game was launched. Wraps around at U32_MAX.
 
 ### Lua Example
 `local integerValue = get_game_tick_counter()`

--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -63,7 +63,6 @@ struct Controller *gPlayer3Controller = &gControllers[2];
 struct DemoInput *gCurrDemoInput = NULL; // demo input sequence
 u16 gDemoInputListID = 0;
 struct DemoInput gRecordedDemoInput = { 0 }; // possibly removed in EU. TODO: Check
-u64 gGameTickCounter = 0;
 
 /**
  * Initializes the Reality Display Processor (RDP).
@@ -602,8 +601,6 @@ void thread5_game_loop(UNUSED void *arg) {
 
 void game_loop_one_iteration(void) {
     profiler_log_thread5_time(THREAD5_START);
-
-    gGameTickCounter++;
 
     // if any controllers are plugged in, start read the data for when
     // read_controller_inputs is called later.

--- a/src/game/game_init.h
+++ b/src/game/game_init.h
@@ -58,7 +58,6 @@ extern u8 gDemoInputs[];
 
 extern u16 frameBufferIndex;
 extern u32 gGlobalTimer;
-extern u64 gGameTickCounter;
 
 void setup_game_memory(void);
 void thread5_game_loop(UNUSED void *arg);

--- a/src/pc/lua/utils/smlua_misc_utils.c
+++ b/src/pc/lua/utils/smlua_misc_utils.c
@@ -627,5 +627,5 @@ void texture_to_lua_table(const u8 *tex) {
 }
 
 u64 get_game_tick_counter(void) {
-    return gGameTickCounter;
+    return gGlobalTimer;
 }

--- a/src/pc/lua/utils/smlua_misc_utils.h
+++ b/src/pc/lua/utils/smlua_misc_utils.h
@@ -234,7 +234,7 @@ struct GraphNodeHeldObject* geo_get_current_held_object(void);
 /* |description|Converts a texture's pixels to a Lua table. Returns nil if failed. Otherwise, returns a table as a pure memory buffer. Supports rgba16 and rgba32 textures.|descriptionEnd|*/
 void texture_to_lua_table(const u8 *tex);
 
-/* |description|Gets the total number of game ticks since the game was launched. Wraps around at U64_MAX.|descriptionEnd|*/
+/* |description|Gets the total number of game ticks since the game was launched. Wraps around at U32_MAX.|descriptionEnd|*/
 u64 get_game_tick_counter(void);
 
 #endif


### PR DESCRIPTION
The old version was incrementing at the start of the code iteration, but it makes more sense to increment after the frame is built. That way every event within one visible game tick will get the same tick identifier