### PR TITLE
Fix warping from one custom level to another

### DIFF
--- a/data/dynos_level.cpp
+++ b/data/dynos_level.cpp
@@ -381,7 +381,7 @@ void DynOS_Level_ParseScript(const void *aScript, s32 (*aPreprocessFunction)(u8,
 // Level Script Utilities
 //
 
-static s32 mCustomLevelSlot[2] = { 0 };
+static s32 mCustomLevelSlot[LEVEL_UNKNOWN_2 + 1] = { 0 };
 
 s16 *DynOS_Level_GetWarp(s32 aLevel, s32 aArea, s8 aWarpId) {
     if (aLevel >= CUSTOM_LEVEL_NUM_START) {
@@ -401,16 +401,19 @@ s16 *DynOS_Level_GetWarp(s32 aLevel, s32 aArea, s8 aWarpId) {
         // custom level to another.
 
         // Check if we're warping to a level we've already loaded into a slot
-        if (mCustomLevelSlot[0] == aLevel) {
+        if (mCustomLevelSlot[LEVEL_UNKNOWN_1] == aLevel) {
             sDynosCurrentLevelNum = LEVEL_UNKNOWN_1;
-        } else if (mCustomLevelSlot[1] == aLevel) {
+        } else if (mCustomLevelSlot[LEVEL_UNKNOWN_2] == aLevel) {
             sDynosCurrentLevelNum = LEVEL_UNKNOWN_2;
         } else {
-            // If we haven't loaded this level, use a slot that is no longer used.
-            sDynosCurrentLevelNum = (mCustomLevelSlot[0] == gCurrLevelNum) ? LEVEL_UNKNOWN_2 : LEVEL_UNKNOWN_1;
+            // Pick the unused slot
+            s32 unusedSlot = (mCustomLevelSlot[LEVEL_UNKNOWN_1] == gCurrLevelNum) ? LEVEL_UNKNOWN_2 : LEVEL_UNKNOWN_1;
+
+            // Assign it to dynos
+            sDynosCurrentLevelNum = unusedSlot;
 
             // Remember that the custom level is loaded into the slot
-            mCustomLevelSlot[sDynosCurrentLevelNum - LEVEL_UNKNOWN_1] = aLevel;
+            mCustomLevelSlot[sDynosCurrentLevelNum] = aLevel;
 
             // Clear cached level warps from the slot to be loaded
             sDynosLevelWarps[sDynosCurrentLevelNum].Clear();

--- a/data/dynos_level.cpp
+++ b/data/dynos_level.cpp
@@ -410,6 +410,7 @@ s16 *DynOS_Level_GetWarp(s32 aLevel, s32 aArea, s8 aWarpId) {
             // used. And then parse the script into the slot.
             sDynosCurrentLevelNum = (mCustomLevelSlot[0] == gCurrLevelNum) ? 2 : 1;
             mCustomLevelSlot[sDynosCurrentLevelNum-1] = aLevel;
+            sDynosLevelWarps[sDynosCurrentLevelNum].Clear();
             DynOS_Level_ParseScript(info->script, DynOS_Level_PreprocessScript);
         }
 

--- a/data/dynos_level.cpp
+++ b/data/dynos_level.cpp
@@ -402,15 +402,20 @@ s16 *DynOS_Level_GetWarp(s32 aLevel, s32 aArea, s8 aWarpId) {
 
         // Check if we're warping to a level we've already loaded into a slot
         if (mCustomLevelSlot[0] == aLevel) {
-            sDynosCurrentLevelNum = 1;
+            sDynosCurrentLevelNum = LEVEL_UNKNOWN_1;
         } else if (mCustomLevelSlot[1] == aLevel) {
-            sDynosCurrentLevelNum = 2;
+            sDynosCurrentLevelNum = LEVEL_UNKNOWN_2;
         } else {
-            // If we haven't loaded this level, use a slot that is no longer
-            // used. And then parse the script into the slot.
-            sDynosCurrentLevelNum = (mCustomLevelSlot[0] == gCurrLevelNum) ? 2 : 1;
-            mCustomLevelSlot[sDynosCurrentLevelNum-1] = aLevel;
+            // If we haven't loaded this level, use a slot that is no longer used.
+            sDynosCurrentLevelNum = (mCustomLevelSlot[0] == gCurrLevelNum) ? LEVEL_UNKNOWN_2 : LEVEL_UNKNOWN_1;
+
+            // Remember that the custom level is loaded into the slot
+            mCustomLevelSlot[sDynosCurrentLevelNum - LEVEL_UNKNOWN_1] = aLevel;
+
+            // Clear cached level warps from the slot to be loaded
             sDynosLevelWarps[sDynosCurrentLevelNum].Clear();
+
+            // Parse the custom level to fill in the level warps
             DynOS_Level_ParseScript(info->script, DynOS_Level_PreprocessScript);
         }
 


### PR DESCRIPTION
The explanation is in the code comments, but previously we only used one slot for custom levels. So when you warped from one to another it would override the current custom level's warp information with the one being loaded. Now we use two slots to avoid that.

> 
>         // This requires some explaination...
>         // It's a bit of a hack but it works.
> 
>         // DynOS's arrays for level information are LEVEL_MAX in size.
>         // LEVEL_MAX is based on the max number of vanilla levels.
> 
>         // So when we want to warp to a custom level we load the
>         // data into a slot that vanilla left unused.
> 
>         // We need two unused slots because we may warp from one
>         // custom level to another.
> 