### PR TITLE
Make character sounds with frequency scale not cumulative

### DIFF
--- a/src/audio/external.c
+++ b/src/audio/external.c
@@ -1694,6 +1694,9 @@ static void update_game_sound(void) {
                             break;
                         case SOUND_BANK_ACTION:
                         case SOUND_BANK_MARIO_VOICE:
+                        case SOUND_BANK_LUIGI_VOICE:
+                        case SOUND_BANK_WARIO_VOICE:
+                        case SOUND_BANK_TOAD_VOICE:
 #if defined(VERSION_EU) || defined(VERSION_SH)
                             queue_audio_cmd_s8(AUDIO_CMD_ARGS(AUDIO_CMD_REVERB, SEQ_PLAYER_SFX, channelIndex, 0),
                                           get_sound_reverb(bank, soundIndex, channelIndex));

--- a/src/game/characters.c
+++ b/src/game/characters.c
@@ -248,7 +248,7 @@ struct Character gCharacters[CT_MAX] = {
         .animOffsetEnabled     = false,
 
         // sounds
-        .soundFreqScale        = 0.99f,
+        .soundFreqScale        = 0.88f,
         .soundYahWahHoo        = SOUND_LUIGI_YAH_WAH_HOO,
         .soundHoohoo           = SOUND_LUIGI_HOOHOO,
         .soundYahoo            = SOUND_LUIGI_YAHOO,


### PR DESCRIPTION
Character sounds with a custom frequency scale have that frequency applied every frame without any resets. This means that any sound with a custom frequency scale which plays long enough will trend toward 0 (-1 < f < 1), infinity (1 < f), or diverge with bias to both infinities (f < -1).

The culprit is simply that the custom sound banks for the new characters were not added to the sound processing for sound already playing, so frequencies for sounds in those banks weren't reset per audio frame. Adding them fixes the issue.

Currently, this issue only affects Waluigi. It's easily observed by allowing him to fall completely asleep, as the snoring sound is not restarted.

Because Waluigi currently accounts for this bug in order to sound "correct", his frequency value is too high. This PR suggests changing it to 0.88. It may be adjusted as the community feels is fitting.

https://github.com/user-attachments/assets/faecf1a4-d258-4ecc-86a7-75ef07ea8025

