### PR TITLE
Fixed the hud camera status not updating for freecam

### DIFF
--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -4171,6 +4171,15 @@ s32 update_camera_hud_status(struct Camera *c) {
     if (gCameraMovementFlags & CAM_MOVE_C_UP_MODE) {
         status |= CAM_STATUS_C_UP;
     }
+    if (gLakituState.mode == CAMERA_MODE_NEWCAM) {
+        status = gNewCamera.directionLocked ? CAM_STATUS_FIXED : CAM_STATUS_LAKITU;
+        switch (gNewCamera.distanceTargetIndex) {
+            case 0: status |= CAM_STATUS_C_UP; break;
+            case 1: break;
+            case 2: status |= CAM_STATUS_C_DOWN; break;
+        }
+    }
+
     set_hud_camera_status(status);
     return status;
 }

--- a/src/game/hud.c
+++ b/src/game/hud.c
@@ -602,16 +602,6 @@ void render_hud(void) {
 
     hudDisplayFlags = gHudDisplay.flags;
 
-    // Placed here to update when the camera hud flag is disabled
-    if (gLakituState.mode == CAMERA_MODE_NEWCAM) {
-        sCameraHUD.status = gNewCamera.directionLocked ? CAM_STATUS_FIXED : CAM_STATUS_LAKITU;
-        switch (gNewCamera.distanceTargetIndex) {
-            case 0: sCameraHUD.status |= CAM_STATUS_C_UP; break;
-            case 1: break;
-            case 2: sCameraHUD.status |= CAM_STATUS_C_DOWN; break;
-        }
-    }
-
     if (hudDisplayFlags == HUD_DISPLAY_NONE) {
         sPowerMeterHUD.animation = POWER_METER_HIDDEN;
         sPowerMeterStoredHealth = 8;

--- a/src/game/hud.c
+++ b/src/game/hud.c
@@ -563,15 +563,6 @@ void render_hud_camera_status(void) {
         return;
     }
 
-    if (gLakituState.mode == CAMERA_MODE_NEWCAM) {
-        sCameraHUD.status = gNewCamera.directionLocked ? CAM_STATUS_FIXED : CAM_STATUS_LAKITU;
-        switch (gNewCamera.distanceTargetIndex) {
-            case 0: sCameraHUD.status |= CAM_STATUS_C_UP; break;
-            case 1: break;
-            case 2: sCameraHUD.status |= CAM_STATUS_C_DOWN; break;
-        }
-    }
-
     gSPDisplayList(gDisplayListHead++, dl_hud_img_begin);
     render_hud_tex_lut(x, y, (*cameraLUT)[GLYPH_CAM_CAMERA]);
 
@@ -610,6 +601,16 @@ void render_hud(void) {
 #endif
 
     hudDisplayFlags = gHudDisplay.flags;
+
+    // Placed here to update when the camera hud flag is disabled
+    if (gLakituState.mode == CAMERA_MODE_NEWCAM) {
+        sCameraHUD.status = gNewCamera.directionLocked ? CAM_STATUS_FIXED : CAM_STATUS_LAKITU;
+        switch (gNewCamera.distanceTargetIndex) {
+            case 0: sCameraHUD.status |= CAM_STATUS_C_UP; break;
+            case 1: break;
+            case 2: sCameraHUD.status |= CAM_STATUS_C_DOWN; break;
+        }
+    }
 
     if (hudDisplayFlags == HUD_DISPLAY_NONE) {
         sPowerMeterHUD.animation = POWER_METER_HIDDEN;


### PR DESCRIPTION
The free cam hud camera status didn't update when the camera flag was disabled because it was being updated within the function that was being disabled when the flag is disabled, credits to @kingthememer