### PR TITLE
Prevent cursor interpolation from causing crashes

### DIFF
--- a/src/pc/djui/djui_cursor.c
+++ b/src/pc/djui/djui_cursor.c
@@ -167,7 +167,6 @@ void djui_cursor_interp_before(void) {
 }
 
 void djui_cursor_interp(void) {
-    djui_cursor_update_position();
     if (sInterpCursor && (sPrevCursorX != gCursorX || sPrevCursorY != gCursorY)) {
         if (sSavedDisplayListHead == NULL) { return; }
         gDisplayListHead = sSavedDisplayListHead;


### PR DESCRIPTION
Previously djui_cursor_interp() called djui_cursor_update_position(), which is really bad, because the cursor can trigger events that would affect the display lists. The number of things in the display list must *not* change during interpolation, or we corrupt the list.

Steps to cause the crash before this change are simple, but maybe only on windows:
1. Open game
2. Open console
3. Wiggle mouse on console

<img width="2562" height="1414" alt="image" src="https://github.com/user-attachments/assets/8501af1e-b807-491d-b4bf-e09bfcb20d36" />
