### PR TITLE
Update djui_chat_message.h with MAX_CHAT_PACKET_LENGTH

### DIFF
--- a/src/pc/djui/djui_chat_message.h
+++ b/src/pc/djui/djui_chat_message.h
@@ -2,6 +2,7 @@
 #include "djui.h"
 
 #define MAX_CHAT_MSG_LENGTH 500
+#definte MAX_CHAT_PACKET_LENGTH 600
 
 struct DjuiChatMessage {
     struct DjuiBase base;


### PR DESCRIPTION
This, in combination with a change to djui_chat_message.c, will also assist with the chat character limit increase by allowing for larger strings to be sent over chat packets without loss.

This could probably be refined down to exactly the amount of extra data chat packets can contain, but 600 works, so that's what I went with.