### PR TITLE
Fix the FPS display for displaying FPS counts higher than 5 digits

### DIFF
--- a/src/pc/djui/djui_fps_display.c
+++ b/src/pc/djui/djui_fps_display.c
@@ -31,7 +31,7 @@ void djui_fps_display_create(void) {
     struct DjuiFpsDisplay *fpsDisplay = calloc(1, sizeof(struct DjuiFpsDisplay));
     struct DjuiBase* base = &fpsDisplay->base;
     djui_base_init(NULL, base, NULL, djui_fps_display_on_destroy);
-    djui_base_set_size(base, 150, 50);
+    djui_base_set_size(base, 165, 50);
     djui_base_set_color(base, 0, 0, 0, 200);
     djui_base_set_border_color(base, 0, 0, 0, 160);
     djui_base_set_border_width(base, 4);


### PR DESCRIPTION
This is a very simple change (just increasing the fps display box width a bit).

Before:
<img width="653" height="315" alt="Screenshot From 2025-08-25 11-51-19" src="https://github.com/user-attachments/assets/a0303e9a-cfad-4cbf-be3d-ab1acbfbde36" />

After:
<img width="653" height="315" alt="Screenshot From 2025-08-25 11-53-56" src="https://github.com/user-attachments/assets/35ba7d9e-30fb-4ca4-be85-2a934b3c3029" />
