### PR TITLE
Add chat scaling and opacity

### DIFF
--- a/lang/Dutch.ini
+++ b/lang/Dutch.ini
@@ -185,6 +185,11 @@ MARIO_THEME = "Mario"
 ODYSSEY_THEME = "Odyssey"
 FILE_SELECT_THEME = "Bestand selecteren"
 
+[CHAT_DISPLAY]
+TEXT_OPACITY = "Chat tekst doorzichtigheid"
+BACKGROUND_OPACITY = "Chat achtergrond doorzichtigheid"
+CHAT_SCALE = "Chat grootte"
+
 [DYNOS]
 DYNOS = "DYNOS"
 LOCAL_PLAYER_MODEL_ONLY = "Alleen lokaal spelermodel"

--- a/lang/English.ini
+++ b/lang/English.ini
@@ -185,6 +185,11 @@ MARIO_THEME = "Mario"
 ODYSSEY_THEME = "Odyssey"
 FILE_SELECT_THEME = "File Select"
 
+[CHAT_DISPLAY]
+TEXT_OPACITY = "Chat text opacity"
+BACKGROUND_OPACITY = "Chat background opacity"
+CHAT_SCALE = "Chat scale"
+
 [DYNOS]
 DYNOS = "DYNOS"
 LOCAL_PLAYER_MODEL_ONLY = "Local Player Model Only"

--- a/lang/French.ini
+++ b/lang/French.ini
@@ -185,6 +185,11 @@ MARIO_THEME = "Mario"
 ODYSSEY_THEME = "Odyssey"
 FILE_SELECT_THEME = "Sélection de fichier"
 
+[CHAT_DISPLAY]
+TEXT_OPACITY = "Opacité du texte du tchat"
+BACKGROUND_OPACITY = "Opacité du fond du tchat"
+CHAT_SCALE = "Échelle du tchat"
+
 [DYNOS]
 DYNOS = "DYNOS"
 LOCAL_PLAYER_MODEL_ONLY = "Modèle de joueur local seulement"

--- a/lang/Italian.ini
+++ b/lang/Italian.ini
@@ -183,6 +183,11 @@ MARIO_THEME = "Mario"
 ODYSSEY_THEME = "Odyssey"
 FILE_SELECT_THEME = "Selezione file"
 
+[CHAT_DISPLAY]
+TEXT_OPACITY = "Opacità testo della chat"
+BACKGROUND_OPACITY = "Opacità sfondo della chat"
+CHAT_SCALE = "Grandezza della chat"
+
 [DYNOS]
 DYNOS = "DYNOS"
 LOCAL_PLAYER_MODEL_ONLY = "Solo modello giocatore locale"

--- a/lang/Portuguese.ini
+++ b/lang/Portuguese.ini
@@ -185,6 +185,11 @@ MARIO_THEME = "Mario"
 ODYSSEY_THEME = "Odyssey"
 FILE_SELECT_THEME = "Seletor de Arquivo"
 
+[CHAT_DISPLAY]
+TEXT_OPACITY = "Opacidade de texto no chat"
+BACKGROUND_OPACITY = "Opacidade do fundo do chat"
+CHAT_SCALE = "Escala de chat"
+
 [DYNOS]
 DYNOS = "DYNOS"
 LOCAL_PLAYER_MODEL_ONLY = "Apenas modelo do jogador local"

--- a/lang/Spanish.ini
+++ b/lang/Spanish.ini
@@ -185,6 +185,11 @@ MARIO_THEME = "Mario"
 ODYSSEY_THEME = "Odyssey"
 FILE_SELECT_THEME = "Selección de archivo"
 
+[CHAT_DISPLAY]
+TEXT_OPACITY = "Opacidad del texto del chat"
+BACKGROUND_OPACITY = "Opacidad del fondo del chat"
+CHAT_SCALE = "Escala del chat"
+
 [DYNOS]
 DYNOS = "DYNOS"
 LOCAL_PLAYER_MODEL_ONLY = "Solo modelo de jugador local"

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -206,6 +206,9 @@ bool         configDjuiThemeCenter                = true;
 bool         configDjuiThemeGradients             = true;
 unsigned int configDjuiThemeFont                  = FONT_NORMAL;
 unsigned int configDjuiScale                      = 0;
+unsigned int configDjuiChatAlpha                  = 255;
+unsigned int configDjuiBaseAlpha                  = 127;
+unsigned int configDjuiChatSize                   = 100;
 // other
 unsigned int configRulesVersion                   = 0;
 bool         configCompressOnStartup              = false;
