### PR TITLE
revise better frame pacing

### DIFF
--- a/.github/workflows/build-coop.yaml
+++ b/.github/workflows/build-coop.yaml
@@ -101,7 +101,7 @@ jobs:
                     zip
 
             - name: Build the game
-              run: make -j$(nproc)
+              run: make -j$(nproc) DEBUG=1
 
             - name: Generate hash
               run: |

--- a/.github/workflows/build-coop.yaml
+++ b/.github/workflows/build-coop.yaml
@@ -101,7 +101,7 @@ jobs:
                     zip
 
             - name: Build the game
-              run: make -j$(nproc) DEBUG=1
+              run: make -j$(nproc)
 
             - name: Generate hash
               run: |

--- a/src/pc/djui/djui.c
+++ b/src/pc/djui/djui.c
@@ -71,14 +71,21 @@ void patch_djui_before(void) {
 }
 
 void patch_djui_interpolated(UNUSED f32 delta) {
-    // reset the head and re-render DJUI
-    if (delta >= 0.5f && !sDjuiRendered60fps && (gDjuiInMainMenu || gDjuiPanelPauseCreated)) {
+    extern f32 gFramePercentage;
+    if (gFramePercentage >= 0.5f && !sDjuiRendered60fps && (gDjuiInMainMenu || gDjuiPanelPauseCreated)) {
+        // reset the head and re-render DJUI
         sDjuiRendered60fps = true;
         if (sSavedDisplayListHead == NULL) { return; }
         gDisplayListHead = sSavedDisplayListHead;
         djui_render();
         gDPFullSync(gDisplayListHead++);
         gSPEndDisplayList(gDisplayListHead++);
+    } else {
+        // patch the display list instead of a full re-render
+        // to make some elements on screen be smooth, while keeping things cheap.
+        Gfx* displayListHead = gDisplayListHead;
+        djui_cursor_interp();
+        gDisplayListHead = displayListHead;
     }
 }
 

--- a/src/pc/djui/djui.c
+++ b/src/pc/djui/djui.c
@@ -68,24 +68,28 @@ void djui_shutdown(void) {
 
 void patch_djui_before(void) {
     sDjuiRendered60fps = false;
+    sSavedDisplayListHead = NULL;
+    djui_cursor_interp_before();
 }
 
 void patch_djui_interpolated(UNUSED f32 delta) {
     extern f32 gFramePercentage;
-    if (gFramePercentage >= 0.5f && !sDjuiRendered60fps && (gDjuiInMainMenu || gDjuiPanelPauseCreated)) {
-        // reset the head and re-render DJUI
-        sDjuiRendered60fps = true;
-        if (sSavedDisplayListHead == NULL) { return; }
-        gDisplayListHead = sSavedDisplayListHead;
-        djui_render();
-        gDPFullSync(gDisplayListHead++);
-        gSPEndDisplayList(gDisplayListHead++);
-    } else {
-        // patch the display list instead of a full re-render
-        // to make some elements on screen be smooth, while keeping things cheap.
-        Gfx* displayListHead = gDisplayListHead;
-        djui_cursor_interp();
-        gDisplayListHead = displayListHead;
+    if (gDjuiInMainMenu || gDjuiPanelPauseCreated) {
+        if (gFramePercentage >= 0.5f && !sDjuiRendered60fps) {
+            // reset the head and re-render DJUI
+            sDjuiRendered60fps = true;
+            if (sSavedDisplayListHead == NULL) { return; }
+            gDisplayListHead = sSavedDisplayListHead;
+            djui_render();
+            gDPFullSync(gDisplayListHead++);
+            gSPEndDisplayList(gDisplayListHead++);
+        } else {
+            // patch the display list instead of a full re-render
+            // to make some elements on screen be smooth, while keeping things cheap.
+            Gfx* displayListHead = gDisplayListHead;
+            djui_cursor_interp();
+            gDisplayListHead = displayListHead;
+        }
     }
 }
 

--- a/src/pc/djui/djui_cursor.c
+++ b/src/pc/djui/djui_cursor.c
@@ -17,6 +17,10 @@ static f32 sSavedMouseY = 0;
 f32 gCursorX = 0;
 f32 gCursorY = 0;
 
+static f32 sPrevCursorX = 0;
+static f32 sPrevCursorY = 0;
+static Gfx* sSavedDisplayListHead = NULL;
+
 void djui_cursor_set_visible(bool visible) {
     if (sMouseCursor) {
         djui_base_set_visible(&sMouseCursor->base, visible);
@@ -111,7 +115,9 @@ void djui_cursor_move(s8 xDir, s8 yDir) {
     }
 }
 
-void djui_cursor_update(void) {
+static void djui_cursor_update_position(void) {
+    sPrevCursorX = gCursorX;
+    sPrevCursorY = gCursorY;
 #if defined(CAPI_SDL2) || defined(CAPI_SDL1)
     if (djui_interactable_is_binding()) { return; }
     if (sMouseCursor == NULL) { return; }
@@ -152,6 +158,20 @@ void djui_cursor_update(void) {
         djui_image_set_image(sMouseCursor, gd_texture_hand_open, 32, 32, 16);
     }
 #endif
+}
+
+void djui_cursor_interp(void) {
+    djui_cursor_update_position();
+    if (sPrevCursorX != gCursorX || sPrevCursorY != gCursorY) {
+        if (sSavedDisplayListHead == NULL) { return; }
+        gDisplayListHead = sSavedDisplayListHead;
+        djui_base_render(&sMouseCursor->base);
+    }
+}
+
+void djui_cursor_update(void) {
+    djui_cursor_update_position();
+    sSavedDisplayListHead = gDisplayListHead;
     djui_base_render(&sMouseCursor->base);
 }
 

--- a/src/pc/djui/djui_cursor.c
+++ b/src/pc/djui/djui_cursor.c
@@ -20,6 +20,7 @@ f32 gCursorY = 0;
 static f32 sPrevCursorX = 0;
 static f32 sPrevCursorY = 0;
 static Gfx* sSavedDisplayListHead = NULL;
+static bool sInterpCursor = false;
 
 void djui_cursor_set_visible(bool visible) {
     if (sMouseCursor) {
@@ -160,9 +161,14 @@ static void djui_cursor_update_position(void) {
 #endif
 }
 
+void djui_cursor_interp_before(void) {
+    sSavedDisplayListHead = NULL;
+    sInterpCursor = false;
+}
+
 void djui_cursor_interp(void) {
     djui_cursor_update_position();
-    if (sPrevCursorX != gCursorX || sPrevCursorY != gCursorY) {
+    if (sInterpCursor && (sPrevCursorX != gCursorX || sPrevCursorY != gCursorY)) {
         if (sSavedDisplayListHead == NULL) { return; }
         gDisplayListHead = sSavedDisplayListHead;
         djui_base_render(&sMouseCursor->base);
@@ -173,6 +179,7 @@ void djui_cursor_update(void) {
     djui_cursor_update_position();
     sSavedDisplayListHead = gDisplayListHead;
     djui_base_render(&sMouseCursor->base);
+    sInterpCursor = gDisplayListHead != sSavedDisplayListHead; // Check that we actually rendered something
 }
 
 void djui_cursor_create(void) {

--- a/src/pc/djui/djui_cursor.h
+++ b/src/pc/djui/djui_cursor.h
@@ -9,5 +9,6 @@ void djui_cursor_set_visible(bool visible);
 bool djui_cursor_inside_base(struct DjuiBase* base);
 void djui_cursor_input_controlled_center(struct DjuiBase* base);
 void djui_cursor_move(s8 xDir, s8 yDir);
+void djui_cursor_interp(void);
 void djui_cursor_update(void);
 void djui_cursor_create(void);

--- a/src/pc/djui/djui_cursor.h
+++ b/src/pc/djui/djui_cursor.h
@@ -9,6 +9,7 @@ void djui_cursor_set_visible(bool visible);
 bool djui_cursor_inside_base(struct DjuiBase* base);
 void djui_cursor_input_controlled_center(struct DjuiBase* base);
 void djui_cursor_move(s8 xDir, s8 yDir);
+void djui_cursor_interp_before(void);
 void djui_cursor_interp(void);
 void djui_cursor_update(void);
 void djui_cursor_create(void);

--- a/src/pc/gfx/gfx_pc.c
+++ b/src/pc/gfx/gfx_pc.c
@@ -1970,16 +1970,24 @@ void gfx_run(Gfx *commands) {
     //double t0 = gfx_wapi->get_time();
     gfx_rapi->start_frame();
     gfx_run_dl(commands);
-    gfx_flush();
-    gfx_rapi->end_frame();
-    gfx_wapi->swap_buffers_begin();
 }
 
-void gfx_end_frame(void) {
+void gfx_end_frame_render(void) {
+    gfx_flush();
+    gfx_rapi->end_frame();
+}
+
+void gfx_display_frame(void) {
+    gfx_wapi->swap_buffers_begin();
     if (!dropped_frame) {
         gfx_rapi->finish_render();
         gfx_wapi->swap_buffers_end();
     }
+}
+
+void gfx_end_frame(void) {
+    gfx_end_frame_render();
+    gfx_display_frame();
 }
 
 void gfx_shutdown(void) {

--- a/src/pc/gfx/gfx_pc.h
+++ b/src/pc/gfx/gfx_pc.h
@@ -21,6 +21,8 @@ void gfx_init(struct GfxWindowManagerAPI *wapi, struct GfxRenderingAPI *rapi, co
 struct GfxRenderingAPI *gfx_get_current_rendering_api(void);
 void gfx_start_frame(void);
 void gfx_run(Gfx *commands);
+void gfx_end_frame_render(void);
+void gfx_display_frame(void);
 void gfx_end_frame(void);
 void gfx_shutdown(void);
 void gfx_pc_precomp_shader(uint32_t rgb1, uint32_t alpha1, uint32_t rgb2, uint32_t alpha2, uint32_t flags);

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -223,7 +223,6 @@ static u32 get_refresh_rate() {
 
 void produce_interpolation_frames_and_delay(void) {
     u32 refreshRate = get_refresh_rate();
-    bool is30Fps = (refreshRate == FRAMERATE);
 
     gRenderingInterpolated = true;
 

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -266,7 +266,6 @@ void produce_interpolation_frames_and_delay(void) {
 
         // send the frame to the screen (should be directly after the delay for good frame pacing)
         gfx_display_frame();
-        gfx_display_frame(); // ! for debugging purposes
         sDrawnFrames++;
         if (configFramerateMode != RRM_UNLIMITED) { numFramesToDraw--; }
     } while ((curTime = clock_elapsed_f64()) < targetTime && numFramesToDraw > 0);

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -266,6 +266,7 @@ void produce_interpolation_frames_and_delay(void) {
 
         // send the frame to the screen (should be directly after the delay for good frame pacing)
         gfx_display_frame();
+        gfx_display_frame(); // ! for debugging purposes
         sDrawnFrames++;
         if (configFramerateMode != RRM_UNLIMITED) { numFramesToDraw--; }
     } while ((curTime = clock_elapsed_f64()) < targetTime && numFramesToDraw > 0);

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -255,19 +255,19 @@ void produce_interpolation_frames_and_delay(void) {
 
         // delay if our framerate is capped
         if (configFramerateMode != RRM_UNLIMITED) {
+            expectedTime += (targetTime - curTime) / (f64) numFramesToDraw;
             f64 now = clock_elapsed_f64();
             f64 elapsedTime = now - loopStartTime;
-            expectedTime += (targetTime - curTime) / (f64) numFramesToDraw;
             f64 delay = (expectedTime - elapsedTime);
             if (delay > 0.0) {
                 precise_delay_f64(delay);
             }
-            numFramesToDraw--;
         }
 
         // send the frame to the screen (should be directly after the delay for good frame pacing)
         gfx_display_frame();
         sDrawnFrames++;
+        if (configFramerateMode != RRM_UNLIMITED) { numFramesToDraw--; }
     } while ((curTime = clock_elapsed_f64()) < targetTime && numFramesToDraw > 0);
 
     // compute and update the frame rate every second

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -210,7 +210,7 @@ static u32 get_refresh_rate() {
     static u32 refreshRate = 0;
     if (!refreshRate) {
         SDL_DisplayMode mode;
-        if (SDL_GetWindowDisplayMode(0, &mode) == 0) {
+        if (SDL_GetCurrentDisplayMode(0, &mode) == 0) {
             if (mode.refresh_rate > 0) { refreshRate = (u32) mode.refresh_rate; }
         } else {
             refreshRate = 60;


### PR DESCRIPTION
improved frame pacing, where frame delaying is done just before displaying the frame.
so, the frame is fully rendered, and then the delay is done to wait the extra time before displaying the frame.
This is a far more reliable and consistent way to manage frame pacing, and it will help to keep the framerate from choking too badly when the game lags a little. 

The changes to `gfx_end_frame` is to minimize the steps necessary between delaying and actually displaying the frame. This is an optimization just to increase the accuracy of frame pacing even further.

Also, delta calculation is improved when the number of frames to draw is known. 