### PR TITLE
Also normalize paths in mod_file_exists()

### DIFF
--- a/src/pc/lua/utils/smlua_misc_utils.c
+++ b/src/pc/lua/utils/smlua_misc_utils.c
@@ -570,7 +570,7 @@ bool mod_file_exists(const char* filename) {
     if (gLuaActiveMod == NULL) { return false; }
 
     char normPath[SYS_MAX_PATH] = { 0 };
-    char normalized_relative[SYS_MAX_PATH] = "";
+    char normRelative[SYS_MAX_PATH] = { 0 };
 
     if (snprintf(normPath, sizeof(normPath), "%s", filename) < 0) {
         LOG_ERROR("Failed to copy filename for normalization: %s", filename);
@@ -580,9 +580,9 @@ bool mod_file_exists(const char* filename) {
 
     for (s32 i = 0; i < gLuaActiveMod->fileCount; i++) {
         struct ModFile* file = &gLuaActiveMod->files[i];
-        strcpy(normalized_relative, file->relativePath);
-        normalize_path(normalized_relative);
-        if (!strcmp(normalized_relative, normPath)) {
+        strcpy(normRelative, file->relativePath);
+        normalize_path(normRelative);
+        if (!strcmp(normRelative, normPath)) {
             return true;
         }
     }


### PR DESCRIPTION
Since the release of 1.4 there have been some reports of issues with CS namely the included 1.14, 1.15, and early development versions of 1.16.

Some issues include:

- Missing File armature_geo.bin error.
<img width="556" height="152" alt="image" src="https://github.com/user-attachments/assets/4ab8e156-cf6c-4d7b-9cc3-599bac322bdf" />

- Voices not working and playing Mario sounds instead.

The issues seemed to occur when the client was running on a different OS from the host. 
e.g. Windows host and Linux client and vice versa. 

Windows connecting to windows or linux connecting to linux experienced no issues to my knowledge. 

I saw that previous versions of CS made use of `mod_file_exists()` to validate the existence of certain files before trying to use them. When the client OS was different from the host, this function always returned `false`. This led me to suspect that there was some issue with path resolution with some of the mod files. 

Any mod that depends on `mod_file_exists()` would likely face an issue with cross platform play.

Then dj noticed a similar path resolution issue with the require and issued #1042 to normalize the paths.

I have applied the same edits to the `mod_file_exists()` to normalize the relative path. This seems to have solved the few cross platform issues with CS from my limited testing.

dj mentioned that I should PR this so here it is 