### PR TITLE
Fix issues with normal cap

### DIFF
--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -456,6 +456,7 @@ void mario_retrieve_cap(struct MarioState* m) {
     if (!m) { return; }
     mario_drop_held_object(m);
     save_file_clear_flags(SAVE_FLAG_CAP_ON_KLEPTO | SAVE_FLAG_CAP_ON_UKIKI);
+    m->cap &= ~(SAVE_FLAG_CAP_ON_KLEPTO | SAVE_FLAG_CAP_ON_UKIKI);
     m->flags &= ~MARIO_CAP_ON_HEAD;
     m->flags |= MARIO_NORMAL_CAP | MARIO_CAP_IN_HAND;
 }
@@ -2155,6 +2156,10 @@ u32 interact_cap(struct MarioState *m, UNUSED u32 interactType, struct Object *o
             case MARIO_WING_CAP:
                 capTime = gLevelValues.wingCapDuration;
                 capMusic = SEQUENCE_ARGS(4, gLevelValues.wingCapSequence);
+                break;
+            
+            case MARIO_NORMAL_CAP:
+                m->cap = 0;
                 break;
         }
 

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -370,7 +370,6 @@ void cutscene_put_cap_on(struct MarioState *m) {
     m->flags &= ~MARIO_CAP_IN_HAND;
     m->flags |= MARIO_CAP_ON_HEAD;
     play_sound(SOUND_ACTION_UNKNOWN43E, m->marioObj->header.gfx.cameraToObject);
-    m->cap = 0;
 }
 
 /**


### PR DESCRIPTION
Fixes the following issues:
- Mario no longer regains his normal cap when doing the picking up cap action (this allowed you to reobtain it by picking up a Wing Cap, for example)
- Mario will now regain his cap from the ground, even without going into the cutscene. Previously, Mario had to enter the cutscene action to get the cap, so it wouldn't activate if Mario jumped into the cap (Klepto and Mr. Blizzard set the flags directly).