### PR TITLE
Fix buffer overruns in update checker's network-facing code.

### DIFF
--- a/src/pc/update_checker.c
+++ b/src/pc/update_checker.c
@@ -45,8 +45,10 @@ void parse_version(const char *data) {
     u8 len = strlen(VERSION_IDENTIFIER);
     version += len;
     const char *end = strchr(version, '"');
-    memcpy(sRemoteVersion, version, end - version);
-    sRemoteVersion[end - version] = '\0';
+    size_t version_length = (size_t)(end - version);
+    if (version_length > sizeof(sRemoteVersion) - 1) { return; }
+    memcpy(sRemoteVersion, version, version_length);
+    sRemoteVersion[version_length] = '\0';
 }
 
 // function to download a text file from the internet

--- a/src/pc/update_checker.c
+++ b/src/pc/update_checker.c
@@ -76,9 +76,9 @@ void get_version_remote(void) {
     DWORD dwSize = sizeof(contentLength);
     HttpQueryInfo(hUrl, HTTP_QUERY_CONTENT_LENGTH | HTTP_QUERY_FLAG_NUMBER, &contentLength, &dwSize, NULL);
 
-    // read data from the URL
+    // read data from the URL, making room in the buffer for the null-terminator
     DWORD bytesRead;
-    if (!InternetReadFile(hUrl, buffer, sizeof(buffer), &bytesRead)) {
+    if (!InternetReadFile(hUrl, buffer, sizeof(buffer) - 1, &bytesRead)) {
         printf("Failed to check for updates!\n");
         InternetCloseHandle(hInternet);
         InternetCloseHandle(hUrl);


### PR DESCRIPTION
There are two buffer overruns in the update checker's network-facing code.

The first one is specific to Windows.  If the read version.h data is exactly 255 bytes long, the null-terminator will overrun the stack buffer by one byte.

The second one is in parse_version(), where there are zero checks on whether data can fit in sRemoteVersion.  For Windows, data can be up to 255 bytes long, and for everyone else it can be up to 200 bytes long due to the way libcurl seems to parse data in 200 byte chunks.

In theory, the second overrun can be combined with a malicious DNS server to overwrite arbitrary data after sRemoteVersion with whatever an attacker may want, which could be a very dangerous security vulnerability.  However, due to the previously mentioned limits on the length of the data, it's unlikely to have much of an effect.  From my experience, I wasn't able to overwrite any important variables, but it still should be fixed.