### PR TITLE
Remove interaction limit for PVP

### DIFF
--- a/src/game/object_collision.c
+++ b/src/game/object_collision.c
@@ -52,12 +52,6 @@ int detect_player_hitbox_overlap(struct MarioState* local, struct MarioState* re
         if (sp20 < sp38) {
             return FALSE;
         }
-        if (a->numCollidedObjs >= 4) {
-            return FALSE;
-        }
-        if (b->numCollidedObjs >= 4) {
-            return FALSE;
-        }
 
         return TRUE;
     }
@@ -196,6 +190,8 @@ void check_player_object_collision(void) {
         if (detect_player_hitbox_overlap(&gMarioStates[0], &gMarioStates[i], 1.0f)) {
             struct Object* a = gMarioStates[0].marioObj;
             struct Object* b = gMarioStates[i].marioObj;
+            if (a->numCollidedObjs >= 4) { continue; }
+            if (b->numCollidedObjs >= 4) { continue; }
             a->collidedObjs[a->numCollidedObjs] = b;
             b->collidedObjs[b->numCollidedObjs] = a;
             a->collidedObjInteractTypes |= b->oInteractType;


### PR DESCRIPTION
Previously, PVP interactions were subject to Mario 64's default interaction limit of 4 objects. This meant that if 4 players or other objects overlapped someone, they wouldn't be able to be hurt by other players. However, since PVP interactions don't use Mario 64's normal interaction system, removing this restriction was fairly easy. This fixes some issues with some of my mods, such as Geoguessr and Drench Game, where players often overlap with each other.

Before:
https://github.com/user-attachments/assets/85a0489f-ffe2-4209-a044-b6a3de354ceb

After:
https://github.com/user-attachments/assets/2cc32072-ac76-4c5e-bff5-fa9e63903068