### PR TITLE
Fix djui menu flashing

### DIFF
--- a/src/pc/djui/djui.c
+++ b/src/pc/djui/djui.c
@@ -176,10 +176,10 @@ void djui_reset_hud_params(void) {
 
 void djui_render(void) {
     if (!sDjuiInited || gDjuiDisabled) { return; }
-    djui_reset_hud_params();
 
     sSavedDisplayListHead = gDisplayListHead;
     gDjuiHudUtilsZ = 0;
+    djui_reset_hud_params();
 
     create_dl_ortho_matrix();
     djui_gfx_displaylist_begin();


### PR DESCRIPTION
    Move djui_reset_hud_params() to after the djui display list save point

    Resetting scissor/viewport before the save point caused the djui menu to rapidly
    flicker when interpolating (and an interpolated HUD texture was rendered)

    Thanks to PeachyPeach for finding the better fix

---

This bug was introduced in this commit:
    ac1cf57cf new djui hud tools: viewport, scissor and render line (#916)
   @Isaac0-dev 

---

I used this lua mod to test:
```Lua
t = 0
function on_hud_render()
    t = t + 0.1

    djui_hud_set_viewport(0, 0, 300, 300 + math.sin(t) * 20)
    djui_hud_render_texture_interpolated(gTextures.coin, 0, 0, 10, 10, 0, 0, 10, 10)

    djui_hud_set_resolution(RESOLUTION_N64)
    djui_hud_set_scissor(0, 0, 400, 50 + math.sin(t) * 20)
    djui_hud_render_texture_interpolated(gTextures.coin, 50, 0, 10, 10, 50, 0, 10, 10)
end

hook_event(HOOK_ON_HUD_RENDER, on_hud_render)
```

---

This must be merged (or a similar fix) before v1.4 releases