### PR TITLE
Some syncing fixes for Bowser and Heave Ho

### DIFF
--- a/src/game/behaviors/bowser.inc.c
+++ b/src/game/behaviors/bowser.inc.c
@@ -3,6 +3,7 @@ static u32 networkBowserAnimationIndex = 0;
 static u8 bowserIsDying = FALSE;
 static u8 bowserCutscenePlayed = FALSE;
 static u8 bowserIsCutscenePlayer = FALSE;
+static u8 bowserCutsceneGlobalIndex = UNKNOWN_GLOBAL_INDEX;
 
 void bowser_tail_anchor_act_0(void) {
     struct Object* bowser = o->parentObj;
@@ -777,6 +778,10 @@ void bowser_act_thrown_dropped(void)
             o->oAction = 4;
         else
             o->oAction = 12;
+        
+        if (is_nearest_mario_state_to_object(gMarioState, o)) {
+            network_send_object(o);
+        }
     }
 }
 
@@ -1125,8 +1130,17 @@ void bowser_act_ride_tilting_platform(void) {
     cur_obj_extend_animation_if_at_end();
 }
 
-void bowser_act_nothing(void) {
-    
+void bowser_act_nothing(void) { // start moving if cutscene player is inactive
+    if (bowserCutsceneGlobalIndex == UNKNOWN_GLOBAL_INDEX) {
+        return;
+    }
+
+    struct NetworkPlayer* np = network_player_from_global_index(bowserCutsceneGlobalIndex);
+    if (np == NULL || !is_player_active(&gMarioStates[np->localIndex])) {
+        bowserCutscenePlayed = TRUE;
+        bowser_initialize_action();
+        return;
+    }
 }
 
 s32 bowser_check_fallen_off_stage(void) // bowser off stage?
@@ -1232,6 +1246,7 @@ void bowser_held_update(void) {
         return;
     }
 
+    o->parentObj = player;
     o->oBowserUnkF4 &= ~0x20000;
     cur_obj_become_intangible();
 
@@ -1385,6 +1400,13 @@ static u8 bhv_bowser_ignore_if_true(void) {
     return FALSE;
 }
 
+static void bhv_bowser_on_received_post(UNUSED u8 localIndex) {
+    // prevent sync from putting bowser in text action instead of nothing action
+    if (!(bowserIsCutscenePlayer || bowserCutscenePlayed) && (o->oAction == 5 || o->oAction == 6)) {
+        o->oAction = 20;
+    }
+}
+
 void bhv_bowser_init(void) {
     bowserIsDying = FALSE;
     s32 level; // 0 is dw, 1 is fs, 2 is sky
@@ -1408,9 +1430,11 @@ void bhv_bowser_init(void) {
     // Make sure we're the first to trigger Bowser.
     if (!is_other_player_active()) {
         bowserIsCutscenePlayer = TRUE;
+        bowserCutsceneGlobalIndex = gNetworkPlayerLocal->globalIndex;
         o->oAction = 5; // bowser_act_text_wait
     } else { // If we aren't do nothing till we get our sync.
         bowserIsCutscenePlayer = FALSE;
+        bowserCutsceneGlobalIndex = UNKNOWN_GLOBAL_INDEX;
         o->oAction = 20; // bowser_act_nothing
     }
     
@@ -1419,9 +1443,11 @@ void bhv_bowser_init(void) {
         if (so) {
             so->override_ownership = bhv_bowser_override_ownership;
             so->ignore_if_true = bhv_bowser_ignore_if_true;
+            so->on_received_post = bhv_bowser_on_received_post;
             so->fullObjectSync = TRUE;
             sync_object_init_field_with_size(o, &o->header.gfx.node.flags, 16);
             sync_object_init_field_with_size(o, &o->header.gfx.animInfo.animFrame, 16);
+            sync_object_init_field_with_size(o, &bowserCutsceneGlobalIndex, 8);
             sync_object_init_field(o, &networkBowserAnimationIndex);
             sync_object_init_field(o, &o->header.gfx.scale[0]);
             sync_object_init_field(o, &o->header.gfx.scale[1]);

--- a/src/game/behaviors/heave_ho.inc.c
+++ b/src/game/behaviors/heave_ho.inc.c
@@ -23,7 +23,7 @@ void bhv_heave_ho_throw_mario_loop(void) {
                 if (player) {
                     player->oInteractStatus |= INT_STATUS_MARIO_UNK2;
                 }
-                if (marioState) {
+                if (marioState && marioState->action == ACT_GRABBED) {
                     marioState->forwardVel = -45.0f;
                     marioState->vel[1] = 95.0f;
                 }


### PR DESCRIPTION
The main focus is on Bowser, who is tied to the most infamous desyncs of all. Here are the changes I have made:

- Bowser's held loop now update o.parentObj to the marioObj of whichever player is holding him. When Bowser is thrown, the game calls cur_obj_set_pos_relative_to_parent to set Bowser's location, which assumes that the parent object is whichever Mario is holding him. This may not be the case due to multiplayer, so doing this ensures that the parent object is set correctly.
- The closest player to Bowser now sends a packet when he hits a mine, hopefully reducing how often Bowser fights get softlocked in multiplayer.
- Fixed a bug where if the player talking to Bowser left the level, the entire fight would be softlocked. A new sync field was created to track which player is currently talking to Bowser, and if that player becomes inactive, Bowser will start attacking.

The minor change to Heave Ho was that he can only throw the player if the player is in ACT_GRABBED, fixing an issue where Heave Ho would launch players that weren't interacting with him (although, this only happens when m->heldByObj is erroneously set to the Heave Ho object, which shouldn't be happening in the first place).