### PR TITLE
Translation error fixed  Spanish.ini

### DIFF
--- a/lang/Spanish.ini
+++ b/lang/Spanish.ini
@@ -363,7 +363,7 @@ MOD_MENU_TITLE = "MENÚ DE MODS"
 
 [PLAYER]
 PLAYER_TITLE = "JUGADOR"
-OVERALLS = "Tirantes"
+OVERALLS = "Overol"
 SHIRT = "Camiseta"
 GLOVES = "Guantes"
 SHOES = "Zapatos"


### PR DESCRIPTION
Translation correction: "Tirantes" → "Overol"

The previous translation "tirantes" (suspenders/straps) was incorrect. Mario wears "overol" (overalls) - the complete garment consisting of pants with a bib front and suspenders. "Tirantes" refers only to the shoulder straps themselves, not the entire clothing item.