### PR TITLE
Fix bug in fixCollisionBugsRoundedCorners, add floorNormalMinY, ceilNormalMaxY

### DIFF
--- a/autogen/lua_definitions/structs.lua
+++ b/autogen/lua_definitions/structs.lua
@@ -1068,6 +1068,7 @@
 
 --- @class LevelValues
 --- @field public bubbleOnDeathBarrierInCapStages integer
+--- @field public ceilNormalMaxY number
 --- @field public cellHeightLimit integer
 --- @field public coinsRequiredForCoinStar integer
 --- @field public disableActs integer
@@ -1087,6 +1088,7 @@
 --- @field public floorLowerLimit integer
 --- @field public floorLowerLimitMisc integer
 --- @field public floorLowerLimitShadow integer
+--- @field public floorNormalMinY number
 --- @field public hudCapTimer integer
 --- @field public hudRedCoinsRadar integer
 --- @field public hudSecretsRadar integer

--- a/docs/lua/structs.md
+++ b/docs/lua/structs.md
@@ -1650,6 +1650,7 @@
 | Field | Type | Access |
 | ----- | ---- | ------ |
 | bubbleOnDeathBarrierInCapStages | `integer` |  |
+| ceilNormalMaxY | `number` |  |
 | cellHeightLimit | `integer` |  |
 | coinsRequiredForCoinStar | `integer` |  |
 | disableActs | `integer` |  |
@@ -1669,6 +1670,7 @@
 | floorLowerLimit | `integer` |  |
 | floorLowerLimitMisc | `integer` |  |
 | floorLowerLimitShadow | `integer` |  |
+| floorNormalMinY | `number` |  |
 | hudCapTimer | `integer` |  |
 | hudRedCoinsRadar | `integer` |  |
 | hudSecretsRadar | `integer` |  |

--- a/src/engine/surface_collision.c
+++ b/src/engine/surface_collision.c
@@ -163,7 +163,7 @@ static s32 find_wall_collisions_from_list(struct SurfaceNode *surfaceNode,
             closest_point_to_triangle(surf, src, cPos);
 
             // Exclude triangles where y isn't inside of it
-            if (fabs(cPos[1] - y) > 1) { continue; }
+            if (cPos[1] < surf->lowerY || cPos[1] > surf->upperY) { continue; }
 
             // Figure out normal
             f32 dX = src[0] - cPos[0];

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -89,10 +89,10 @@ static void add_surface_to_cell(s16 dynamic, s16 cellX, s16 cellZ, struct Surfac
     s16 sortDir;
     s16 listIndex;
 
-    if (surface->normal.y > 0.01) {
+    if (surface->normal.y > gLevelValues.floorNormalMinY) {
         listIndex = SPATIAL_PARTITION_FLOORS;
         sortDir = 1; // highest to lowest, then insertion order
-    } else if (surface->normal.y < -0.01) {
+    } else if (surface->normal.y < gLevelValues.ceilNormalMaxY) {
         listIndex = SPATIAL_PARTITION_CEILS;
         sortDir = -1; // lowest to highest, then insertion order
     } else {

--- a/src/game/hardcoded.c
+++ b/src/game/hardcoded.c
@@ -128,6 +128,8 @@ struct LevelValues gDefaultLevelValues = {
     .zoomOutCameraOnPause             = TRUE,
     .jrbDarkenSkybox                  = TRUE,
     .wallMaxRadius                    = 200.0f,
+    .floorNormalMinY                  = 0.01,
+    .ceilNormalMaxY                   = -0.01,
 };
 
 struct LevelValues gLevelValues = { 0 };

--- a/src/game/hardcoded.h
+++ b/src/game/hardcoded.h
@@ -95,6 +95,8 @@ struct LevelValues {
     u8 zoomOutCameraOnPause;
     u8 jrbDarkenSkybox;
     f32 wallMaxRadius;
+    f32 floorNormalMinY;
+    f32 ceilNormalMaxY;
 };
 
 extern struct LevelValues gLevelValues;

--- a/src/pc/lua/smlua_cobject_autogen.c
+++ b/src/pc/lua/smlua_cobject_autogen.c
@@ -1369,9 +1369,10 @@ static struct LuaObjectField sLakituStateFields[LUA_LAKITU_STATE_FIELD_COUNT] = 
     { "yaw",                              LVT_S16,     offsetof(struct LakituState, yaw),                              false, LOT_NONE,  1,  sizeof(s16)   },
 };
 
-#define LUA_LEVEL_VALUES_FIELD_COUNT 53
+#define LUA_LEVEL_VALUES_FIELD_COUNT 55
 static struct LuaObjectField sLevelValuesFields[LUA_LEVEL_VALUES_FIELD_COUNT] = {
     { "bubbleOnDeathBarrierInCapStages",  LVT_U8,      offsetof(struct LevelValues, bubbleOnDeathBarrierInCapStages),  false, LOT_NONE,          1, sizeof(u8)                   },
+    { "ceilNormalMaxY",                   LVT_F32,     offsetof(struct LevelValues, ceilNormalMaxY),                   false, LOT_NONE,          1, sizeof(f32)                  },
     { "cellHeightLimit",                  LVT_S16,     offsetof(struct LevelValues, cellHeightLimit),                  false, LOT_NONE,          1, sizeof(s16)                  },
     { "coinsRequiredForCoinStar",         LVT_S16,     offsetof(struct LevelValues, coinsRequiredForCoinStar),         false, LOT_NONE,          1, sizeof(s16)                  },
     { "disableActs",                      LVT_U8,      offsetof(struct LevelValues, disableActs),                      false, LOT_NONE,          1, sizeof(u8)                   },
@@ -1391,6 +1392,7 @@ static struct LuaObjectField sLevelValuesFields[LUA_LEVEL_VALUES_FIELD_COUNT] = 
     { "floorLowerLimit",                  LVT_S16,     offsetof(struct LevelValues, floorLowerLimit),                  false, LOT_NONE,          1, sizeof(s16)                  },
     { "floorLowerLimitMisc",              LVT_S16,     offsetof(struct LevelValues, floorLowerLimitMisc),              false, LOT_NONE,          1, sizeof(s16)                  },
     { "floorLowerLimitShadow",            LVT_S16,     offsetof(struct LevelValues, floorLowerLimitShadow),            false, LOT_NONE,          1, sizeof(s16)                  },
+    { "floorNormalMinY",                  LVT_F32,     offsetof(struct LevelValues, floorNormalMinY),                  false, LOT_NONE,          1, sizeof(f32)                  },
     { "hudCapTimer",                      LVT_U8,      offsetof(struct LevelValues, hudCapTimer),                      false, LOT_NONE,          1, sizeof(u8)                   },
     { "hudRedCoinsRadar",                 LVT_U8,      offsetof(struct LevelValues, hudRedCoinsRadar),                 false, LOT_NONE,          1, sizeof(u8)                   },
     { "hudSecretsRadar",                  LVT_U8,      offsetof(struct LevelValues, hudSecretsRadar),                  false, LOT_NONE,          1, sizeof(u8)                   },


### PR DESCRIPTION
There was a bug in resolving wall collisions with fixCollisionBugsRoundedCorners enabled.
Due to the way a check was written, it would often ignore walls when it shouldn't have.

I've also added gLevelValues.floorNormalMinY and gLevelValues.ceilNormalMaxY
These will values will be used to determine which surfaces will become a wall, floor, or ceiling