### PR TITLE
Fix negative zero network_send() edgecase

### DIFF
--- a/src/pc/lua/smlua_utils.c
+++ b/src/pc/lua/smlua_utils.c
@@ -1,5 +1,3 @@
-#include <math.h>
-
 #include "smlua.h"
 #include "pc/mods/mods.h"
 #include "audio/external.h"


### PR DESCRIPTION
Lua mods in very rare scenarios would send a value of -0 over the network, and receive MIN_U64 due to an incorrect guess at the variable type in an LNT.

Reproducible on previous builds with this code:
```Lua
local t = 0

hook_event(HOOK_UPDATE, function ()
    t = t + 1
    if (t % 10) == 0 then
        n = -0.0 / 1e309
        network_send(true, {
            pos = -n,
            neg = n,
        })
    end
end)

hook_event(HOOK_ON_PACKET_RECEIVE, function(vals)
    djui_chat_message_create('pos: ' .. vals.pos .. ', neg: ' .. vals.neg)
end)
```

---

Found and narrowed down by Holc

