### PR TITLE
Adds compilation fixes for ARM in headless mode

### DIFF
--- a/src/engine/math_util.c
+++ b/src/engine/math_util.c
@@ -827,7 +827,7 @@ OPTIMIZE_O3 bool mtxf_inverse_non_affine(OUT Mat4 dest, Mat4 src) {
             if (fabsf(aug[i][k]) > fabsf(aug[piv][k])) { piv = i; }
         }
 
-        if (fabsf(aug[piv][k]) < FLT_EPSILON) { return false; }
+        if (fabsf(aug[piv][k]) < __FLT_EPSILON__) { return false; }
 
         // swap pivot row into place
         if (piv != k) {

--- a/src/pc/platform.c
+++ b/src/pc/platform.c
@@ -411,4 +411,12 @@ static void sys_fatal_impl(const char *msg) {
     exit(1);
 }
 
+const char *sys_resource_path(void) {
+    return ".";
+}
+
+const char *sys_exe_path_dir(void) {
+    return ".";
+}
+
 #endif // platform switch


### PR DESCRIPTION
Should fix #1034. It seems sm64coopdx won't compile in `HEADLESS=1` and `TARGET_RPI=1` without these changes. Testing the waters here and I hope to be able to contribute way more in the coming days. Thank you.
