### PR TITLE
Fix certain GraphNodeObject fields not resetting between objects

### DIFF
--- a/src/game/spawn_object.c
+++ b/src/game/spawn_object.c
@@ -331,6 +331,9 @@ struct Object *allocate_object(struct ObjectNode *objList) {
     vec3s_zero(obj->header.gfx.angle);
     obj->header.gfx.throwMatrix = NULL;
     obj->header.gfx.inited = false;
+    obj->header.gfx.disableAutomaticShadowPos = false;
+    obj->header.gfx.shadowInvisible = false;
+    obj->header.gfx.skipInViewCheck = false;
 
     obj->coopFlags = 0;
     obj->hookRender = 0;


### PR DESCRIPTION
Previously, the GraphNodeObject fields disableAutomaticShadowPos, shadowInvisible, and skipInViewCheck did not reset when a new object was created. This meant that any mods that used these fields would cause new objects that took those slots to use the new values, usually resulting in broken shadows. This was common in Blocky's Hide and Seek Rebirth mod (aka Prop Hunt) and old versions of Extra Characters with Birdo's eggs. Now, all of these fields are set to false by default, fixing this issue.