### PR TITLE
gsSPLightColor() support

### DIFF
--- a/src/pc/gfx/gfx_pc.c
+++ b/src/pc/gfx/gfx_pc.c
@@ -1358,9 +1358,9 @@ static void gfx_sp_moveword(uint8_t index, uint16_t offset, uint32_t data) {
             int lightNum = offset / 24;
             // data = packed color
             if (lightNum >= 0 && lightNum <= MAX_LIGHTS) {
-                rsp.current_lights[lightNum].col[0] = data >> 24;
-                rsp.current_lights[lightNum].col[1] = data >> 16;
-                rsp.current_lights[lightNum].col[2] = data >> 8;
+                rsp.current_lights[lightNum].col[0] = (uint8_t)(data >> 24);
+                rsp.current_lights[lightNum].col[1] = (uint8_t)(data >> 16);
+                rsp.current_lights[lightNum].col[2] = (uint8_t)(data >> 8);
             }
             break;
         }

--- a/src/pc/gfx/gfx_pc.c
+++ b/src/pc/gfx/gfx_pc.c
@@ -1354,6 +1354,16 @@ static void gfx_sp_moveword(uint8_t index, uint16_t offset, uint32_t data) {
                 rsp.fresnel_offset = (int16_t)data;
             }
             break;
+        case G_MW_LIGHTCOL: {
+            int lightNum = offset / 24;
+            // data = packed color
+            if (lightNum >= 0 && lightNum <= MAX_LIGHTS) {
+                rsp.current_lights[lightNum].col[0] = data >> 24;
+                rsp.current_lights[lightNum].col[1] = data >> 16;
+                rsp.current_lights[lightNum].col[2] = data >> 8;
+            }
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
Adds gsSPLightColor support to the PC port renderer.
This makes the "Matstack Fix" option in Fast64 work.

You can now modify lights from Lua using gsSPLightColor instead of gsSPSetLights* (which you can't even use).
It takes a light index and a packed color (0xRRGGBBAA).
Alpha is ignored, and It updates the light’s color without recalculating light direction.