@@ -360,6 +363,9 @@ static const struct ConfigOption options[] = {
     {.name = "djui_theme_gradients",           .type = CONFIG_TYPE_BOOL,   .boolValue   = &configDjuiThemeGradients},
     {.name = "djui_theme_font",                .type = CONFIG_TYPE_UINT,   .uintValue   = &configDjuiThemeFont},
     {.name = "djui_scale",                     .type = CONFIG_TYPE_UINT,   .uintValue   = &configDjuiScale},
+    {.name = "djui_chat_alpha",                .type = CONFIG_TYPE_UINT,   .uintValue   = &configDjuiChatAlpha},
+    {.name = "djui_base_alpha",                .type = CONFIG_TYPE_UINT,   .uintValue   = &configDjuiBaseAlpha},
+    {.name = "djui_chat_size",                 .type = CONFIG_TYPE_UINT,   .uintValue   = &configDjuiChatSize},
     // other
     {.name = "rules_version",                  .type = CONFIG_TYPE_UINT,   .uintValue   = &configRulesVersion},
     {.name = "compress_on_startup",            .type = CONFIG_TYPE_BOOL,   .boolValue   = &configCompressOnStartup},
@@ -785,6 +791,10 @@ NEXT_OPTION:
 
     if (configDjuiTheme >= DJUI_THEME_MAX) { configDjuiTheme = 0; }
     if (configDjuiScale >= 5) { configDjuiScale = 0; }
+
+    if (configDjuiChatAlpha > 255) { configDjuiChatAlpha = 255; }
+    if (configDjuiBaseAlpha > 255) { configDjuiBaseAlpha = 255; }
+    if (configDjuiChatSize > 200) { configDjuiChatSize = 200; }
 
     if (gCLIOpts.fullscreen == 1) {
         configWindow.fullscreen = true;

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -160,6 +160,9 @@ extern bool         configDjuiThemeCenter;
 extern bool         configDjuiThemeGradients;
 extern unsigned int configDjuiThemeFont;
 extern unsigned int configDjuiScale;
+extern unsigned int configDjuiChatAlpha;
+extern unsigned int configDjuiBaseAlpha;
+extern unsigned int configDjuiChatSize;
 // other
 extern unsigned int configRulesVersion;
 extern bool         configCompressOnStartup;

--- a/src/pc/djui/djui_chat_message.c
+++ b/src/pc/djui/djui_chat_message.c
@@ -14,6 +14,7 @@
 static bool djui_chat_message_render(struct DjuiBase* base) {
     struct DjuiChatMessage* chatMessage = (struct DjuiChatMessage*)base;
     struct DjuiBase* ctBase = &chatMessage->message->base;
+    struct DjuiTheme* theme = gDjuiThemes[configDjuiTheme];
 
     f32 seconds = clock_elapsed() - chatMessage->createTime;
     f32 f = 1.0f;
@@ -24,15 +25,15 @@ static bool djui_chat_message_render(struct DjuiBase* base) {
     }
 
     if (gDjuiChatBoxFocus) {
-        djui_base_set_color(base, 0, 0, 0, 120);
-        djui_base_set_color(ctBase, 255, 255, 255, 255);
+        djui_base_set_color(base, theme->threePanels.rectColor.r, theme->threePanels.rectColor.g, theme->threePanels.rectColor.b, configDjuiBaseAlpha);
+        djui_base_set_color(ctBase, theme->interactables.textColor.r, theme->interactables.textColor.g, theme->interactables.textColor.b, configDjuiChatAlpha);
         djui_base_set_size_type(base, DJUI_SVT_RELATIVE, DJUI_SVT_ABSOLUTE);
         djui_base_set_size(base, 1.0f, chatMessage->base.height.value);
     } else if (f <= 0.1f) {
         return false;
     } else {
-        djui_base_set_color(base, 0, 0, 0, 180 * f);
-        djui_base_set_color(ctBase, 255, 255, 255, 255 * f);
+        djui_base_set_color(base, theme->threePanels.rectColor.r, theme->threePanels.rectColor.g, theme->threePanels.rectColor.b, configDjuiBaseAlpha * f);
+        djui_base_set_color(ctBase, theme->interactables.textColor.r, theme->interactables.textColor.g, theme->interactables.textColor.b, configDjuiChatAlpha * f);
         djui_base_set_size_type(base, DJUI_SVT_ABSOLUTE, DJUI_SVT_ABSOLUTE);
         djui_base_set_size(base, chatMessage->messageWidth, chatMessage->base.height.value);
     }
@@ -73,10 +74,11 @@ void djui_chat_message_create(const char* message) {
     if (gDjuiChatBox == NULL || gDjuiChatBox->chatFlow == NULL) { return; }
     struct DjuiChatMessage* chatMessage = calloc(1, sizeof(struct DjuiChatMessage));
     struct DjuiBase* base = &chatMessage->base;
+    f32 chatScale = (configDjuiChatSize * 0.01);
     djui_base_init(&gDjuiChatBox->chatFlow->base, base, djui_chat_message_render, djui_chat_message_destroy);
     djui_base_set_size_type(base, DJUI_SVT_RELATIVE, DJUI_SVT_ABSOLUTE);
-    djui_base_set_size(base, 1.0f, 0);
-    djui_base_set_color(base, 0, 0, 0, 64);
+    djui_base_set_size(base, chatScale, 0);
+    djui_base_set_color(base, 0, 0, 0, configDjuiBaseAlpha);
     djui_base_set_padding(base, 2, 4, 2, 4);
     djui_base_set_alignment(base, DJUI_HALIGN_LEFT, DJUI_VALIGN_BOTTOM);
 
@@ -86,15 +88,17 @@ void djui_chat_message_create(const char* message) {
     struct DjuiBase* ctBase = &chatText->base;
     djui_base_set_size_type(ctBase, DJUI_SVT_ABSOLUTE, DJUI_SVT_RELATIVE);
     djui_base_set_size(ctBase, maxTextWidth, 1.0f);
-    djui_base_set_color(ctBase, 255, 255, 255, 255);
     djui_base_set_location(ctBase, 0, 0);
     djui_text_set_alignment(chatText, DJUI_HALIGN_LEFT, DJUI_VALIGN_TOP);
+    djui_base_set_color(&chatText->base, 255, 255, 255, configDjuiChatAlpha);
+
     chatMessage->message = chatText;
+    chatText->fontScale *= chatScale;
     chatMessage->createTime = clock_elapsed();
 
     // figure out chat message height
     chatText->base.comp.width = maxTextWidth;
-    f32 messageHeight = djui_text_count_lines(chatText, 10) * (chatText->font->lineHeight * chatText->font->defaultFontScale) + 8;
+    f32 messageHeight = djui_text_count_lines(chatText, 10) * (chatText->font->lineHeight * chatText->font->defaultFontScale * chatScale) + 8 * chatScale;
     djui_base_set_size(base, 1.0f, messageHeight);
     gDjuiChatBox->chatFlow->base.height.value += messageHeight + gDjuiChatBox->chatFlow->margin.value;
     if (!gDjuiChatBox->scrolling) {

--- a/src/pc/djui/djui_panel_menu_options.c
+++ b/src/pc/djui/djui_panel_menu_options.c
@@ -142,6 +142,10 @@ void djui_panel_main_menu_create(struct DjuiBase* caller) {
         char* djuiFontChoices[2] = {DLANG(DJUI_THEMES, FONT_NORMAL), DLANG(DJUI_THEMES, FONT_ALIASED)};
         djui_selectionbox_create(body, DLANG(DJUI_THEMES, DJUI_FONT), djuiFontChoices, 2, &configDjuiThemeFont, djui_panel_menu_options_djui_setting_change);
 
+        djui_slider_create(body, DLANG(CHAT_DISPLAY, TEXT_OPACITY), &configDjuiChatAlpha, 0, 255, NULL);
+        djui_slider_create(body, DLANG(CHAT_DISPLAY, BACKGROUND_OPACITY), &configDjuiBaseAlpha, 0, 255, NULL);
+        djui_slider_create(body, DLANG(CHAT_DISPLAY, CHAT_SCALE), &configDjuiChatSize, 0, 200, NULL);
+
         if (gDjuiInMainMenu) {
             // copy sound choices from gMainMenuSounds
             int numSounds = sizeof(gMainMenuSounds) / sizeof(gMainMenuSounds[0]);


### PR DESCRIPTION
This adds a way to change the chat opacity and its scaling
While i was at it i also made the chat support the djui themes

Languages are a work in progress so it would be appreciated if people speaking a supported language could help me complete this setting, if nobody answers hopefully using a translator will be enough (so i got English, French, Spanish, Italian, Dutch and Portuguese)

https://github.com/user-attachments/assets/a9a463b3-4e8c-4780-83c2-3dad80a261d6

