### PR TITLE
Fix graph node interpolation

### DIFF
--- a/autogen/lua_definitions/structs.lua
+++ b/autogen/lua_definitions/structs.lua
@@ -969,15 +969,12 @@
 --- @class GraphNodeRotation
 --- @field public displayList Pointer_Gfx
 --- @field public node GraphNode
---- @field public prevRotation Vec3s
---- @field public prevTimestamp integer
 --- @field public rotation Vec3s
 
 --- @class GraphNodeScale
 --- @field public displayList Pointer_Gfx
 --- @field public node GraphNode
---- @field public prevScale number
---- @field public scale number
+--- @field public scale Vec3f
 
 --- @class GraphNodeShadow
 --- @field public node GraphNode

--- a/data/dynos_bin_geo.cpp
+++ b/data/dynos_bin_geo.cpp
@@ -312,6 +312,8 @@ static void ParseGeoSymbol(GfxData* aGfxData, DataNode<GeoLayout>* aNode, GeoLay
     geo_symbol_5(GEO_HELD_OBJECT, 2);
     geo_symbol_2(GEO_SCALE, 0);
     geo_symbol_3(GEO_SCALE_WITH_DL, 2);
+    geo_symbol_4(GEO_SCALE_XYZ, 0);
+    geo_symbol_5(GEO_SCALE_XYZ_WITH_DL, 4);
     geo_symbol_0(GEO_NOP_1E);
     geo_symbol_0(GEO_NOP_1F);
     geo_symbol_1(GEO_CULLING_RADIUS, 0);

--- a/data/dynos_cmap.cpp
+++ b/data/dynos_cmap.cpp
@@ -135,8 +135,8 @@ private:
 };
 
 extern "C" {
-void* hmap_create(MapType type) {
-    return new HMap(type);
+void* hmap_create(bool useUnordered) {
+    return new HMap(useUnordered ? MapType::Unordered : MapType::Ordered);
 }
 
 void* hmap_get(void* map, int64_t key) {

--- a/docs/lua/structs.md
+++ b/docs/lua/structs.md
@@ -1477,8 +1477,6 @@
 | ----- | ---- | ------ |
 | displayList | `Pointer` <`Gfx`> |  |
 | node | [GraphNode](structs.md#GraphNode) | read-only |
-| prevRotation | [Vec3s](structs.md#Vec3s) | read-only |
-| prevTimestamp | `integer` |  |
 | rotation | [Vec3s](structs.md#Vec3s) | read-only |
 
 [:arrow_up_small:](#)
@@ -1491,8 +1489,7 @@
 | ----- | ---- | ------ |
 | displayList | `Pointer` <`Gfx`> |  |
 | node | [GraphNode](structs.md#GraphNode) | read-only |
-| prevScale | `number` |  |
-| scale | `number` |  |
+| scale | [Vec3f](structs.md#Vec3f) | read-only |
 
 [:arrow_up_small:](#)
 

--- a/include/geo_commands.h
+++ b/include/geo_commands.h
@@ -408,6 +408,30 @@ enum SkyBackgroundParams {
     CMD_PTR(displayList)
 
 /**
+ * 0x1D: Create scale scene graph node with optional display list
+ *   0x01: u8 params
+ *     0b1000_0000: if set, enable displayList field and drawingLayer
+ *     0b0100_0000: if set, enable scale XYZ
+ *     0b0000_1111: drawingLayer
+ *   0x02-0x03: unused
+ *   0x04: u32 scale X (0x10000 = 1.0)
+ *   0x08: u32 scale Y (0x10000 = 1.0)
+ *   0x0C: u32 scale Z (0x10000 = 1.0)
+ *   0x10: [u32 displayList: if MSbit bit of params is set, display list segment address]
+ */
+#define GEO_SCALE_XYZ(layer, sx, sy, sz) \
+    CMD_BBH(0x1D, (layer | 0x40), 0x0000), \
+    CMD_W(sx), \
+    CMD_W(sy), \
+    CMD_W(sz)
+#define GEO_SCALE_XYZ_WITH_DL(layer, sx, sy, sz, displayList) \
+    CMD_BBH(0x1D, (layer | 0xC0), 0x0000), \
+    CMD_W(sx), \
+    CMD_W(sy), \
+    CMD_W(sz), \
+    CMD_PTR(displayList)
+
+/**
  * 0x1E: No operation
  */
 #define GEO_NOP_1E() \

--- a/src/engine/geo_layout.c
+++ b/src/engine/geo_layout.c
@@ -535,29 +535,42 @@ void geo_layout_cmd_node_rotation(void) {
   0x1D: Create scale scene graph node with optional display list
    cmd+0x01: u8 params
      (params & 0x80): if set, enable displayList field and drawingLayer
+     (params & 0x40): if set, enable scale XYZ
      (params & 0x0F): drawingLayer
    cmd+0x04: u32 scale (0x10000 = 1.0)
-  [cmd+0x08: void *displayList]
+     or
+   cmd+0x04: u32 scale X (0x10000 = 1.0)
+   cmd+0x08: u32 scale Y (0x10000 = 1.0)
+   cmd+0x0C: u32 scale Z (0x10000 = 1.0)
+  [cmd+0x08/0x10: void *displayList]
 */
 void geo_layout_cmd_node_scale(void) {
     struct GraphNodeScale *graphNode;
 
     s16 drawingLayer = 0;
     s16 params = cur_geo_cmd_u8(0x01);
-    f32 scale = cur_geo_cmd_u32(0x04) / 65536.0f;
+    Vec3f scale;
     void *displayList = NULL;
 
+    if (params & 0x40) {
+        scale[0] = cur_geo_cmd_u32(0x04) / 65536.0f;
+        scale[1] = cur_geo_cmd_u32(0x08) / 65536.0f;
+        scale[2] = cur_geo_cmd_u32(0x0C) / 65536.0f;
+        gGeoLayoutCommand += 0x10 << CMD_SIZE_SHIFT;
+    } else {
+        scale[0] = scale[1] = scale[2] = cur_geo_cmd_u32(0x04) / 65536.0f;
+        gGeoLayoutCommand += 0x08 << CMD_SIZE_SHIFT;
+    }
+
     if (params & 0x80) {
-        displayList = cur_geo_cmd_ptr(0x08);
+        displayList = cur_geo_cmd_ptr(0x00);
         drawingLayer = params & 0x0F;
-        gGeoLayoutCommand += 4 << CMD_SIZE_SHIFT;
+        gGeoLayoutCommand += 0x04 << CMD_SIZE_SHIFT;
     }
 
     graphNode = init_graph_node_scale(gGraphNodePool, NULL, drawingLayer, displayList, scale);
 
     register_scene_graph_node(&graphNode->node);
-
-    gGeoLayoutCommand += 0x08 << CMD_SIZE_SHIFT;
 }
 
 // 0x1E: No operation

--- a/src/engine/graph_node.c
+++ b/src/engine/graph_node.c
@@ -282,7 +282,7 @@ struct GraphNodeRotation *init_graph_node_rotation(struct DynamicPool *pool,
  */
 struct GraphNodeScale *init_graph_node_scale(struct DynamicPool *pool,
                                              struct GraphNodeScale *graphNode, s32 drawingLayer,
-                                             void *displayList, f32 scale) {
+                                             void *displayList, Vec3f scale) {
     if (pool != NULL) {
         graphNode = dynamic_pool_alloc(pool, sizeof(struct GraphNodeScale));
     }
@@ -290,8 +290,7 @@ struct GraphNodeScale *init_graph_node_scale(struct DynamicPool *pool,
     if (graphNode != NULL) {
         init_scene_graph_node_links(&graphNode->node, GRAPH_NODE_TYPE_SCALE);
         graphNode->node.flags = (drawingLayer << 8) | (graphNode->node.flags & 0xFF);
-        graphNode->scale = scale;
-        graphNode->prevScale = scale;
+        vec3f_copy(graphNode->scale, scale);
         graphNode->displayList = dynos_gfx_get_writable_display_list(displayList);
     }
 

--- a/src/engine/graph_node.h
+++ b/src/engine/graph_node.h
@@ -241,8 +241,6 @@ struct GraphNodeRotation
     /*0x00*/ struct GraphNode node;
     /*0x14*/ Gfx *displayList;
     /*0x18*/ Vec3s rotation;
-    Vec3s prevRotation;
-    u32 prevTimestamp;
 };
 
 /** GraphNode part that transforms itself and its children based on animation
@@ -292,8 +290,7 @@ struct GraphNodeScale
 {
     /*0x00*/ struct GraphNode node;
     /*0x14*/ Gfx *displayList;
-    /*0x18*/ f32 scale;
-    /*????*/ f32 prevScale;
+    /*0x18*/ Vec3f scale;
 };
 
 /** GraphNode that draws a shadow under an object.
@@ -402,7 +399,7 @@ struct GraphNodeTranslation *init_graph_node_translation(struct DynamicPool *poo
 struct GraphNodeRotation *init_graph_node_rotation(struct DynamicPool *pool, struct GraphNodeRotation *graphNode,
                                                    s32 drawingLayer, void *displayList, Vec3s rotation);
 struct GraphNodeScale *init_graph_node_scale(struct DynamicPool *pool, struct GraphNodeScale *graphNode,
-                                             s32 drawingLayer, void *displayList, f32 scale);
+                                             s32 drawingLayer, void *displayList, Vec3f scale);
 struct GraphNodeObject *init_graph_node_object(struct DynamicPool *pool, struct GraphNodeObject *graphNode,
                                                struct GraphNode *sharedChild, Vec3f pos, Vec3s angle, Vec3f scale);
 struct GraphNodeCullingRadius *init_graph_node_culling_radius(struct DynamicPool *pool, struct GraphNodeCullingRadius *graphNode, s16 radius);

--- a/src/engine/level_script.c
+++ b/src/engine/level_script.c
@@ -495,7 +495,8 @@ static void level_cmd_23(void) {
     // GraphNodeScale has a GraphNode at the top. This
     // is being stored to the array, so cast the pointer.
     u32 id = model;
-    dynos_model_store_geo(&id, MODEL_POOL_LEVEL, arg1, (struct GraphNode*)init_graph_node_scale(gLevelPool, 0, arg0H, arg1, arg2.f));
+    Vec3f scale = { arg2.f, arg2.f, arg2.f };
+    dynos_model_store_geo(&id, MODEL_POOL_LEVEL, arg1, (struct GraphNode*)init_graph_node_scale(gLevelPool, 0, arg0H, arg1, scale));
 
     sCurrentCmd = CMD_NEXT;
 }

--- a/src/game/area.c
+++ b/src/game/area.c
@@ -253,6 +253,7 @@ void clear_areas(void) {
     }
 
     le_clear();
+    geo_clear_interp_data();
 }
 
 void clear_area_graph_nodes(void) {
@@ -311,6 +312,7 @@ void unload_area(void) {
     }
 
     le_clear();
+    geo_clear_interp_data();
 }
 
 void load_mario_area(void) {

--- a/src/game/behaviors/bowser_key_cutscene.inc.c
+++ b/src/game/behaviors/bowser_key_cutscene.inc.c
@@ -4,7 +4,8 @@ Gfx *geo_scale_bowser_key(s32 run, struct GraphNode *node, UNUSED f32 mtx[4][4])
     struct Object *sp4;
     if (run == TRUE) {
         sp4 = (struct Object *) gCurGraphNodeObject;
-        ((struct GraphNodeScale *) node->next)->scale = sp4->oBowserKeyScale;
+        f32 scale = sp4->oBowserKeyScale;
+        vec3f_set(((struct GraphNodeScale *) node->next)->scale, scale, scale, scale);
     }
     return 0;
 }

--- a/src/game/behaviors/snufit.inc.c
+++ b/src/game/behaviors/snufit.inc.c
@@ -60,7 +60,8 @@ Gfx *geo_snufit_scale_body(s32 callContext, struct GraphNode *node, UNUSED Mat4 
         obj = (struct Object *) gCurGraphNodeObject;
         scaleNode = (struct GraphNodeScale *) node->next;
 
-        scaleNode->scale = obj->oSnufitBodyScale / 1000.0f;
+        f32 scale = obj->oSnufitBodyScale / 1000.0f;
+        vec3f_set(scaleNode->scale, scale, scale, scale);
     }
 
     return NULL;

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -12,6 +12,7 @@
 #include "main.h"
 #include "engine/math_util.h"
 #include "engine/graph_node.h"
+#include "rendering_graph_node.h"
 #include "area.h"
 #include "save_file.h"
 #include "sound_init.h"
@@ -1749,6 +1750,7 @@ s32 update_level(void) {
 
 s32 init_level(void) {
     sync_objects_clear();
+    geo_clear_interp_data();
     reset_dialog_render_state();
 
     s32 val4 = 0;

--- a/src/game/mario_misc.c
+++ b/src/game/mario_misc.c
@@ -460,11 +460,6 @@ Gfx* geo_mario_tilt_torso(s32 callContext, struct GraphNode* node, Mat4* mtx) {
         rotNode->rotation[0] = bodyState->torsoAngle[1] * character->torsoRotMult;
         rotNode->rotation[1] = bodyState->torsoAngle[2] * character->torsoRotMult;
         rotNode->rotation[2] = bodyState->torsoAngle[0] * character->torsoRotMult;
-        if (plrIdx != 0) {
-            // only interpolate angles for the local player
-            vec3s_copy(rotNode->prevRotation, rotNode->rotation);
-            rotNode->prevTimestamp = gGlobalTimer;
-        }
         // update torso position in bodyState
         get_pos_from_transform_mtx(bodyState->torsoPos, *curTransform, *gCurGraphNodeCamera->matrixPtr);
         bodyState->updateTorsoTime = gGlobalTimer;
@@ -500,12 +495,6 @@ Gfx* geo_mario_head_rotation(s32 callContext, struct GraphNode* node, Mat4* c) {
         } else {
             vec3s_set(bodyState->headAngle, 0, 0, 0);
             vec3s_set(rotNode->rotation, 0, 0, 0);
-        }
-
-        if (plrIdx != 0) {
-            // only interpolate angles for the local player
-            vec3s_copy(rotNode->prevRotation, rotNode->rotation);
-            rotNode->prevTimestamp = gGlobalTimer;
         }
 
         // update head position in bodyState
@@ -560,15 +549,14 @@ Gfx* geo_mario_hand_foot_scaler(s32 callContext, struct GraphNode* node, UNUSED 
     struct MarioBodyState* bodyState = geo_get_body_state();
 
     if (callContext == GEO_CONTEXT_RENDER) {
-        scaleNode->scale = 1.0f;
+        vec3f_copy(scaleNode->scale, gVec3fOne);
         if (asGenerated->parameter == bodyState->punchState >> 6) {
             if (sMarioAttackAnimCounter[index] != gAreaUpdateCounter && (bodyState->punchState & 0x3F) > 0) {
                 bodyState->punchState -= 1;
                 sMarioAttackAnimCounter[index] = gAreaUpdateCounter;
             }
-            scaleNode->scale =
-                gMarioAttackScaleAnimation[asGenerated->parameter * 6 + (bodyState->punchState & 0x3F)]
-                / 10.0f;
+            f32 scale = gMarioAttackScaleAnimation[asGenerated->parameter * 6 + (bodyState->punchState & 0x3F)] / 10.0f;
+            vec3f_set(scaleNode->scale, scale, scale, scale);
         }
     }
     return NULL;

--- a/src/game/object_list_processor.c
+++ b/src/game/object_list_processor.c
@@ -19,6 +19,7 @@
 #include "obj_behaviors.h"
 #include "platform_displacement.h"
 #include "profiler.h"
+#include "rendering_graph_node.h"
 #include "spawn_object.h"
 #include "first_person_cam.h"
 #include "engine/math_util.h"
@@ -624,6 +625,7 @@ void clear_objects(void) {
     gObjectLists = gObjectListArray;
 
     clear_dynamic_surfaces();
+    geo_clear_interp_data();
 }
 
 /**

--- a/src/game/rendering_graph_node.h
+++ b/src/game/rendering_graph_node.h
@@ -43,6 +43,7 @@ extern f32 gOverrideFar;
 
 void geo_process_node_and_siblings(struct GraphNode *firstNode);
 void geo_process_root(struct GraphNodeRoot *node, Vp *b, Vp *c, s32 clearColor);
+void geo_clear_interp_data();
 
 struct ShadowInterp {
     Gfx*  gfx;

--- a/src/pc/lua/smlua_cobject_autogen.c
+++ b/src/pc/lua/smlua_cobject_autogen.c
@@ -1248,21 +1248,18 @@ static struct LuaObjectField sGraphNodeRootFields[LUA_GRAPH_NODE_ROOT_FIELD_COUN
     { "y",         LVT_S16,     offsetof(struct GraphNodeRoot, y),         false, LOT_NONE,      1, sizeof(s16)              },
 };
 
-#define LUA_GRAPH_NODE_ROTATION_FIELD_COUNT 5
+#define LUA_GRAPH_NODE_ROTATION_FIELD_COUNT 3
 static struct LuaObjectField sGraphNodeRotationFields[LUA_GRAPH_NODE_ROTATION_FIELD_COUNT] = {
-    { "displayList",   LVT_COBJECT_P, offsetof(struct GraphNodeRotation, displayList),   false, LOT_GFX,       1, sizeof(Gfx*)             },
-    { "node",          LVT_COBJECT,   offsetof(struct GraphNodeRotation, node),          true,  LOT_GRAPHNODE, 1, sizeof(struct GraphNode) },
-    { "prevRotation",  LVT_COBJECT,   offsetof(struct GraphNodeRotation, prevRotation),  true,  LOT_VEC3S,     1, sizeof(Vec3s)            },
-    { "prevTimestamp", LVT_U32,       offsetof(struct GraphNodeRotation, prevTimestamp), false, LOT_NONE,      1, sizeof(u32)              },
-    { "rotation",      LVT_COBJECT,   offsetof(struct GraphNodeRotation, rotation),      true,  LOT_VEC3S,     1, sizeof(Vec3s)            },
+    { "displayList", LVT_COBJECT_P, offsetof(struct GraphNodeRotation, displayList), false, LOT_GFX,       1, sizeof(Gfx*)             },
+    { "node",        LVT_COBJECT,   offsetof(struct GraphNodeRotation, node),        true,  LOT_GRAPHNODE, 1, sizeof(struct GraphNode) },
+    { "rotation",    LVT_COBJECT,   offsetof(struct GraphNodeRotation, rotation),    true,  LOT_VEC3S,     1, sizeof(Vec3s)            },
 };
 
-#define LUA_GRAPH_NODE_SCALE_FIELD_COUNT 4
+#define LUA_GRAPH_NODE_SCALE_FIELD_COUNT 3
 static struct LuaObjectField sGraphNodeScaleFields[LUA_GRAPH_NODE_SCALE_FIELD_COUNT] = {
     { "displayList", LVT_COBJECT_P, offsetof(struct GraphNodeScale, displayList), false, LOT_GFX,       1, sizeof(Gfx*)             },
     { "node",        LVT_COBJECT,   offsetof(struct GraphNodeScale, node),        true,  LOT_GRAPHNODE, 1, sizeof(struct GraphNode) },
-    { "prevScale",   LVT_F32,       offsetof(struct GraphNodeScale, prevScale),   false, LOT_NONE,      1, sizeof(f32)              },
-    { "scale",       LVT_F32,       offsetof(struct GraphNodeScale, scale),       false, LOT_NONE,      1, sizeof(f32)              },
+    { "scale",       LVT_COBJECT,   offsetof(struct GraphNodeScale, scale),       true,  LOT_VEC3F,     1, sizeof(Vec3f)            },
 };
 
 #define LUA_GRAPH_NODE_SHADOW_FIELD_COUNT 4


### PR DESCRIPTION
Shared graph nodes were incorrectly interpolated, only the first object with a shared graph node was interpolated properly.
Thanks to @Cooliokid956 for noticing that most of node types were **never** interpolated.

- Use a double hashmap to store interpolated data for each graph node and object. All translations, rotations and scales are now interpolated correctly.
- Extend `GraphNodeScale` scale to all 3 dimensions; Add `GEO_SCALE_XYZ` command.

Example with node type `GraphNodeTranslation`:
Before:

https://github.com/user-attachments/assets/c737b002-561b-4914-8481-94083f28841d

After:

https://github.com/user-attachments/assets/35214fa3-51ef-4d3c-affd-5900d127ea77
