### PR TITLE
Update djui_chat_message.c to replace two instances of MAX_CHAT_MSG_LENGTH with MAX_CHAT_PACKET_LENGTH

### DIFF
--- a/src/pc/djui/djui_chat_message.c
+++ b/src/pc/djui/djui_chat_message.c
@@ -62,8 +62,8 @@ void djui_chat_message_create_from(u8 globalIndex, const char* message) {
     }
 
     const char* playerColorString = network_get_player_text_color_string(np->localIndex);
-    char chatMsg[MAX_CHAT_MSG_LENGTH] = { 0 };
-    snprintf(chatMsg, MAX_CHAT_MSG_LENGTH, "%s%s\\#dcdcdc\\: %s", playerColorString, (np != NULL) ? np->name : "Player", message);
+    char chatMsg[MAX_CHAT_PACKET_LENGTH] = { 0 };
+    snprintf(chatMsg, MAX_CHAT_PACKET_LENGTH, "%s%s\\#dcdcdc\\: %s", playerColorString, (np != NULL) ? np->name : "Player", message);
 
     play_sound((globalIndex == gNetworkPlayerLocal->globalIndex) ? SOUND_MENU_MESSAGE_DISAPPEAR : SOUND_MENU_MESSAGE_APPEAR, gGlobalSoundSource);
     djui_chat_message_create(chatMsg);


### PR DESCRIPTION
If we replace MAX_CHAT_MSG_LENGTH in these two spots, it fixes the previous issue of having the chat text entry spill over the character limit (resulting in characters at the end of messages that are lost) while raising the character limit to the intended limit of 500. Or 499 more specifically.