### PR TITLE
Remove 10 joystick limit in controller selection box

### DIFF
--- a/src/pc/djui/djui_panel_controls.c
+++ b/src/pc/djui/djui_panel_controls.c
@@ -45,9 +45,8 @@ void djui_panel_controls_create(struct DjuiBase* caller) {
 #ifdef HAVE_SDL2
         int numJoys = SDL_NumJoysticks();
         if (numJoys == 0) { numJoys = 1; }
-        if (numJoys > 10) { numJoys = 10; }
 
-        char* gamepadChoices[numJoys];
+        char** gamepadChoices = calloc(numJoys, sizeof(char *));
 
         // Get the names of all connected gamepads, if none is provided, use "Unknown"
         for (int i = 0; i < numJoys; i++) {
@@ -90,6 +89,8 @@ void djui_panel_controls_create(struct DjuiBase* caller) {
         for (int i = 0; i < numJoys; i++) {
             free(gamepadChoices[i]);
         }
+
+        free(gamepadChoices);
 #endif
 
         djui_slider_create(body, DLANG(CONTROLS, DEADZONE), &configStickDeadzone, 0, 100, djui_panel_controls_value_change);


### PR DESCRIPTION
When collecting the names of all connected gamepads, there is an arbitrary limit of 10 controllers to set as choices. 

This appears to be due to older builds using the index number instead of name, so you could have a single character printed. 

Since it has been updated to show the actual controller name, now, the limit does not need to exist. 

Additionally, there have been recent issues with certain 3rd party GC to USB adapters reporting 16 controllers, making some of the ports unusable with the 10 controller limit.

This change removes the use of the VLA for the gamepadChoices array, and instead has it heap allocated without the 10 controller limit.