### PR TITLE
Fix - Remove incorrect collision validation check

### DIFF
--- a/data/dynos_bin_col.cpp
+++ b/data/dynos_bin_col.cpp
@@ -64,9 +64,6 @@ static void ValidateColSectionChange(GfxData* aGfxData, struct CollisionValidati
 }
 
 static void ValidateColInit(GfxData* aGfxData, struct CollisionValidationData& aColValData) {
-    if (aColValData.tokenIndex != 0) {
-        PrintDataError("COL_INIT found after the first token");
-    }
     ValidateColSectionChange(aGfxData, aColValData, COL_SECTION_VTX);
 }
 


### PR DESCRIPTION
A validation check in dynos_bin_col.cpp was wrong, which would block otherwise well formed collision files. Since collisions are parsed as s16, if you reach the bounds of s16 values will begin to overflow and the validation will catch it.

To work around this overflow issue, you need to output groups of triangles and vertices. However the existing check in ValidateColInit() would prevent this workaround. Now there is essentially no hard-coded limit when it comes to vertex and triangle counts of collision structs.