### PR TITLE
Merry-Go-Round Fixes (includes fixes for rooms and remote object-spawned objects)

### DIFF
--- a/src/engine/behavior_script.c
+++ b/src/engine/behavior_script.c
@@ -797,7 +797,22 @@ static s32 bhv_cmd_load_collision_data(void) {
 // Command 0x2D: Sets the home position of the object to its current position.
 // Usage: SET_HOME()
 static s32 bhv_cmd_set_home(void) {
-    if (!(gCurrentObject->coopFlags & (COOP_OBJ_FLAG_LUA | COOP_OBJ_FLAG_NETWORK))) {
+    // COOP: only set home via behavior for the following cases
+    if (
+        // if the object wasn't created via Lua
+        !(gCurrentObject->coopFlags & COOP_OBJ_FLAG_LUA)
+        // if the object wasn't created via network
+        // OR
+        // the object has never had its home set via behavior AND its home is default (e.g. (0, 0, 0))
+        // (this case handles an object that needs its home set via behavior after being spawned by another player)
+        && (
+            !(gCurrentObject->coopFlags & COOP_OBJ_FLAG_NETWORK)
+            || (
+                !gCurrentObject->setHome
+                && gCurrentObject->oHomeX == 0.0f && gCurrentObject->oHomeY == 0.0f && gCurrentObject->oHomeZ == 0.0f
+            )
+        )
+    ) {
         gCurrentObject->oHomeX = gCurrentObject->oPosX;
         gCurrentObject->oHomeY = gCurrentObject->oPosY;
         gCurrentObject->oHomeZ = gCurrentObject->oPosZ;

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -805,7 +805,10 @@ static void load_object_collision_model_internal(bool isSOC) {
 
         for (s32 i = 0; i < MAX_PLAYERS; i++) {
             f32 dist = dist_between_objects(gCurrentObject, gMarioStates[i].marioObj);
-            if (dist < tangibleDist) { anyPlayerInTangibleRange = TRUE; }
+            if (dist < tangibleDist) {
+                anyPlayerInTangibleRange = TRUE;
+                break;
+            }
         }
 
         // If the object collision is supposed to be loaded more than the

--- a/src/engine/surface_load.c
+++ b/src/engine/surface_load.c
@@ -805,10 +805,7 @@ static void load_object_collision_model_internal(bool isSOC) {
 
         for (s32 i = 0; i < MAX_PLAYERS; i++) {
             f32 dist = dist_between_objects(gCurrentObject, gMarioStates[i].marioObj);
-            if (dist < tangibleDist) {
-                anyPlayerInTangibleRange = TRUE;
-                break;
-            }
+            if (dist < tangibleDist) { anyPlayerInTangibleRange = TRUE; }
         }
 
         // If the object collision is supposed to be loaded more than the

--- a/src/game/behaviors/bbh_merry_go_round.inc.c
+++ b/src/game/behaviors/bbh_merry_go_round.inc.c
@@ -42,7 +42,7 @@ static void handle_merry_go_round_music(void) {
         // for co-op, this means that this check needs to be separated from the music check, since music is client-side.
 
         // `marioFloorType` refers to the client's Mario
-        gMarioOnMerryGoRound = cur_obj_is_any_player_on_platform() || marioFloorType == SURFACE_MGR_MUSIC;
+        gMarioOnMerryGoRound = marioFloorType == SURFACE_MGR_MUSIC || cur_obj_is_any_player_on_platform();
         if (!gMarioOnMerryGoRound) {
             // check the other Marios' floors
             for (s32 i = 1; i < MAX_PLAYERS; i++) {

--- a/src/game/behaviors/bbh_merry_go_round.inc.c
+++ b/src/game/behaviors/bbh_merry_go_round.inc.c
@@ -71,6 +71,7 @@ static void handle_merry_go_round_music(void) {
     gMarioOnMerryGoRound = marioFloorType == SURFACE_MGR_MUSIC || cur_obj_is_any_player_on_platform();
     if (!gMarioOnMerryGoRound) {
         // check the other Marios' floors
+        // starting at 1 since local player was already checked
         for (s32 i = 1; i < MAX_PLAYERS; i++) {
             if (!is_player_active(&gMarioStates[i])) { continue; }
 

--- a/src/game/behaviors/bbh_merry_go_round.inc.c
+++ b/src/game/behaviors/bbh_merry_go_round.inc.c
@@ -67,7 +67,7 @@ static void handle_merry_go_round_music(void) {
     }
 
     // COOP: floor check happens here
-    // `marioFloorType` refers to the client's Mario
+    // `marioFloorType` refers to the local player's character
     gMarioOnMerryGoRound = marioFloorType == SURFACE_MGR_MUSIC || cur_obj_is_any_player_on_platform();
     if (!gMarioOnMerryGoRound) {
         // check the other Marios' floors
@@ -75,10 +75,13 @@ static void handle_merry_go_round_music(void) {
         for (s32 i = 1; i < MAX_PLAYERS; i++) {
             if (!is_player_active(&gMarioStates[i])) { continue; }
 
-            struct Object *otherMarioObject = gMarioStates[i].marioObj;
-            if (otherMarioObject == NULL) { continue; }
+            struct Object *marioObject = gMarioStates[i].marioObj;
+            if (marioObject == NULL) { continue; }
+
+            struct Surface *marioFloor = NULL;
+            find_floor(marioObject->oPosX, marioObject->oPosY, marioObject->oPosZ, &marioFloor);
             
-            if (otherMarioObject->oFloorType == SURFACE_MGR_MUSIC) {
+            if (marioFloor != NULL && marioFloor->type == SURFACE_MGR_MUSIC) {
                 gMarioOnMerryGoRound = TRUE;
                 break;
             }

--- a/src/game/behaviors/bbh_merry_go_round.inc.c
+++ b/src/game/behaviors/bbh_merry_go_round.inc.c
@@ -37,7 +37,33 @@ static void handle_merry_go_round_music(void) {
         // The cur_obj_is_mario_on_platform check is redundant since the merry-go-round
         // has surface type 0x1A, so Mario cannot be on the merry-go-round
         // without being on a floor with surface type 0x1A (SURFACE_MGR_MUSIC).
-        gMarioOnMerryGoRound = cur_obj_is_any_player_on_platform();
+
+        // `gMarioOnMerryGoRound` is used to determine if the merry-go-round Boos should be active
+        // for co-op, this means that this check needs to be separated from the music check, since music is client-side.
+
+        // `marioFloorType` refers to the client's Mario
+        gMarioOnMerryGoRound = cur_obj_is_any_player_on_platform() || marioFloorType == SURFACE_MGR_MUSIC;
+        if (!gMarioOnMerryGoRound) {
+            // check the other Marios' floors
+            for (s32 i = 1; i < MAX_PLAYERS; i++) {
+                if (!is_player_active(&gMarioStates[i])) { continue; }
+
+                struct Object *otherMarioObject = gMarioStates[i].marioObj;
+                if (otherMarioObject == NULL) { continue; }
+
+                /*struct Surface *otherMarioFloor = 0;
+                find_floor(otherMarioObject->oPosX, otherMarioObject->oPosY, otherMarioObject->oPosZ, &otherMarioFloor);
+                if (otherMarioFloor == NULL) { continue; }
+
+                if (otherMarioFloor->type == SURFACE_MGR_MUSIC) {*/
+                if (otherMarioObject->oFloorType == SURFACE_MGR_MUSIC) {
+                    gMarioOnMerryGoRound = TRUE;
+                    break;
+                }
+            }
+        }
+
+        // continue with music check
         if (cur_obj_is_mario_on_platform() || marioFloorType == SURFACE_MGR_MUSIC) {
             // If Mario is in the merry-go-round's enclosure, play only the merry-go-round music.
             play_secondary_music(SEQ_EVENT_MERRY_GO_ROUND, 0, 78, 50);

--- a/src/game/behaviors/bbh_merry_go_round.inc.c
+++ b/src/game/behaviors/bbh_merry_go_round.inc.c
@@ -10,6 +10,9 @@
  * in the enclosure nor in the room around it.
  */
 static void handle_merry_go_round_music(void) {
+    // COOP: raise scope of this variable since floor check is no longer strictly tied to music
+    u16 marioFloorType = 0;
+
     // If the music should play, play it and check whether it still should.
     // Otherwise, don't play it and check whether it should.
     if (o->oMerryGoRoundMusicShouldPlay == FALSE) {
@@ -23,7 +26,7 @@ static void handle_merry_go_round_music(void) {
         // Get Mario's floor and floor surface type
         struct Surface *marioFloor = NULL;
         struct Object *marioObject = gMarioObjects[0];
-        u16 marioFloorType = 0;
+        // COOP: `marioFloorType` originally here
 
         if (marioObject) {
             find_floor(marioObject->oPosX, marioObject->oPosY, marioObject->oPosZ, &marioFloor);
@@ -38,27 +41,8 @@ static void handle_merry_go_round_music(void) {
         // has surface type 0x1A, so Mario cannot be on the merry-go-round
         // without being on a floor with surface type 0x1A (SURFACE_MGR_MUSIC).
 
-        // `gMarioOnMerryGoRound` is used to determine if the merry-go-round Boos should be active
+        // COOP: `gMarioOnMerryGoRound` is used to determine if the merry-go-round Boos should be active
         // for co-op, this means that this check needs to be separated from the music check, since music is client-side.
-
-        // `marioFloorType` refers to the client's Mario
-        gMarioOnMerryGoRound = marioFloorType == SURFACE_MGR_MUSIC || cur_obj_is_any_player_on_platform();
-        if (!gMarioOnMerryGoRound) {
-            // check the other Marios' floors
-            for (s32 i = 1; i < MAX_PLAYERS; i++) {
-                if (!is_player_active(&gMarioStates[i])) { continue; }
-
-                struct Object *otherMarioObject = gMarioStates[i].marioObj;
-                if (otherMarioObject == NULL) { continue; }
-                
-                if (otherMarioObject->oFloorType == SURFACE_MGR_MUSIC) {
-                    gMarioOnMerryGoRound = TRUE;
-                    break;
-                }
-            }
-        }
-
-        // continue with music check
         if (cur_obj_is_mario_on_platform() || marioFloorType == SURFACE_MGR_MUSIC) {
             // If Mario is in the merry-go-round's enclosure, play only the merry-go-round music.
             play_secondary_music(SEQ_EVENT_MERRY_GO_ROUND, 0, 78, 50);
@@ -79,6 +63,26 @@ static void handle_merry_go_round_music(void) {
             o->oMerryGoRoundMusicShouldPlay = FALSE;
         } else {
             cur_obj_play_sound_1(SOUND_ENV_MERRY_GO_ROUND_CREAKING);
+        }
+    }
+
+    // `gMarioOnMerryGoRound` is used to determine if the merry-go-round Boos should be active
+    // for co-op, this means that this check needs to be separated from the music check, since music is client-side.
+
+    // `marioFloorType` refers to the client's Mario
+    gMarioOnMerryGoRound = marioFloorType == SURFACE_MGR_MUSIC || cur_obj_is_any_player_on_platform();
+    if (!gMarioOnMerryGoRound) {
+        // check the other Marios' floors
+        for (s32 i = 1; i < MAX_PLAYERS; i++) {
+            if (!is_player_active(&gMarioStates[i])) { continue; }
+
+            struct Object *otherMarioObject = gMarioStates[i].marioObj;
+            if (otherMarioObject == NULL) { continue; }
+            
+            if (otherMarioObject->oFloorType == SURFACE_MGR_MUSIC) {
+                gMarioOnMerryGoRound = TRUE;
+                break;
+            }
         }
     }
 }

--- a/src/game/behaviors/bbh_merry_go_round.inc.c
+++ b/src/game/behaviors/bbh_merry_go_round.inc.c
@@ -66,9 +66,7 @@ static void handle_merry_go_round_music(void) {
         }
     }
 
-    // `gMarioOnMerryGoRound` is used to determine if the merry-go-round Boos should be active
-    // for co-op, this means that this check needs to be separated from the music check, since music is client-side.
-
+    // COOP: floor check happens here
     // `marioFloorType` refers to the client's Mario
     gMarioOnMerryGoRound = marioFloorType == SURFACE_MGR_MUSIC || cur_obj_is_any_player_on_platform();
     if (!gMarioOnMerryGoRound) {

--- a/src/game/behaviors/bbh_merry_go_round.inc.c
+++ b/src/game/behaviors/bbh_merry_go_round.inc.c
@@ -50,12 +50,7 @@ static void handle_merry_go_round_music(void) {
 
                 struct Object *otherMarioObject = gMarioStates[i].marioObj;
                 if (otherMarioObject == NULL) { continue; }
-
-                /*struct Surface *otherMarioFloor = 0;
-                find_floor(otherMarioObject->oPosX, otherMarioObject->oPosY, otherMarioObject->oPosZ, &otherMarioFloor);
-                if (otherMarioFloor == NULL) { continue; }
-
-                if (otherMarioFloor->type == SURFACE_MGR_MUSIC) {*/
+                
                 if (otherMarioObject->oFloorType == SURFACE_MGR_MUSIC) {
                     gMarioOnMerryGoRound = TRUE;
                     break;

--- a/src/game/behaviors/boo.inc.c
+++ b/src/game/behaviors/boo.inc.c
@@ -379,9 +379,7 @@ static void boo_chase_mario(f32 a0, s16 a1, f32 a2) {
     if (boo_vanish_or_appear()) {
         o->oInteractType = 0x8000;
 
-
-        u8 isMerryGoRoundBoo = (cur_obj_has_behavior(bhvMerryGoRoundBigBoo) || cur_obj_has_behavior(bhvMerryGoRoundBoo));
-        if (!isMerryGoRoundBoo && cur_obj_lateral_dist_from_obj_to_home(player) > 1500.0f) {
+        if (cur_obj_lateral_dist_from_obj_to_home(player) > 1500.0f) {
             sp1A = cur_obj_angle_to_home();
         } else {
             sp1A = angleToPlayer;

--- a/src/game/behaviors/boo.inc.c
+++ b/src/game/behaviors/boo.inc.c
@@ -535,7 +535,8 @@ static void (*sBooActions[])(void) = {
 };
 
 void bhv_boo_loop(void) {
-    if (o->oAction < 3) {
+    // only sync when Boo isn't in a death state
+    if (o->oAction < 3 || o->oAction == 5) {
         if (!sync_object_is_initialized(o->oSyncID)) {
             struct SyncObject* so = boo_sync_object_init();
             if (so) { so->syncDeathEvent = FALSE; }

--- a/src/game/behaviors/boo.inc.c
+++ b/src/game/behaviors/boo.inc.c
@@ -56,16 +56,11 @@ void bhv_boo_init(void) {
 
 static s32 boo_should_be_stopped(void) {
     if (cur_obj_has_behavior(bhvMerryGoRoundBigBoo) || cur_obj_has_behavior(bhvMerryGoRoundBoo)) {
-        for (s32 i = 0; i < MAX_PLAYERS; i++) {
-            if (!is_player_active(&gMarioStates[i])) { continue; }
-            if (gMarioStates[i].currentRoom != BBH_DYNAMIC_SURFACE_ROOM && gMarioStates[i].currentRoom != BBH_NEAR_MERRY_GO_ROUND_ROOM) { return TRUE; }
-        }
-        return FALSE;
-        /*if (!gMarioOnMerryGoRound) {
+        if (!gMarioOnMerryGoRound) {
             return TRUE;
         } else {
             return FALSE;
-        }*/
+        }
     } else {
         if (o->activeFlags & ACTIVE_FLAG_IN_DIFFERENT_ROOM) {
             return TRUE;

--- a/src/game/behaviors/boo.inc.c
+++ b/src/game/behaviors/boo.inc.c
@@ -528,7 +528,7 @@ static void (*sBooActions[])(void) = {
 };
 
 void bhv_boo_loop(void) {
-    // only sync when Boo isn't in a death state
+    // COOP: only sync when Boo isn't in a death state
     if (o->oAction < 3 || o->oAction == 5) {
         if (!sync_object_is_initialized(o->oSyncID)) {
             struct SyncObject* so = boo_sync_object_init();

--- a/src/game/object_helpers.c
+++ b/src/game/object_helpers.c
@@ -2948,8 +2948,6 @@ void cur_obj_enable_rendering_if_mario_in_room(void) {
     // 2) They are on an object surface with no explicit room
     // In vanilla, a room of 0 stops the game from checking if the object shouldn't be rendered
     // In coop, this needs to be respected to ensure the object remains active in areas with rooms
-    //if (gMarioCurrentRoom == 0) { return; }
-
     u8 marioInRoom = FALSE;
 
     // check if any player character can "see" the object's room

--- a/src/game/object_helpers.c
+++ b/src/game/object_helpers.c
@@ -2942,13 +2942,21 @@ void bhv_init_room(void) {
 void cur_obj_enable_rendering_if_mario_in_room(void) {
     if (!o) { return; }
     if (o->oRoom == -1) { return; }
-    if (gMarioCurrentRoom == 0) { return; }
+
+    // COOP: if any active player character's room is 0, then either:
+    // 1) There are no rooms in the area
+    // 2) They are on an object surface with no explicit room
+    // In vanilla, a room of 0 stops the game from checking if the object shouldn't be rendered
+    // In coop, this needs to be respected to ensure the object remains active in areas with rooms
+    //if (gMarioCurrentRoom == 0) { return; }
 
     u8 marioInRoom = FALSE;
 
     // check if any player character can "see" the object's room
     for (s32 i = 0; i < MAX_PLAYERS; i++) {
-        if (is_player_active(&gMarioStates[i]) && gMarioStates[i].currentRoom != 0) {
+        if (is_player_active(&gMarioStates[i])) {
+            // TODO: separate rendering and activation
+            if (gMarioStates[i].currentRoom == 0) { return; }
             s16 currentRoom = gMarioStates[i].currentRoom;
             if (
                 currentRoom == o->oRoom

--- a/src/game/object_helpers.c
+++ b/src/game/object_helpers.c
@@ -2946,15 +2946,17 @@ void cur_obj_enable_rendering_if_mario_in_room(void) {
 
     u8 marioInRoom = FALSE;
 
+    // check if any player character can "see" the object's room
     for (s32 i = 0; i < MAX_PLAYERS; i++) {
-        if (gMarioStates[i].currentRoom != 0) {
+        if (is_player_active(&gMarioStates[i]) && gMarioStates[i].currentRoom != 0) {
             s16 currentRoom = gMarioStates[i].currentRoom;
-            if (currentRoom == o->oRoom) {
+            if (
+                currentRoom == o->oRoom
+                || gDoorAdjacentRooms[currentRoom][0] == o->oRoom
+                || gDoorAdjacentRooms[currentRoom][1] == o->oRoom
+            ) {
                 marioInRoom = TRUE;
-            } else if (gDoorAdjacentRooms[currentRoom][0] == o->oRoom) {
-                marioInRoom = TRUE;
-            } else if (gDoorAdjacentRooms[currentRoom][1] == o->oRoom) {
-                marioInRoom = TRUE;
+                break;
             }
         }
     }


### PR DESCRIPTION
In the original SM64 code, `gMarioOnMerryGoRound` is tied with the music checks. This involves checking if Mario is on the merry-go-round platform, or if the floor type is `SURFACE_MGR_MUSIC`. Since music is client-side, SM64CDX needs the check for a Mario on the merry-go-round to be separated.

It currently does this by checking if any player character is on the platform, but not if the floor type is `SURFACE_MGR_MUSIC`. This has a side effect of the merry-go-round Boos not activating until a player character is on the merry-go-round platform. Critically, this means **the entrances to the merry-go-round do not activate the merry-go-round Boos**.

This can be observed in v1.4.1 if the player stands their character in the entrance of the merry-go-round closest to the painting where the Boos exit, and looks at said painting while close enough, <ins>but not on the platform</ins>. The Boos will spawn, but will not move, since they don't activate.

The fix is simple: also check if any player character's floor type is `SURFACE_MGR_MUSIC`. I considered removing the object platform check, since it's redundant in SM64, but I chose to keep it for consistency with expected behavior for mods.

---

It's very common for the merry-go-round Boos to desync if more than one player is in the same act of BBH. Sometimes it's possible to hit the Boos in the middle of the action transition from exiting the painting to roaming, but sometimes they stop spawning at all.

<ins>From minimal testing</ins>, it seems this is caused by a check on a Boo's action to determine if it should continue to be synced. It checks if `oAction` is less than 3. This seems to make sense at first glance, because action 3 is for dying, and action 4 is for displaying the text box for a "Go on a Ghost Hunt" Boo. However, there's also action 5, which is for a merry-go-round Boo exiting the painting. So this check is **causing the sync object to be forgotten specifically for merry-go-round Boos as they exit the painting**.

Adjusting the check to make sure action 5 is also included for syncing ~~seems to fix the issue.~~ However, I have my doubts, as since Boos sometimes don't spawn at all, and the spawning action is action 0, there's a chance that there's a different issue causing that. For that reason, in addition to the volatile nature of desyncs, **testing with various server circumstances would be prudent to see if this fix is sufficient**.

---

In addition to the first section, various parts of the code were preventing the game from properly detecting if a remote player was on the merry-go-round. Included in this was the rotating platform, since **an object's dynamic collision isn't loaded unless the rooms match**. The code has been modified to account for this. **This means other objects might be affected**.

---

Merry-go-round Boos aren't supposed to chase Mario if he goes too far away from their home. For some reason, Coop DX made it so merry-go-round Boos can **chase a player character regardless of distance**. This check has been added back.

---

Objects that are spawned after level load by a remote player are flagged as having been sent over the network. This affects the `SET_HOME` behavior command's function, `bhv_cmd_set_home`, where it **doesn't set the home if the object was sent over the network**. This is a problem for merry-go-round Boos since they use their behavior to set their home on spawn. To account for this, objects sent over the network can now set their home via behavior if the home hasn't already been set by behavior (e.g., if `Object.setHome` is `FALSE`) and the home is still the default initialization of (`0.0f`, `0.0f`, `0.0f`).  **This change potentially affects many objects, and obligates testing in an uncontrolled environment to prevent nasty oversights from affecting nonexperimental players.**