### PR TITLE
Create Lua function log_to_stdout()

### DIFF
--- a/autogen/convert_functions.py
+++ b/autogen/convert_functions.py
@@ -223,6 +223,7 @@ manual_index_documentation = """
    - [smlua_anim_util_register_animation](#smlua_anim_util_register_animation)
    - [level_script_parse](#level_script_parse)
    - [log_to_console](#log_to_console)
+   - [log_to_stdout](#log_to_stdout)
    - [add_scroll_target](#add_scroll_target)
    - [collision_find_surface_on_ray](#collision_find_surface_on_ray)
    - [cast_graph_node](#cast_graph_node)
@@ -489,6 +490,29 @@ Logs a message to the in-game console.
 
 ### C Prototype
 `void log_to_console(const char* message, enum ConsoleMessageLevel level);`
+
+[:arrow_up_small:](#)
+
+<br />
+
+## [log_to_stdout](#log_to_stdout)
+
+Logs a message to standard output.
+
+### Lua Example
+`log_to_stdout("sm64coopdx FTW", CONSOLE_MESSAGE_INFO)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| message | `string` |
+| level (optional) | `ConsoleMessageLevel` |
+
+### Returns
+- None
+
+### C Prototype
+`void log_to_stdout(const char* message, enum ConsoleMessageLevel level);`
 
 [:arrow_up_small:](#)
 

--- a/autogen/lua_definitions/manual.lua
+++ b/autogen/lua_definitions/manual.lua
@@ -405,6 +405,13 @@ function log_to_console(message, level)
     -- ...
 end
 
+--- @param message string The message to log
+--- @param level? ConsoleMessageLevel Optional; Determines whether the message should appear as info, a warning or an error.
+--- Logs a message to standard output
+function log_to_stdout(message, level)
+    -- ...
+end
+
 --- @param index integer The index of the scroll target, should match up with the behavior param of `RM_Scroll_Texture` or `editor_Scroll_Texture`
 --- @param name string The name of the vertex buffer that should be used while scrolling the texture
 --- Registers a vertex buffer to be used for a scrolling texture. Should be used with `RM_Scroll_Texture` or `editor_Scroll_Texture`

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -20,6 +20,7 @@
    - [smlua_anim_util_register_animation](#smlua_anim_util_register_animation)
    - [level_script_parse](#level_script_parse)
    - [log_to_console](#log_to_console)
+   - [log_to_stdout](#log_to_stdout)
    - [add_scroll_target](#add_scroll_target)
    - [collision_find_surface_on_ray](#collision_find_surface_on_ray)
    - [cast_graph_node](#cast_graph_node)
@@ -2450,6 +2451,29 @@ Logs a message to the in-game console.
 
 ### C Prototype
 `void log_to_console(const char* message, enum ConsoleMessageLevel level);`
+
+[:arrow_up_small:](#)
+
+<br />
+
+## [log_to_stdout](#log_to_stdout)
+
+Logs a message to standard output.
+
+### Lua Example
+`log_to_stdout("sm64coopdx FTW", CONSOLE_MESSAGE_INFO)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| message | `string` |
+| level (optional) | `ConsoleMessageLevel` |
+
+### Returns
+- None
+
+### C Prototype
+`void log_to_stdout(const char* message, enum ConsoleMessageLevel level);`
 
 [:arrow_up_small:](#)
 

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -158,6 +158,7 @@ bool         configCameraToxicGas                 = true;
 bool         configLuaProfiler                    = false;
 bool         configDebugPrint                     = false;
 bool         configDebugInfo                      = false;
+bool         configDebugWarning                   = false;
 bool         configDebugError                     = false;
 #ifdef DEVELOPMENT
 bool         configCtxProfiler                    = false;
@@ -310,6 +311,7 @@ static const struct ConfigOption options[] = {
     {.name = "lua_profiler",                   .type = CONFIG_TYPE_BOOL, .boolValue   = &configLuaProfiler},
     {.name = "debug_print",                    .type = CONFIG_TYPE_BOOL, .boolValue   = &configDebugPrint},
     {.name = "debug_info",                     .type = CONFIG_TYPE_BOOL, .boolValue   = &configDebugInfo},
+    {.name = "debug_warning",                  .type = CONFIG_TYPE_BOOL, .boolValue   = &configDebugWarning},
     {.name = "debug_error",                    .type = CONFIG_TYPE_BOOL, .boolValue   = &configDebugError},
 #ifdef DEVELOPMENT
     {.name = "ctx_profiler",                   .type = CONFIG_TYPE_BOOL, .boolValue   = &configCtxProfiler},

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -123,6 +123,7 @@ extern bool         configCameraToxicGas;
 extern bool         configLuaProfiler;
 extern bool         configDebugPrint;
 extern bool         configDebugInfo;
+extern bool         configDebugWarning;
 extern bool         configDebugError;
 #ifdef DEVELOPMENT
 extern bool         configCtxProfiler;

--- a/src/pc/debuglog.h
+++ b/src/pc/debuglog.h
@@ -46,11 +46,13 @@ static void _debuglog_print_log(const char* logType, char* filename) {
 #if defined(DISABLE_MODULE_LOG)
 #define LOG_DEBUG(...)
 #define LOG_INFO(...)
+#define LOG_WARNING(...)
 #define LOG_ERROR(...)
 #else
-#define LOG_DEBUG(...) (configDebugPrint ? ( _debuglog_print_log("DEBUG", __FILE__), printf(__VA_ARGS__), printf("\n") ) : 0)
-#define LOG_INFO(...)  ((configDebugInfo || gCLIOpts.headless) ? ( _debuglog_print_log("INFO",  __FILE__), printf(__VA_ARGS__), printf("\n") ) : 0)
-#define LOG_ERROR(...) (configDebugError ? ( _debuglog_print_log("ERROR", __FILE__), printf(__VA_ARGS__), printf("\n") ) : 0)
+#define LOG_DEBUG(...)     (configDebugPrint ? ( _debuglog_print_log("DEBUG", __FILE__), printf(__VA_ARGS__), printf("\n") ) : 0)
+#define LOG_INFO(...)      ((configDebugInfo || gCLIOpts.headless) ? ( _debuglog_print_log("INFO",  __FILE__), printf(__VA_ARGS__), printf("\n") ) : 0)
+#define LOG_WARNING(...)   (configDebugWarning ? ( _debuglog_print_log("WARNING",  __FILE__), printf(__VA_ARGS__), printf("\n") ) : 0)
+#define LOG_ERROR(...)     (configDebugError ? ( _debuglog_print_log("ERROR", __FILE__), printf(__VA_ARGS__), printf("\n") ) : 0)
 #endif
 #define LOG_CONSOLE(...)  { snprintf(gDjuiConsoleTmpBuffer, CONSOLE_MAX_TMP_BUFFER, __VA_ARGS__), djui_console_message_create(gDjuiConsoleTmpBuffer, CONSOLE_MESSAGE_INFO); }
 

--- a/src/pc/lua/smlua_functions.c
+++ b/src/pc/lua/smlua_functions.c
@@ -796,6 +796,37 @@ int smlua_func_log_to_console(lua_State* L) {
     return 1;
 }
 
+int smlua_func_log_to_stdout(lua_State* L) {
+    if (!smlua_functions_valid_param_range(L, 1, 2)) { return 0; }
+
+    int paramCount = lua_gettop(L);
+
+    const char* message = smlua_to_string(L, 1);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("log_to_stdout: Failed to convert parameter 1 for function"); return 0; }
+
+    enum ConsoleMessageLevel level = CONSOLE_MESSAGE_INFO;
+    if (paramCount >= 2) {
+        level = smlua_to_integer(L, 2);
+        if (!gSmLuaConvertSuccess) { LOG_LUA("log_to_stdout: Failed to convert parameter 2 for function"); return 0; }
+    }
+
+    const char* origin = gLuaActiveModFile->relativePath;
+
+    switch (level) {
+        case CONSOLE_MESSAGE_INFO:
+            LOG_INFO("%s: %s", origin, message);
+            break;
+        case CONSOLE_MESSAGE_WARNING:
+            LOG_WARNING("%s: %s", origin, message);
+            break;
+        case CONSOLE_MESSAGE_ERROR:
+            LOG_ERROR("%s: %s", origin, message);
+            break;
+    }
+
+    return 1;
+}
+
   ////////////////////
  // scroll targets //
 ////////////////////
@@ -1042,6 +1073,7 @@ void smlua_bind_functions(void) {
     smlua_bind_function(L, "level_script_parse", smlua_func_level_script_parse);
     smlua_bind_function(L, "smlua_anim_util_register_animation", smlua_func_smlua_anim_util_register_animation);
     smlua_bind_function(L, "log_to_console", smlua_func_log_to_console);
+    smlua_bind_function(L, "log_to_stdout", smlua_func_log_to_stdout);
     smlua_bind_function(L, "add_scroll_target", smlua_func_add_scroll_target);
     smlua_bind_function(L, "collision_find_surface_on_ray", smlua_func_collision_find_surface_on_ray);
     smlua_bind_function(L, "cast_graph_node", smlua_func_cast_graph_node);


### PR DESCRIPTION
Revised version of #922

Adds a new Lua function `log_to_stdout()` which sends log messages to the game's debug logger (`LOG_INFO`, `LOG_ERROR`, etc).

Of the options, I think it's best to make a new function.  If we modify the parameters for `log_to_console()`, this could potentially break existing mods which might have funky wrappers that break with a 3rd optional parameter.  I don't like having to replicate the formatting in Lua scripts, as we then have to duplicate the formatting code for every single mod that wants to print logging information.