### PR TITLE
Add clamping at 99999 to the FPS counter

### DIFF
--- a/src/pc/djui/djui_fps_display.c
+++ b/src/pc/djui/djui_fps_display.c
@@ -31,7 +31,7 @@ void djui_fps_display_create(void) {
     struct DjuiFpsDisplay *fpsDisplay = calloc(1, sizeof(struct DjuiFpsDisplay));
     struct DjuiBase* base = &fpsDisplay->base;
     djui_base_init(NULL, base, NULL, djui_fps_display_on_destroy);
-    djui_base_set_size(base, 150, 50);
+    djui_base_set_size(base, 165, 50);
     djui_base_set_color(base, 0, 0, 0, 200);
     djui_base_set_border_color(base, 0, 0, 0, 160);
     djui_base_set_border_width(base, 4);

--- a/src/pc/djui/djui_fps_display.c
+++ b/src/pc/djui/djui_fps_display.c
@@ -11,6 +11,7 @@ struct DjuiFpsDisplay *sFpsDisplay = NULL;
 void djui_fps_display_update(u16 fps) {
     if (configShowFPS && sFpsDisplay != NULL) {
         char fpsText[30] = "";
+        fps = fps > 99999 ? 99999 : fps; // Prevent overflowing the FPS display (cap at 99999)
         snprintf(fpsText, 30, "\\#dcdcdc\\FPS: \\#ffffff\\%d", fps);
         djui_text_set_text(sFpsDisplay->text, fpsText);
     }


### PR DESCRIPTION
As the title implies this PR adds clamping to the FPS counter so that the FPS cannot exceed 5 digits. This was suggested in [my previous PR](https://github.com/coop-deluxe/sm64coopdx/pull/931).