### PR TITLE
Fix crash on input box

### DIFF
--- a/src/pc/djui/djui_interactable.c
+++ b/src/pc/djui/djui_interactable.c
@@ -279,10 +279,6 @@ bool djui_interactable_on_key_down(int scancode) {
 
 void djui_interactable_on_key_up(int scancode) {
 
-    bool keyFocused = (gInteractableFocus != NULL)
-                   && (gInteractableFocus->interactable != NULL)
-                   && (gInteractableFocus->interactable->on_key_up != NULL);
-
     if (!gDjuiChatBoxFocus) {
         for (int i = 0; i < MAX_BINDS; i++) {
             if (scancode == (int)configKeyConsole[i]) { djui_console_toggle(); break; }
@@ -303,6 +299,10 @@ void djui_interactable_on_key_up(int scancode) {
             }
         }
     }
+
+    bool keyFocused = (gInteractableFocus != NULL)
+                   && (gInteractableFocus->interactable != NULL)
+                   && (gInteractableFocus->interactable->on_key_up != NULL);
 
     if (keyFocused) {
         gInteractableFocus->interactable->on_key_up(gInteractableFocus, scancode);


### PR DESCRIPTION
When typing ` into the coopnet password inputbox (the same as the console bind) It would do all of the null checks, then open the console changing the focus, then call a null function because the null checks are no longer valid.

So I moved the null checks to where they're needed.