### PR TITLE
Add implicit string conversion to function params

### DIFF
--- a/src/pc/lua/smlua_utils.c
+++ b/src/pc/lua/smlua_utils.c
@@ -119,13 +119,20 @@ lua_Number smlua_to_number(lua_State* L, int index) {
 }
 
 const char* smlua_to_string(lua_State* L, int index) {
-    if (lua_type(L, index) != LUA_TSTRING) {
-        LOG_LUA_LINE("smlua_to_string received improper type '%s'", luaL_typename(L, index));
+    const char* str = luaL_tolstring(L, index, NULL);
+
+    if (!str) {
+        LOG_LUA_LINE("smlua_to_string failed to convert value of type '%s'", luaL_typename(L, index));
         gSmLuaConvertSuccess = false;
         return 0;
     }
+
     gSmLuaConvertSuccess = true;
-    return lua_tostring(L, index);
+
+    // Pop the string that luaL_tolstring pushed
+    lua_pop(L, 1);
+
+    return str;
 }
 
 LuaFunction smlua_to_lua_function(lua_State* L, int index) {


### PR DESCRIPTION
This updates ``smlua_to_string`` to align with Lua behavior, where many built-in Lua functions that receive string params implicitly convert values to strings (e.g. both ``print(1)`` and ``print("1")`` output ``1``)

Now code like the following works without requiring a tostring call:
```lua
local function mario_update(m)
    if m.playerIndex ~= 0 then return end

    djui_chat_message_create(m.forwardVel) -- No need to tostring it
end

hook_event(HOOK_MARIO_UPDATE, mario_update)
```

I don’t like having to call tostring every time i want to log something, so this change simplifies that. Lazy moment.