### PR TITLE
Make temporary objects actually unique and temporary

### DIFF
--- a/autogen/convert_functions.py
+++ b/autogen/convert_functions.py
@@ -137,7 +137,6 @@ override_disallowed_functions = {
     "src/pc/lua/utils/smlua_gfx_utils.h":       [ "gfx_allocate_internal", "vtx_allocate_internal", "gfx_get_length_no_sentinel" ],
     "src/pc/network/lag_compensation.h":        [ "lag_compensation_clear" ],
     "src/game/first_person_cam.h":              [ "first_person_update" ],
-    "src/pc/lua/utils/smlua_collision_utils.h": [ "collision_find_surface_on_ray" ],
     "src/engine/behavior_script.h":             [ "stub_behavior_script_2", "cur_obj_update" ],
     "src/pc/mods/mod_storage.h":                [ "mod_storage_shutdown" ],
     "src/pc/mods/mod_fs.h":                     [ "mod_fs_read_file_from_uri", "mod_fs_shutdown" ],
@@ -229,7 +228,6 @@ manual_index_documentation = """
    - [level_script_parse](#level_script_parse)
    - [log_to_console](#log_to_console)
    - [add_scroll_target](#add_scroll_target)
-   - [collision_find_surface_on_ray](#collision_find_surface_on_ray)
    - [cast_graph_node](#cast_graph_node)
    - [get_uncolored_string](#get_uncolored_string)
    - [gfx_set_command](#gfx_set_command)
@@ -517,34 +515,6 @@ Registers a vertex buffer to be used for a scrolling texture. Should be used wit
 
 ### C Prototype
 `void dynos_add_scroll_target(u32 index, const char *name, u32 offset, u32 size);`
-
-[:arrow_up_small:](#)
-
-<br />
-
-## [collision_find_surface_on_ray](#collision_find_surface_on_ray)
-
-Shoots a raycast from `startX`, `startY`, and `startZ` in the direction of `dirX`, `dirY`, and `dirZ`.
-
-### Lua Example
-`collision_find_surface_on_ray(0, 0, 0, 50, 100, 50)`
-
-### Parameters
-| Field | Type |
-| ----- | ---- |
-| startX | `number` |
-| startY | `number` |
-| startZ | `number` |
-| dirX | `number` |
-| dirY | `number` |
-| dirZ | `number` |
-| precision (optional) | `number` |
-
-### Returns
-- [RayIntersectionInfo](structs.md#RayIntersectionInfo)
-
-### C Prototype
-`struct RayIntersectionInfo* collision_find_surface_on_ray(f32 startX, f32 startY, f32 startZ, f32 dirX, f32 dirY, f32 dirZ, f32 precision);`
 
 [:arrow_up_small:](#)
 
@@ -867,7 +837,15 @@ def build_return_value(id, rtype):
         lvt = translate_type_to_lvt(rtype)
         return '    smlua_push_pointer(L, %s, (void*)%s, NULL);\n' % (lvt, id)
     elif '???' not in lot and lot != 'LOT_NONE':
-        return '    smlua_push_object(L, %s, %s, NULL);\n' % (lot, id)
+        if '*' in rtype:
+            return '    smlua_push_object(L, %s, %s, NULL, false);\n' % (lot, id)
+        else:
+            return '''
+    %s *p = malloc(sizeof(%s));
+    if (!p) { LOG_LUA("Cannot allocate pointer for the return value of function '%%s'", "%s"); return 0; }
+    *p = %s;
+    smlua_push_object(L, %s, p, NULL, true);
+''' % (rtype, rtype, id[:id.find('(')], id, lot)
 
     return '    %s(L, %s);\n' % (lfunc, id)
 

--- a/autogen/gen_hooks.py
+++ b/autogen/gen_hooks.py
@@ -196,7 +196,7 @@ def init():
             SMLUA_TYPES[typename] = {
 "input": """
         // push {name}
-        smlua_push_object(L, %s, {name}, NULL);
+        smlua_push_object(L, %s, {name}, NULL, false);
 """ % (lot)
             }
 

--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -10635,6 +10635,19 @@ function camera_set_checking_surfaces(value)
     -- ...
 end
 
+--- @param startX number
+--- @param startY number
+--- @param startZ number
+--- @param dirX number
+--- @param dirY number
+--- @param dirZ number
+--- @param precision? number
+--- @return RayIntersectionInfo
+--- Shoots a raycast from `startX`, `startY`, and `startZ` in the direction of `dirX`, `dirY`, and `dirZ`, with a non-zero `precision`
+function collision_find_surface_on_ray(startX, startY, startZ, dirX, dirY, dirZ, precision)
+    -- ...
+end
+
 --- @param x number
 --- @param y number
 --- @param z number
@@ -11133,20 +11146,6 @@ end
 --- @return integer
 --- Gets the area update counter incremented when objects are updated
 function get_area_update_counter()
-    -- ...
-end
-
---- @param initialValue integer
---- @return Pointer_integer
---- Returns a temporary signed 32-bit integer pointer with its value set to `initialValue`
-function get_temp_s32_pointer(initialValue)
-    -- ...
-end
-
---- @param pointer Pointer_integer
---- @return integer
---- Gets the signed 32-bit integer value from `pointer`
-function deref_s32_pointer(pointer)
     -- ...
 end
 

--- a/autogen/lua_definitions/manual.lua
+++ b/autogen/lua_definitions/manual.lua
@@ -351,19 +351,6 @@ function add_scroll_target(index, name)
     -- ...
 end
 
---- @param startX number Start position X
---- @param startY number Start position Y
---- @param startZ number Start position Z
---- @param dirX number Direction X
---- @param dirY number Direction Y
---- @param dirZ number Direction Z
---- @param precision? number Optional; How precise the raycast should be. The default value is 3.0, the higher the number, the more precise.
---- @return RayIntersectionInfo
---- Shoots a raycast from `startX`, `startY`, and `startZ` in the direction of `dirX`, `dirY`, and `dirZ`
-function collision_find_surface_on_ray(startX, startY, startZ, dirX, dirY, dirZ, precision)
-    -- ...
-end
-
 --- @param contents ExclamationBoxContent[]
 --- Sets the contents that the exclamation box spawns.
 --- A single content has 5 keys: `id`, `unused`, `firstByte`, `model`, and `behavior`

--- a/docs/lua/functions-3.md
+++ b/docs/lua/functions-3.md
@@ -2870,7 +2870,7 @@ Gets the current DJUI HUD color
 - [DjuiColor](structs.md#DjuiColor)
 
 ### C Prototype
-`struct DjuiColor* djui_hud_get_color(void);`
+`struct DjuiColor djui_hud_get_color(void);`
 
 [:arrow_up_small:](#)
 

--- a/docs/lua/functions-6.md
+++ b/docs/lua/functions-6.md
@@ -7171,6 +7171,35 @@ Sets if the camera should account for surfaces
 <br />
 
 
+## [collision_find_surface_on_ray](#collision_find_surface_on_ray)
+
+### Description
+Shoots a raycast from `startX`, `startY`, and `startZ` in the direction of `dirX`, `dirY`, and `dirZ`, with a non-zero `precision`
+
+### Lua Example
+`local rayIntersectionInfoValue = collision_find_surface_on_ray(startX, startY, startZ, dirX, dirY, dirZ, precision)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| startX | `number` |
+| startY | `number` |
+| startZ | `number` |
+| dirX | `number` |
+| dirY | `number` |
+| dirZ | `number` |
+| precision | `number` |
+
+### Returns
+- [RayIntersectionInfo](structs.md#RayIntersectionInfo)
+
+### C Prototype
+`struct RayIntersectionInfo collision_find_surface_on_ray(f32 startX, f32 startY, f32 startZ, f32 dirX, f32 dirY, f32 dirZ, OPTIONAL f32 precision);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ## [collision_find_floor](#collision_find_floor)
 
 ### Description
@@ -7280,7 +7309,7 @@ Returns a temporary wall collision data pointer
 - [WallCollisionData](structs.md#WallCollisionData)
 
 ### C Prototype
-`struct WallCollisionData* collision_get_temp_wall_collision_data(void);`
+`struct WallCollisionData collision_get_temp_wall_collision_data(void);`
 
 [:arrow_up_small:](#)
 

--- a/docs/lua/functions-7.md
+++ b/docs/lua/functions-7.md
@@ -343,52 +343,6 @@ Gets the area update counter incremented when objects are updated
 
 <br />
 
-## [get_temp_s32_pointer](#get_temp_s32_pointer)
-
-### Description
-Returns a temporary signed 32-bit integer pointer with its value set to `initialValue`
-
-### Lua Example
-`local pointerValue = get_temp_s32_pointer(initialValue)`
-
-### Parameters
-| Field | Type |
-| ----- | ---- |
-| initialValue | `integer` |
-
-### Returns
-- `Pointer` <`integer`>
-
-### C Prototype
-`s32* get_temp_s32_pointer(s32 initialValue);`
-
-[:arrow_up_small:](#)
-
-<br />
-
-## [deref_s32_pointer](#deref_s32_pointer)
-
-### Description
-Gets the signed 32-bit integer value from `pointer`
-
-### Lua Example
-`local integerValue = deref_s32_pointer(pointer)`
-
-### Parameters
-| Field | Type |
-| ----- | ---- |
-| pointer | `Pointer` <`integer`> |
-
-### Returns
-- `integer`
-
-### C Prototype
-`s32 deref_s32_pointer(s32* pointer);`
-
-[:arrow_up_small:](#)
-
-<br />
-
 ## [djui_popup_create_global](#djui_popup_create_global)
 
 ### Description
@@ -1683,7 +1637,7 @@ Gets the system clock's date and time
 - [DateTime](structs.md#DateTime)
 
 ### C Prototype
-`struct DateTime* get_date_and_time(void);`
+`struct DateTime get_date_and_time(void);`
 
 [:arrow_up_small:](#)
 
@@ -3185,7 +3139,7 @@ Returns a temporary particle spawn info pointer with its model loaded in from `m
 - [SpawnParticlesInfo](structs.md#SpawnParticlesInfo)
 
 ### C Prototype
-`struct SpawnParticlesInfo* obj_get_temp_spawn_particles_info(enum ModelExtendedId modelId);`
+`struct SpawnParticlesInfo obj_get_temp_spawn_particles_info(enum ModelExtendedId modelId);`
 
 [:arrow_up_small:](#)
 
@@ -3209,7 +3163,7 @@ Returns a temporary water droplet params pointer with its model and behavior loa
 - [WaterDropletParams](structs.md#WaterDropletParams)
 
 ### C Prototype
-`struct WaterDropletParams* obj_get_temp_water_droplet_params(enum ModelExtendedId modelId, enum BehaviorId behaviorId);`
+`struct WaterDropletParams obj_get_temp_water_droplet_params(enum ModelExtendedId modelId, enum BehaviorId behaviorId);`
 
 [:arrow_up_small:](#)
 
@@ -3230,7 +3184,7 @@ Returns a temporary object hitbox pointer
 - [ObjectHitbox](structs.md#ObjectHitbox)
 
 ### C Prototype
-`struct ObjectHitbox* get_temp_object_hitbox(void);`
+`struct ObjectHitbox get_temp_object_hitbox(void);`
 
 [:arrow_up_small:](#)
 

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -21,7 +21,6 @@
    - [level_script_parse](#level_script_parse)
    - [log_to_console](#log_to_console)
    - [add_scroll_target](#add_scroll_target)
-   - [collision_find_surface_on_ray](#collision_find_surface_on_ray)
    - [cast_graph_node](#cast_graph_node)
    - [get_uncolored_string](#get_uncolored_string)
    - [gfx_set_command](#gfx_set_command)
@@ -1905,6 +1904,7 @@
 <br />
 
 - smlua_collision_utils.h
+   - [collision_find_surface_on_ray](functions-6.md#collision_find_surface_on_ray)
    - [collision_find_floor](functions-6.md#collision_find_floor)
    - [collision_find_ceil](functions-6.md#collision_find_ceil)
    - [get_water_surface_pseudo_floor](functions-6.md#get_water_surface_pseudo_floor)
@@ -1992,8 +1992,6 @@
 - smlua_misc_utils.h
    - [get_network_area_timer](functions-7.md#get_network_area_timer)
    - [get_area_update_counter](functions-7.md#get_area_update_counter)
-   - [get_temp_s32_pointer](functions-7.md#get_temp_s32_pointer)
-   - [deref_s32_pointer](functions-7.md#deref_s32_pointer)
    - [djui_popup_create_global](functions-7.md#djui_popup_create_global)
    - [djui_is_popup_disabled](functions-7.md#djui_is_popup_disabled)
    - [djui_set_popup_disabled_override](functions-7.md#djui_set_popup_disabled_override)
@@ -2515,34 +2513,6 @@ Registers a vertex buffer to be used for a scrolling texture. Should be used wit
 
 ### C Prototype
 `void dynos_add_scroll_target(u32 index, const char *name, u32 offset, u32 size);`
-
-[:arrow_up_small:](#)
-
-<br />
-
-## [collision_find_surface_on_ray](#collision_find_surface_on_ray)
-
-Shoots a raycast from `startX`, `startY`, and `startZ` in the direction of `dirX`, `dirY`, and `dirZ`.
-
-### Lua Example
-`collision_find_surface_on_ray(0, 0, 0, 50, 100, 50)`
-
-### Parameters
-| Field | Type |
-| ----- | ---- |
-| startX | `number` |
-| startY | `number` |
-| startZ | `number` |
-| dirX | `number` |
-| dirY | `number` |
-| dirZ | `number` |
-| precision (optional) | `number` |
-
-### Returns
-- [RayIntersectionInfo](structs.md#RayIntersectionInfo)
-
-### C Prototype
-`struct RayIntersectionInfo* collision_find_surface_on_ray(f32 startX, f32 startY, f32 startZ, f32 dirX, f32 dirY, f32 dirZ, f32 precision);`
 
 [:arrow_up_small:](#)
 

--- a/src/engine/behavior_script.c
+++ b/src/engine/behavior_script.c
@@ -1042,7 +1042,7 @@ static s32 bhv_cmd_call_native_ext(void) {
     lua_rawgeti(gLuaState, LUA_REGISTRYINDEX, funcRef);
 
     // Push object
-    smlua_push_object(gLuaState, LOT_OBJECT, gCurrentObject, NULL);
+    smlua_push_object(gLuaState, LOT_OBJECT, gCurrentObject, NULL, false);
 
     // Call the callback
     if (0 != smlua_call_hook(gLuaState, 1, 0, 0, mod, modFile)) {

--- a/src/game/mario_misc.c
+++ b/src/game/mario_misc.c
@@ -916,7 +916,7 @@ Gfx *geo_process_lua_function(s32 callContext, struct GraphNode *node, UNUSED Ma
 
     // Push the callback, the graph node and the current matrix stack index
     lua_rawgeti(L, LUA_REGISTRYINDEX, funcRef);
-    smlua_push_object(L, LOT_GRAPHNODE, node, NULL);
+    smlua_push_object(L, LOT_GRAPHNODE, node, NULL, false);
     lua_pushinteger(L, gMatStackIndex);
 
     // Call the callback

--- a/src/pc/djui/djui_hud_utils.c
+++ b/src/pc/djui/djui_hud_utils.c
@@ -62,8 +62,6 @@ static struct HudUtilsState sHudUtilsState = {
     },
 };
 
-static struct DjuiColor sRefColor = { 255, 255, 255, 255 };
-
 f32 gDjuiHudUtilsZ = 0;
 bool gDjuiHudLockMouse = false;
 
@@ -315,12 +313,8 @@ void djui_hud_set_font(s8 fontType) {
     sHudUtilsState.font = fontType;
 }
 
-struct DjuiColor* djui_hud_get_color(void) {
-    sRefColor.r = sHudUtilsState.color.r;
-    sRefColor.g = sHudUtilsState.color.g;
-    sRefColor.b = sHudUtilsState.color.b;
-    sRefColor.a = sHudUtilsState.color.a;
-    return &sRefColor;
+struct DjuiColor djui_hud_get_color(void) {
+    return sHudUtilsState.color;
 }
 
 void djui_hud_set_color(u8 r, u8 g, u8 b, u8 a) {

--- a/src/pc/djui/djui_hud_utils.h
+++ b/src/pc/djui/djui_hud_utils.h
@@ -75,7 +75,7 @@ s8 djui_hud_get_font(void);
 /* |description|Sets the current DJUI HUD font|descriptionEnd| */
 void djui_hud_set_font(s8 fontType);
 /* |description|Gets the current DJUI HUD color|descriptionEnd| */
-struct DjuiColor* djui_hud_get_color(void);
+struct DjuiColor djui_hud_get_color(void);
 /* |description|Sets the current DJUI HUD color|descriptionEnd| */
 void djui_hud_set_color(u8 r, u8 g, u8 b, u8 a);
 /* |description|Resets the current DJUI HUD color|descriptionEnd| */

--- a/src/pc/lua/smlua.c
+++ b/src/pc/lua/smlua.c
@@ -407,8 +407,10 @@ void smlua_update(void) {
     // doing incremental garbage collection.
     // The real fix would be to make smlua produce less
     // garbage.
-    // lua_gc(L, LUA_GCSTOP, 0);
-    // lua_gc(L, LUA_GCCOLLECT, 0);
+    // EDIT²: smlua is so lazy during its GC that userdata is
+    // never garbage collected. Perform a GC cycle at the end
+    // of each frame to make sure it doesn't "forget" about it.
+    lua_gc(L, LUA_GCSTEP, 0);
 }
 
 void smlua_shutdown(void) {

--- a/src/pc/lua/smlua_cobject.c
+++ b/src/pc/lua/smlua_cobject.c
@@ -364,25 +364,25 @@ struct LuaObjectField* smlua_get_custom_field(lua_State* L, u32 lot, int keyInde
     return &lof;
 }
 
-  /////////////////////
- // CObject get/set //
-/////////////////////
+  /////////////
+ // CObject //
+/////////////
 
-static bool smlua_push_field(lua_State* L, u8* p, struct LuaObjectField *data) {
+static bool smlua_cobject_get_field(lua_State* L, u8* p, struct LuaObjectField *data) {
     switch (data->valueType) {
-        case LVT_BOOL:      lua_pushboolean(L, *(u8* )p);                    break;
-        case LVT_U8:        lua_pushinteger(L, *(u8* )p);                    break;
-        case LVT_U16:       lua_pushinteger(L, *(u16*)p);                    break;
-        case LVT_U32:       lua_pushinteger(L, *(u32*)p);                    break;
-        case LVT_S8:        lua_pushinteger(L, *(s8* )p);                    break;
-        case LVT_S16:       lua_pushinteger(L, *(s16*)p);                    break;
-        case LVT_S32:       lua_pushinteger(L, *(s32*)p);                    break;
-        case LVT_F32:       lua_pushnumber( L, *(f32*)p);                    break;
-        case LVT_U64:       lua_pushinteger(L, *(u64*)p);                    break;
-        case LVT_COBJECT:   smlua_push_object(L, data->lot, p, NULL);        break;
-        case LVT_COBJECT_P: smlua_push_object(L, data->lot, *(u8**)p, NULL); break;
-        case LVT_STRING:    lua_pushstring(L, (char*)p);                     break;
-        case LVT_STRING_P:  lua_pushstring(L, *(char**)p);                   break;
+        case LVT_BOOL:      lua_pushboolean(L, *(u8* )p);                           break;
+        case LVT_U8:        lua_pushinteger(L, *(u8* )p);                           break;
+        case LVT_U16:       lua_pushinteger(L, *(u16*)p);                           break;
+        case LVT_U32:       lua_pushinteger(L, *(u32*)p);                           break;
+        case LVT_S8:        lua_pushinteger(L, *(s8* )p);                           break;
+        case LVT_S16:       lua_pushinteger(L, *(s16*)p);                           break;
+        case LVT_S32:       lua_pushinteger(L, *(s32*)p);                           break;
+        case LVT_F32:       lua_pushnumber( L, *(f32*)p);                           break;
+        case LVT_U64:       lua_pushinteger(L, *(u64*)p);                           break;
+        case LVT_COBJECT:   smlua_push_object(L, data->lot, p, NULL, false);        break;
+        case LVT_COBJECT_P: smlua_push_object(L, data->lot, *(u8**)p, NULL, false); break;
+        case LVT_STRING:    lua_pushstring(L, (char*)p);                            break;
+        case LVT_STRING_P:  lua_pushstring(L, *(char**)p);                          break;
 
         // pointers
         case LVT_BOOL_P:
@@ -409,7 +409,7 @@ static bool smlua_push_field(lua_State* L, u8* p, struct LuaObjectField *data) {
     return false;
 }
 
-static bool smlua_set_field(lua_State* L, u8* p, struct LuaObjectField *data) {
+static bool smlua_cobject_set_field(lua_State* L, u8* p, struct LuaObjectField *data) {
     void* valuePointer = NULL;
     switch (data->valueType) {
         case LVT_BOOL:*(u8*) p = smlua_to_boolean(L, 3); break;
@@ -465,7 +465,7 @@ static bool smlua_set_field(lua_State* L, u8* p, struct LuaObjectField *data) {
     return false;
 }
 
-static int smlua__get_field(lua_State* L) {
+static int smlua_cobject_get(lua_State* L) {
     LUA_STACK_CHECK_BEGIN_NUM(L, 1);
 
     const CObject *cobj = lua_touserdata(L, 1);
@@ -514,7 +514,7 @@ static int smlua__get_field(lua_State* L) {
         }
 
         u8* p = ((u8*)(intptr_t)pointer) + (key * data->size);
-        if (smlua_push_field(L, p, data)) {
+        if (smlua_cobject_get_field(L, p, data)) {
             LOG_LUA_LINE("_get_field on unimplemented type '%d', key '%u'", data->valueType, key);
             return 0;
         }
@@ -560,12 +560,12 @@ static int smlua__get_field(lua_State* L) {
 
     u8* p = ((u8*)(intptr_t)pointer) + data->valueOffset;
     if (data->count == 1) {
-        if (smlua_push_field(L, p, data)) {
+        if (smlua_cobject_get_field(L, p, data)) {
             LOG_LUA_LINE("_get_field on unimplemented type '%d', key '%s'", data->valueType, key);
             return 0;
         }
     } else {
-        smlua_push_object(L, LOT_ARRAY, p, data);
+        smlua_push_object(L, LOT_ARRAY, p, data, false);
         if (!gSmLuaConvertSuccess) {
             LOG_LUA_LINE("_set_field failed to retrieve value type '%d', key '%s'", data->valueType, key);
             return 0;
@@ -576,7 +576,7 @@ static int smlua__get_field(lua_State* L) {
     return 1;
 }
 
-static int smlua__set_field(lua_State* L) {
+static int smlua_cobject_set(lua_State* L) {
     LUA_STACK_CHECK_BEGIN(L);
 
     const CObject *cobj = lua_touserdata(L, 1);
@@ -608,7 +608,7 @@ static int smlua__set_field(lua_State* L) {
         }
 
         u8* p = ((u8*)(intptr_t)pointer) + (key * data->size);
-        if (smlua_set_field(L, p, data)) {
+        if (smlua_cobject_set_field(L, p, data)) {
             LOG_LUA_LINE("_set_field on unimplemented type '%d', key '%u'", data->valueType, key);
             return 0;
         }
@@ -639,7 +639,7 @@ static int smlua__set_field(lua_State* L) {
     }
 
     u8* p = ((u8*)(intptr_t)pointer) + data->valueOffset;
-    if (smlua_set_field(L, p, data)) {
+    if (smlua_cobject_set_field(L, p, data)) {
         LOG_LUA_LINE("_set_field on unimplemented type '%d', key '%s'", data->valueType, key);
         return 0;
     }
@@ -652,18 +652,32 @@ static int smlua__set_field(lua_State* L) {
     return 1;
 }
 
-int smlua__eq(lua_State *L) {
+static int smlua_cobject_eq(lua_State* L) {
     const CObject *a = lua_touserdata(L, 1);
     const CObject *b = lua_touserdata(L, 2);
     lua_pushboolean(L, a && b && a->lot == b->lot && a->pointer == b->pointer);
     return 1;
 }
 
-int smlua__bnot(lua_State *L) {
+static int smlua_cobject_bnot(lua_State* L) {
     const CObject *a = lua_touserdata(L, 1);
     lua_pushboolean(L, !a || a->freed);
     return 1;
 }
+
+static int smlua_cobject_gc(lua_State* L) {
+    CObject *cobj = lua_touserdata(L, 1);
+    if (cobj && cobj->dynamic) {
+        free(cobj->pointer);
+        cobj->pointer = NULL;
+        cobj->freed = true;
+    }
+    return 0;
+}
+
+  //////////////
+ // CPointer //
+//////////////
 
 static int smlua_cpointer_get(lua_State* L) {
     const CPointer *cptr = lua_touserdata(L, 1);
@@ -684,7 +698,23 @@ static int smlua_cpointer_get(lua_State* L) {
 
     return 0;
 }
-static int smlua_cpointer_set(UNUSED lua_State* L) { return 0; }
+
+static int smlua_cpointer_set(UNUSED lua_State* L) {
+    return 0;
+}
+
+static int smlua_cpointer_eq(lua_State* L) {
+    const CPointer *a = lua_touserdata(L, 1);
+    const CPointer *b = lua_touserdata(L, 2);
+    lua_pushboolean(L, a && b && a->lvt == b->lvt && a->pointer == b->pointer);
+    return 1;
+}
+
+static int smlua_cpointer_bnot(lua_State* L) {
+    const CPointer *a = lua_touserdata(L, 1);
+    lua_pushboolean(L, !a || a->freed);
+    return 1;
+}
 
   //////////
  // bind //
@@ -702,10 +732,11 @@ void smlua_cobject_init_globals(void) {
     // Create metatables
     luaL_newmetatable(L, "CObject");
     luaL_Reg cObjectMethods[] = {
-        { "__index",    smlua__get_field },
-        { "__newindex", smlua__set_field },
-        { "__eq",       smlua__eq },
-        { "__bnot",     smlua__bnot },
+        { "__index",    smlua_cobject_get },
+        { "__newindex", smlua_cobject_set },
+        { "__eq",       smlua_cobject_eq },
+        { "__bnot",     smlua_cobject_bnot },
+        { "__gc",       smlua_cobject_gc },
         { "__metatable", NULL },
         { NULL, NULL }
     };
@@ -715,8 +746,8 @@ void smlua_cobject_init_globals(void) {
     luaL_Reg cPointerMethods[] = {
         { "__index",    smlua_cpointer_get },
         { "__newindex", smlua_cpointer_set },
-        { "__eq",       smlua__eq },
-        { "__bnot",     smlua__bnot },
+        { "__eq",       smlua_cpointer_eq },
+        { "__bnot",     smlua_cpointer_bnot },
         { "__metatable", NULL },
         { NULL, NULL }
     };
@@ -729,15 +760,15 @@ void smlua_cobject_init_globals(void) {
         int t = lua_gettop(gLuaState); \
         for (s32 i = 0; i < iterator; i++) { \
             lua_pushinteger(L, i); \
-            smlua_push_object(L, lot, &ptr[i], NULL); \
+            smlua_push_object(L, lot, &ptr[i], NULL, false); \
             lua_settable(L, t); \
         } \
         lua_setglobal(L, #ptr); \
     } \
 
-#define EXPOSE_GLOBAL(lot, ptr) smlua_push_object(L, lot, &ptr, NULL); lua_setglobal(L, #ptr);
-#define EXPOSE_GLOBAL_PTR(lot, ptr) smlua_push_object(L, lot, ptr, NULL); lua_setglobal(L, #ptr);
-#define EXPOSE_GLOBAL_WITH_NAME(lot, ptr, name) smlua_push_object(L, lot, ptr, NULL); lua_setglobal(L, name);
+#define EXPOSE_GLOBAL(lot, ptr) smlua_push_object(L, lot, &ptr, NULL, false); lua_setglobal(L, #ptr);
+#define EXPOSE_GLOBAL_PTR(lot, ptr) smlua_push_object(L, lot, ptr, NULL, false); lua_setglobal(L, #ptr);
+#define EXPOSE_GLOBAL_WITH_NAME(lot, ptr, name) smlua_push_object(L, lot, ptr, NULL, false); lua_setglobal(L, name);
 
     // Array structs
 
@@ -750,7 +781,7 @@ void smlua_cobject_init_globals(void) {
         int t = lua_gettop(gLuaState);
         for (s32 i = 0; i < gActiveMods.entryCount; i++) {
             lua_pushinteger(L, i);
-            smlua_push_object(L, LOT_MOD, gActiveMods.entries[i], NULL);
+            smlua_push_object(L, LOT_MOD, gActiveMods.entries[i], NULL, false);
             lua_settable(L, t);
         }
         lua_setglobal(L, "gActiveMods");

--- a/src/pc/lua/smlua_cobject.h
+++ b/src/pc/lua/smlua_cobject.h
@@ -60,6 +60,7 @@ typedef struct {
     u16 lot;
     bool freed;
     void *info;
+    bool dynamic;
 } CObject;
 
 typedef struct {

--- a/src/pc/lua/smlua_functions.c
+++ b/src/pc/lua/smlua_functions.c
@@ -840,34 +840,6 @@ int smlua_func_add_scroll_target(lua_State* L) {
     return 1;
 }
 
-  /////////////
- // raycast //
-/////////////
-
-int smlua_func_collision_find_surface_on_ray(lua_State* L) {
-    if (!smlua_functions_valid_param_range(L, 6, 7)) { return 0; }
-    int paramCount = lua_gettop(L);
-
-    f32 startX = smlua_to_number(L, 1);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("collision_find_surface_on_ray: Failed to convert parameter 1"); return 0; }
-    f32 startY = smlua_to_number(L, 2);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("collision_find_surface_on_ray: Failed to convert parameter 2"); return 0; }
-    f32 startZ = smlua_to_number(L, 3);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("collision_find_surface_on_ray: Failed to convert parameter 3"); return 0; }
-    f32 dirX = smlua_to_number(L, 4);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("collision_find_surface_on_ray: Failed to convert parameter 4"); return 0; }
-    f32 dirY = smlua_to_number(L, 5);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("collision_find_surface_on_ray: Failed to convert parameter 5"); return 0; }
-    f32 dirZ = smlua_to_number(L, 6);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("collision_find_surface_on_ray: Failed to convert parameter 6"); return 0; }
-    f32 precision = paramCount == 7 ? smlua_to_number(L, 7) : 3.0f;
-    if (!gSmLuaConvertSuccess) { LOG_LUA("collision_find_surface_on_ray: Failed to convert parameter 7"); return 0; }
-
-    smlua_push_object(L, LOT_RAYINTERSECTIONINFO, collision_find_surface_on_ray(startX, startY, startZ, dirX, dirY, dirZ, precision), NULL);
-
-    return 1;
-}
-
   ////////////////
  // graph node //
 ////////////////
@@ -927,7 +899,7 @@ int smlua_func_cast_graph_node(lua_State* L) {
         return 0;
     }
 
-    smlua_push_object(L, lot, graphNode, NULL);
+    smlua_push_object(L, lot, graphNode, NULL, false);
 
     // Register this graph node as modified so it can be reset later
     dynos_actor_register_modified_graph_node(graphNode);
@@ -1027,7 +999,6 @@ void smlua_bind_functions(void) {
     smlua_bind_function(L, "smlua_anim_util_register_animation", smlua_func_smlua_anim_util_register_animation);
     smlua_bind_function(L, "log_to_console", smlua_func_log_to_console);
     smlua_bind_function(L, "add_scroll_target", smlua_func_add_scroll_target);
-    smlua_bind_function(L, "collision_find_surface_on_ray", smlua_func_collision_find_surface_on_ray);
     smlua_bind_function(L, "cast_graph_node", smlua_func_cast_graph_node);
     smlua_bind_function(L, "get_uncolored_string", smlua_func_get_uncolored_string);
     smlua_bind_function(L, "gfx_set_command", smlua_func_gfx_set_command);

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -474,7 +474,7 @@ int smlua_func_area_get_warp_node(lua_State* L) {
     u8 id = smlua_to_integer(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "area_get_warp_node"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECTWARPNODE, area_get_warp_node(id), NULL);
+    smlua_push_object(L, LOT_OBJECTWARPNODE, area_get_warp_node(id), NULL, false);
 
     return 1;
 }
@@ -489,7 +489,7 @@ int smlua_func_area_get_any_warp_node(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_OBJECTWARPNODE, area_get_any_warp_node(), NULL);
+    smlua_push_object(L, LOT_OBJECTWARPNODE, area_get_any_warp_node(), NULL, false);
 
     return 1;
 }
@@ -506,7 +506,7 @@ int smlua_func_area_get_warp_node_from_params(lua_State* L) {
     struct Object* o = (struct Object*)smlua_to_cobject(L, 1, LOT_OBJECT);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "area_get_warp_node_from_params"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECTWARPNODE, area_get_warp_node_from_params(o), NULL);
+    smlua_push_object(L, LOT_OBJECTWARPNODE, area_get_warp_node_from_params(o), NULL, false);
 
     return 1;
 }
@@ -9746,7 +9746,7 @@ int smlua_func_spawn_default_star(lua_State* L) {
     f32 z = smlua_to_number(L, 3);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "spawn_default_star"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, spawn_default_star(x, y, z), NULL);
+    smlua_push_object(L, LOT_OBJECT, spawn_default_star(x, y, z), NULL, false);
 
     return 1;
 }
@@ -9767,7 +9767,7 @@ int smlua_func_spawn_red_coin_cutscene_star(lua_State* L) {
     f32 z = smlua_to_number(L, 3);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "spawn_red_coin_cutscene_star"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, spawn_red_coin_cutscene_star(x, y, z), NULL);
+    smlua_push_object(L, LOT_OBJECT, spawn_red_coin_cutscene_star(x, y, z), NULL, false);
 
     return 1;
 }
@@ -9788,7 +9788,7 @@ int smlua_func_spawn_no_exit_star(lua_State* L) {
     f32 z = smlua_to_number(L, 3);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "spawn_no_exit_star"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, spawn_no_exit_star(x, y, z), NULL);
+    smlua_push_object(L, LOT_OBJECT, spawn_no_exit_star(x, y, z), NULL, false);
 
     return 1;
 }
@@ -12006,7 +12006,7 @@ int smlua_func_get_character(lua_State* L) {
     struct MarioState* m = (struct MarioState*)smlua_to_cobject(L, 1, LOT_MARIOSTATE);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "get_character"); return 0; }
 
-    smlua_push_object(L, LOT_CHARACTER, get_character(m), NULL);
+    smlua_push_object(L, LOT_CHARACTER, get_character(m), NULL, false);
 
     return 1;
 }
@@ -12275,7 +12275,11 @@ int smlua_func_djui_hud_get_color(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_DJUICOLOR, djui_hud_get_color(), NULL);
+
+    struct DjuiColor *p = malloc(sizeof(struct DjuiColor));
+    if (!p) { LOG_LUA("Cannot allocate pointer for the return value of function '%s'", "djui_hud_get_color"); return 0; }
+    *p = djui_hud_get_color();
+    smlua_push_object(L, LOT_DJUICOLOR, p, NULL, true);
 
     return 1;
 }
@@ -14930,7 +14934,7 @@ int smlua_func_mario_get_collided_object(lua_State* L) {
     u32 interactType = smlua_to_integer(L, 2);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "mario_get_collided_object"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, mario_get_collided_object(m, interactType), NULL);
+    smlua_push_object(L, LOT_OBJECT, mario_get_collided_object(m, interactType), NULL, false);
 
     return 1;
 }
@@ -15093,7 +15097,7 @@ int smlua_func_lag_compensation_get_local_state(lua_State* L) {
     struct NetworkPlayer* otherNp = (struct NetworkPlayer*)smlua_to_cobject(L, 1, LOT_NETWORKPLAYER);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "lag_compensation_get_local_state"); return 0; }
 
-    smlua_push_object(L, LOT_MARIOSTATE, lag_compensation_get_local_state(otherNp), NULL);
+    smlua_push_object(L, LOT_MARIOSTATE, lag_compensation_get_local_state(otherNp), NULL, false);
 
     return 1;
 }
@@ -15286,7 +15290,7 @@ int smlua_func_area_create_warp_node(lua_State* L) {
     struct Object* o = (struct Object*)smlua_to_cobject(L, 6, LOT_OBJECT);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 6, "area_create_warp_node"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECTWARPNODE, area_create_warp_node(id, destLevel, destArea, destNode, checkpoint, o), NULL);
+    smlua_push_object(L, LOT_OBJECTWARPNODE, area_create_warp_node(id, destLevel, destArea, destNode, checkpoint, o), NULL, false);
 
     return 1;
 }
@@ -15356,7 +15360,7 @@ int smlua_func_get_instant_warp(lua_State* L) {
     u8 index = smlua_to_integer(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "get_instant_warp"); return 0; }
 
-    smlua_push_object(L, LOT_INSTANTWARP, get_instant_warp(index), NULL);
+    smlua_push_object(L, LOT_INSTANTWARP, get_instant_warp(index), NULL, false);
 
     return 1;
 }
@@ -15371,7 +15375,7 @@ int smlua_func_get_painting_warp_node(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_WARPNODE, get_painting_warp_node(), NULL);
+    smlua_push_object(L, LOT_WARPNODE, get_painting_warp_node(), NULL, false);
 
     return 1;
 }
@@ -16530,7 +16534,7 @@ int smlua_func_resolve_and_return_wall_collisions(lua_State* L) {
     f32 radius = smlua_to_number(L, 3);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "resolve_and_return_wall_collisions"); return 0; }
 
-    smlua_push_object(L, LOT_SURFACE, resolve_and_return_wall_collisions(pos, offset, radius), NULL);
+    smlua_push_object(L, LOT_SURFACE, resolve_and_return_wall_collisions(pos, offset, radius), NULL, false);
 
     smlua_push_vec3f(pos, 1);
 
@@ -16584,7 +16588,7 @@ int smlua_func_vec3f_find_ceil(lua_State* L) {
 
     lua_pushnumber(L, vec3f_find_ceil(pos, height, &ceil));
 
-    smlua_push_object(L, LOT_SURFACE, ceil, NULL);
+    smlua_push_object(L, LOT_SURFACE, ceil, NULL, false);
 
     return 2;
 }
@@ -16609,7 +16613,7 @@ int smlua_func_vec3f_mario_ceil(lua_State* L) {
 
     lua_pushnumber(L, vec3f_mario_ceil(pos, height, &ceil));
 
-    smlua_push_object(L, LOT_SURFACE, ceil, NULL);
+    smlua_push_object(L, LOT_SURFACE, ceil, NULL, false);
 
     return 2;
 }
@@ -17053,7 +17057,7 @@ int smlua_func_get_mario_state_from_object(lua_State* L) {
     struct Object* o = (struct Object*)smlua_to_cobject(L, 1, LOT_OBJECT);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "get_mario_state_from_object"); return 0; }
 
-    smlua_push_object(L, LOT_MARIOSTATE, get_mario_state_from_object(o), NULL);
+    smlua_push_object(L, LOT_MARIOSTATE, get_mario_state_from_object(o), NULL, false);
 
     return 1;
 }
@@ -19184,7 +19188,7 @@ int smlua_func_geo_get_mario_state(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_MARIOSTATE, geo_get_mario_state(), NULL);
+    smlua_push_object(L, LOT_MARIOSTATE, geo_get_mario_state(), NULL, false);
 
     return 1;
 }
@@ -19199,7 +19203,7 @@ int smlua_func_geo_get_body_state(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_MARIOBODYSTATE, geo_get_body_state(), NULL);
+    smlua_push_object(L, LOT_MARIOBODYSTATE, geo_get_body_state(), NULL, false);
 
     return 1;
 }
@@ -22397,7 +22401,7 @@ int smlua_func_mod_fs_get(lua_State* L) {
         if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "mod_fs_get"); return 0; }
     }
 
-    smlua_push_object(L, LOT_MODFS, mod_fs_get(modPath), NULL);
+    smlua_push_object(L, LOT_MODFS, mod_fs_get(modPath), NULL, false);
 
     return 1;
 }
@@ -22417,7 +22421,7 @@ int smlua_func_mod_fs_reload(lua_State* L) {
         if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "mod_fs_reload"); return 0; }
     }
 
-    smlua_push_object(L, LOT_MODFS, mod_fs_reload(modPath), NULL);
+    smlua_push_object(L, LOT_MODFS, mod_fs_reload(modPath), NULL, false);
 
     return 1;
 }
@@ -22432,7 +22436,7 @@ int smlua_func_mod_fs_create(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_MODFS, mod_fs_create(), NULL);
+    smlua_push_object(L, LOT_MODFS, mod_fs_create(), NULL, false);
 
     return 1;
 }
@@ -22470,7 +22474,7 @@ int smlua_func_mod_fs_get_file(lua_State* L) {
     const char* filepath = smlua_to_string(L, 2);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "mod_fs_get_file"); return 0; }
 
-    smlua_push_object(L, LOT_MODFSFILE, mod_fs_get_file(modFs, filepath), NULL);
+    smlua_push_object(L, LOT_MODFSFILE, mod_fs_get_file(modFs, filepath), NULL, false);
 
     return 1;
 }
@@ -22491,7 +22495,7 @@ int smlua_func_mod_fs_create_file(lua_State* L) {
     bool text = smlua_to_boolean(L, 3);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "mod_fs_create_file"); return 0; }
 
-    smlua_push_object(L, LOT_MODFSFILE, mod_fs_create_file(modFs, filepath, text), NULL);
+    smlua_push_object(L, LOT_MODFSFILE, mod_fs_create_file(modFs, filepath, text), NULL, false);
 
     return 1;
 }
@@ -23275,7 +23279,7 @@ int smlua_func_network_player_from_global_index(lua_State* L) {
     u8 globalIndex = smlua_to_integer(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "network_player_from_global_index"); return 0; }
 
-    smlua_push_object(L, LOT_NETWORKPLAYER, network_player_from_global_index(globalIndex), NULL);
+    smlua_push_object(L, LOT_NETWORKPLAYER, network_player_from_global_index(globalIndex), NULL, false);
 
     return 1;
 }
@@ -23296,7 +23300,7 @@ int smlua_func_get_network_player_from_level(lua_State* L) {
     s16 levelNum = smlua_to_integer(L, 3);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "get_network_player_from_level"); return 0; }
 
-    smlua_push_object(L, LOT_NETWORKPLAYER, get_network_player_from_level(courseNum, actNum, levelNum), NULL);
+    smlua_push_object(L, LOT_NETWORKPLAYER, get_network_player_from_level(courseNum, actNum, levelNum), NULL, false);
 
     return 1;
 }
@@ -23319,7 +23323,7 @@ int smlua_func_get_network_player_from_area(lua_State* L) {
     s16 areaIndex = smlua_to_integer(L, 4);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 4, "get_network_player_from_area"); return 0; }
 
-    smlua_push_object(L, LOT_NETWORKPLAYER, get_network_player_from_area(courseNum, actNum, levelNum, areaIndex), NULL);
+    smlua_push_object(L, LOT_NETWORKPLAYER, get_network_player_from_area(courseNum, actNum, levelNum, areaIndex), NULL, false);
 
     return 1;
 }
@@ -23334,7 +23338,7 @@ int smlua_func_get_network_player_smallest_global(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_NETWORKPLAYER, get_network_player_smallest_global(), NULL);
+    smlua_push_object(L, LOT_NETWORKPLAYER, get_network_player_smallest_global(), NULL, false);
 
     return 1;
 }
@@ -23938,7 +23942,7 @@ int smlua_func_nearest_mario_state_to_object(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "nearest_mario_state_to_object"); return 0; }
 
     extern struct MarioState* nearest_mario_state_to_object(struct Object *obj);
-    smlua_push_object(L, LOT_MARIOSTATE, nearest_mario_state_to_object(obj), NULL);
+    smlua_push_object(L, LOT_MARIOSTATE, nearest_mario_state_to_object(obj), NULL, false);
 
     return 1;
 }
@@ -23956,7 +23960,7 @@ int smlua_func_nearest_possible_mario_state_to_object(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "nearest_possible_mario_state_to_object"); return 0; }
 
     extern struct MarioState* nearest_possible_mario_state_to_object(struct Object *obj);
-    smlua_push_object(L, LOT_MARIOSTATE, nearest_possible_mario_state_to_object(obj), NULL);
+    smlua_push_object(L, LOT_MARIOSTATE, nearest_possible_mario_state_to_object(obj), NULL, false);
 
     return 1;
 }
@@ -23974,7 +23978,7 @@ int smlua_func_nearest_player_to_object(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "nearest_player_to_object"); return 0; }
 
     extern struct Object* nearest_player_to_object(struct Object *obj);
-    smlua_push_object(L, LOT_OBJECT, nearest_player_to_object(obj), NULL);
+    smlua_push_object(L, LOT_OBJECT, nearest_player_to_object(obj), NULL, false);
 
     return 1;
 }
@@ -23992,7 +23996,7 @@ int smlua_func_nearest_interacting_mario_state_to_object(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "nearest_interacting_mario_state_to_object"); return 0; }
 
     extern struct MarioState *nearest_interacting_mario_state_to_object(struct Object *obj);
-    smlua_push_object(L, LOT_MARIOSTATE, nearest_interacting_mario_state_to_object(obj), NULL);
+    smlua_push_object(L, LOT_MARIOSTATE, nearest_interacting_mario_state_to_object(obj), NULL, false);
 
     return 1;
 }
@@ -24010,7 +24014,7 @@ int smlua_func_nearest_interacting_player_to_object(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "nearest_interacting_player_to_object"); return 0; }
 
     extern struct Object *nearest_interacting_player_to_object(struct Object *obj);
-    smlua_push_object(L, LOT_OBJECT, nearest_interacting_player_to_object(obj), NULL);
+    smlua_push_object(L, LOT_OBJECT, nearest_interacting_player_to_object(obj), NULL, false);
 
     return 1;
 }
@@ -25269,7 +25273,7 @@ int smlua_func_obj_spit_fire(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 8, "obj_spit_fire"); return 0; }
 
     extern struct Object* obj_spit_fire(s16 relativePosX, s16 relativePosY, s16 relativePosZ, f32 scale, s32 model, f32 startSpeed, f32 endSpeed, s16 movePitch);
-    smlua_push_object(L, LOT_OBJECT, obj_spit_fire(relativePosX, relativePosY, relativePosZ, scale, model, startSpeed, endSpeed, movePitch), NULL);
+    smlua_push_object(L, LOT_OBJECT, obj_spit_fire(relativePosX, relativePosY, relativePosZ, scale, model, startSpeed, endSpeed, movePitch), NULL, false);
 
     return 1;
 }
@@ -25885,7 +25889,7 @@ int smlua_func_spawn_water_droplet(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "spawn_water_droplet"); return 0; }
 
     extern struct Object *spawn_water_droplet(struct Object *parent, struct WaterDropletParams *params);
-    smlua_push_object(L, LOT_OBJECT, spawn_water_droplet(parent, params), NULL);
+    smlua_push_object(L, LOT_OBJECT, spawn_water_droplet(parent, params), NULL, false);
 
     return 1;
 }
@@ -26531,7 +26535,7 @@ int smlua_func_cur_obj_nearest_object_with_behavior(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "cur_obj_nearest_object_with_behavior"); return 0; }
 
     extern struct Object *cur_obj_nearest_object_with_behavior(const BehaviorScript *behavior);
-    smlua_push_object(L, LOT_OBJECT, cur_obj_nearest_object_with_behavior(behavior), NULL);
+    smlua_push_object(L, LOT_OBJECT, cur_obj_nearest_object_with_behavior(behavior), NULL, false);
 
     return 1;
 }
@@ -26565,7 +26569,7 @@ int smlua_func_cur_obj_find_nearest_pole(UNUSED lua_State* L) {
 
 
     extern struct Object* cur_obj_find_nearest_pole(void);
-    smlua_push_object(L, LOT_OBJECT, cur_obj_find_nearest_pole(), NULL);
+    smlua_push_object(L, LOT_OBJECT, cur_obj_find_nearest_pole(), NULL, false);
 
     return 1;
 }
@@ -26585,7 +26589,7 @@ int smlua_func_cur_obj_find_nearest_object_with_behavior(lua_State* L) {
     f32 dist;
 
     extern struct Object *cur_obj_find_nearest_object_with_behavior(const BehaviorScript *behavior, RET f32 *dist);
-    smlua_push_object(L, LOT_OBJECT, cur_obj_find_nearest_object_with_behavior(behavior, &dist), NULL);
+    smlua_push_object(L, LOT_OBJECT, cur_obj_find_nearest_object_with_behavior(behavior, &dist), NULL, false);
 
     lua_pushnumber(L, dist);
 
@@ -26623,7 +26627,7 @@ int smlua_func_find_unimportant_object(UNUSED lua_State* L) {
 
 
     extern struct Object *find_unimportant_object(void);
-    smlua_push_object(L, LOT_OBJECT, find_unimportant_object(), NULL);
+    smlua_push_object(L, LOT_OBJECT, find_unimportant_object(), NULL, false);
 
     return 1;
 }
@@ -26675,7 +26679,7 @@ int smlua_func_find_object_with_behavior(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "find_object_with_behavior"); return 0; }
 
     extern struct Object *find_object_with_behavior(const BehaviorScript *behavior);
-    smlua_push_object(L, LOT_OBJECT, find_object_with_behavior(behavior), NULL);
+    smlua_push_object(L, LOT_OBJECT, find_object_with_behavior(behavior), NULL, false);
 
     return 1;
 }
@@ -26695,7 +26699,7 @@ int smlua_func_cur_obj_find_nearby_held_actor(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "cur_obj_find_nearby_held_actor"); return 0; }
 
     extern struct Object *cur_obj_find_nearby_held_actor(const BehaviorScript *behavior, f32 maxDist);
-    smlua_push_object(L, LOT_OBJECT, cur_obj_find_nearby_held_actor(behavior, maxDist), NULL);
+    smlua_push_object(L, LOT_OBJECT, cur_obj_find_nearby_held_actor(behavior, maxDist), NULL, false);
 
     return 1;
 }
@@ -27157,7 +27161,7 @@ int smlua_func_cur_obj_update_floor_height_and_get_floor(UNUSED lua_State* L) {
 
 
     extern struct Surface *cur_obj_update_floor_height_and_get_floor(void);
-    smlua_push_object(L, LOT_SURFACE, cur_obj_update_floor_height_and_get_floor(), NULL);
+    smlua_push_object(L, LOT_SURFACE, cur_obj_update_floor_height_and_get_floor(), NULL, false);
 
     return 1;
 }
@@ -28838,7 +28842,7 @@ int smlua_func_spawn_star_with_no_lvl_exit(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "spawn_star_with_no_lvl_exit"); return 0; }
 
     extern struct Object *spawn_star_with_no_lvl_exit(s32 sp20, s32 sp24);
-    smlua_push_object(L, LOT_OBJECT, spawn_star_with_no_lvl_exit(sp20, sp24), NULL);
+    smlua_push_object(L, LOT_OBJECT, spawn_star_with_no_lvl_exit(sp20, sp24), NULL, false);
 
     return 1;
 }
@@ -30341,7 +30345,7 @@ int smlua_func_get_mario_vanilla_animation(lua_State* L) {
     u16 index = smlua_to_integer(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "get_mario_vanilla_animation"); return 0; }
 
-    smlua_push_object(L, LOT_ANIMATION, get_mario_vanilla_animation(index), NULL);
+    smlua_push_object(L, LOT_ANIMATION, get_mario_vanilla_animation(index), NULL, false);
 
     return 1;
 }
@@ -30436,7 +30440,7 @@ int smlua_func_audio_stream_load(lua_State* L) {
     const char* filename = smlua_to_string(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "audio_stream_load"); return 0; }
 
-    smlua_push_object(L, LOT_MODAUDIO, audio_stream_load(filename), NULL);
+    smlua_push_object(L, LOT_MODAUDIO, audio_stream_load(filename), NULL, false);
 
     return 1;
 }
@@ -30690,7 +30694,7 @@ int smlua_func_audio_sample_load(lua_State* L) {
     const char* filename = smlua_to_string(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "audio_sample_load"); return 0; }
 
-    smlua_push_object(L, LOT_MODAUDIO, audio_sample_load(filename), NULL);
+    smlua_push_object(L, LOT_MODAUDIO, audio_sample_load(filename), NULL, false);
 
     return 1;
 }
@@ -31573,6 +31577,42 @@ int smlua_func_camera_set_checking_surfaces(lua_State* L) {
  // smlua_collision_utils.h //
 /////////////////////////////
 
+int smlua_func_collision_find_surface_on_ray(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top < 6 || top > 7) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "collision_find_surface_on_ray", 6, 7, top);
+        return 0;
+    }
+
+    f32 startX = smlua_to_number(L, 1);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "collision_find_surface_on_ray"); return 0; }
+    f32 startY = smlua_to_number(L, 2);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "collision_find_surface_on_ray"); return 0; }
+    f32 startZ = smlua_to_number(L, 3);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "collision_find_surface_on_ray"); return 0; }
+    f32 dirX = smlua_to_number(L, 4);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 4, "collision_find_surface_on_ray"); return 0; }
+    f32 dirY = smlua_to_number(L, 5);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 5, "collision_find_surface_on_ray"); return 0; }
+    f32 dirZ = smlua_to_number(L, 6);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 6, "collision_find_surface_on_ray"); return 0; }
+    f32 precision = (f32) 0;
+    if (top >= 7) {
+        precision = smlua_to_number(L, 7);
+        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 7, "collision_find_surface_on_ray"); return 0; }
+    }
+
+
+    struct RayIntersectionInfo *p = malloc(sizeof(struct RayIntersectionInfo));
+    if (!p) { LOG_LUA("Cannot allocate pointer for the return value of function '%s'", "collision_find_surface_on_ray"); return 0; }
+    *p = collision_find_surface_on_ray(startX, startY, startZ, dirX, dirY, dirZ, precision);
+    smlua_push_object(L, LOT_RAYINTERSECTIONINFO, p, NULL, true);
+
+    return 1;
+}
+
 int smlua_func_collision_find_floor(lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -31589,7 +31629,7 @@ int smlua_func_collision_find_floor(lua_State* L) {
     f32 z = smlua_to_number(L, 3);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "collision_find_floor"); return 0; }
 
-    smlua_push_object(L, LOT_SURFACE, collision_find_floor(x, y, z), NULL);
+    smlua_push_object(L, LOT_SURFACE, collision_find_floor(x, y, z), NULL, false);
 
     return 1;
 }
@@ -31610,7 +31650,7 @@ int smlua_func_collision_find_ceil(lua_State* L) {
     f32 z = smlua_to_number(L, 3);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "collision_find_ceil"); return 0; }
 
-    smlua_push_object(L, LOT_SURFACE, collision_find_ceil(x, y, z), NULL);
+    smlua_push_object(L, LOT_SURFACE, collision_find_ceil(x, y, z), NULL, false);
 
     return 1;
 }
@@ -31625,7 +31665,7 @@ int smlua_func_get_water_surface_pseudo_floor(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_SURFACE, get_water_surface_pseudo_floor(), NULL);
+    smlua_push_object(L, LOT_SURFACE, get_water_surface_pseudo_floor(), NULL, false);
 
     return 1;
 }
@@ -31657,7 +31697,11 @@ int smlua_func_collision_get_temp_wall_collision_data(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_WALLCOLLISIONDATA, collision_get_temp_wall_collision_data(), NULL);
+
+    struct WallCollisionData *p = malloc(sizeof(struct WallCollisionData));
+    if (!p) { LOG_LUA("Cannot allocate pointer for the return value of function '%s'", "collision_get_temp_wall_collision_data"); return 0; }
+    *p = collision_get_temp_wall_collision_data();
+    smlua_push_object(L, LOT_WALLCOLLISIONDATA, p, NULL, true);
 
     return 1;
 }
@@ -31676,7 +31720,7 @@ int smlua_func_get_surface_from_wcd_index(lua_State* L) {
     s8 index = smlua_to_integer(L, 2);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "get_surface_from_wcd_index"); return 0; }
 
-    smlua_push_object(L, LOT_SURFACE, get_surface_from_wcd_index(wcd, index), NULL);
+    smlua_push_object(L, LOT_SURFACE, get_surface_from_wcd_index(wcd, index), NULL, false);
 
     return 1;
 }
@@ -32294,7 +32338,7 @@ int smlua_func_gfx_get_display_list(lua_State* L) {
     Gfx * cmd = (Gfx *)smlua_to_cobject(L, 1, LOT_GFX);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "gfx_get_display_list"); return 0; }
 
-    smlua_push_object(L, LOT_GFX, gfx_get_display_list(cmd), NULL);
+    smlua_push_object(L, LOT_GFX, gfx_get_display_list(cmd), NULL, false);
 
     return 1;
 }
@@ -32311,7 +32355,7 @@ int smlua_func_gfx_get_vertex_buffer(lua_State* L) {
     Gfx * cmd = (Gfx *)smlua_to_cobject(L, 1, LOT_GFX);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "gfx_get_vertex_buffer"); return 0; }
 
-    smlua_push_object(L, LOT_VTX, gfx_get_vertex_buffer(cmd), NULL);
+    smlua_push_object(L, LOT_VTX, gfx_get_vertex_buffer(cmd), NULL, false);
 
     return 1;
 }
@@ -32364,7 +32408,7 @@ int smlua_func_gfx_get_from_name(lua_State* L) {
 
     u32 length;
 
-    smlua_push_object(L, LOT_GFX, gfx_get_from_name(name, &length), NULL);
+    smlua_push_object(L, LOT_GFX, gfx_get_from_name(name, &length), NULL, false);
 
     lua_pushinteger(L, length);
 
@@ -32419,7 +32463,7 @@ int smlua_func_gfx_get_command(lua_State* L) {
     u32 offset = smlua_to_integer(L, 2);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "gfx_get_command"); return 0; }
 
-    smlua_push_object(L, LOT_GFX, gfx_get_command(gfx, offset), NULL);
+    smlua_push_object(L, LOT_GFX, gfx_get_command(gfx, offset), NULL, false);
 
     return 1;
 }
@@ -32436,7 +32480,7 @@ int smlua_func_gfx_get_next_command(lua_State* L) {
     Gfx * gfx = (Gfx *)smlua_to_cobject(L, 1, LOT_GFX);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "gfx_get_next_command"); return 0; }
 
-    smlua_push_object(L, LOT_GFX, gfx_get_next_command(gfx), NULL);
+    smlua_push_object(L, LOT_GFX, gfx_get_next_command(gfx), NULL, false);
 
     return 1;
 }
@@ -32476,7 +32520,7 @@ int smlua_func_gfx_create(lua_State* L) {
     u32 length = smlua_to_integer(L, 2);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "gfx_create"); return 0; }
 
-    smlua_push_object(L, LOT_GFX, gfx_create(name, length), NULL);
+    smlua_push_object(L, LOT_GFX, gfx_create(name, length), NULL, false);
 
     return 1;
 }
@@ -32546,7 +32590,7 @@ int smlua_func_vtx_get_from_name(lua_State* L) {
 
     u32 count;
 
-    smlua_push_object(L, LOT_VTX, vtx_get_from_name(name, &count), NULL);
+    smlua_push_object(L, LOT_VTX, vtx_get_from_name(name, &count), NULL, false);
 
     lua_pushinteger(L, count);
 
@@ -32601,7 +32645,7 @@ int smlua_func_vtx_get_vertex(lua_State* L) {
     u32 offset = smlua_to_integer(L, 2);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "vtx_get_vertex"); return 0; }
 
-    smlua_push_object(L, LOT_VTX, vtx_get_vertex(vtx, offset), NULL);
+    smlua_push_object(L, LOT_VTX, vtx_get_vertex(vtx, offset), NULL, false);
 
     return 1;
 }
@@ -32618,7 +32662,7 @@ int smlua_func_vtx_get_next_vertex(lua_State* L) {
     Vtx * vtx = (Vtx *)smlua_to_cobject(L, 1, LOT_VTX);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "vtx_get_next_vertex"); return 0; }
 
-    smlua_push_object(L, LOT_VTX, vtx_get_next_vertex(vtx), NULL);
+    smlua_push_object(L, LOT_VTX, vtx_get_next_vertex(vtx), NULL, false);
 
     return 1;
 }
@@ -32658,7 +32702,7 @@ int smlua_func_vtx_create(lua_State* L) {
     u32 count = smlua_to_integer(L, 2);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "vtx_create"); return 0; }
 
-    smlua_push_object(L, LOT_VTX, vtx_create(name, count), NULL);
+    smlua_push_object(L, LOT_VTX, vtx_create(name, count), NULL, false);
 
     return 1;
 }
@@ -32747,7 +32791,7 @@ int smlua_func_smlua_level_util_get_info(lua_State* L) {
     s16 levelNum = smlua_to_integer(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "smlua_level_util_get_info"); return 0; }
 
-    smlua_push_object(L, LOT_CUSTOMLEVELINFO, smlua_level_util_get_info(levelNum), NULL);
+    smlua_push_object(L, LOT_CUSTOMLEVELINFO, smlua_level_util_get_info(levelNum), NULL, false);
 
     return 1;
 }
@@ -32764,7 +32808,7 @@ int smlua_func_smlua_level_util_get_info_from_short_name(lua_State* L) {
     const char* shortName = smlua_to_string(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "smlua_level_util_get_info_from_short_name"); return 0; }
 
-    smlua_push_object(L, LOT_CUSTOMLEVELINFO, smlua_level_util_get_info_from_short_name(shortName), NULL);
+    smlua_push_object(L, LOT_CUSTOMLEVELINFO, smlua_level_util_get_info_from_short_name(shortName), NULL, false);
 
     return 1;
 }
@@ -32781,7 +32825,7 @@ int smlua_func_smlua_level_util_get_info_from_course_num(lua_State* L) {
     u8 courseNum = smlua_to_integer(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "smlua_level_util_get_info_from_course_num"); return 0; }
 
-    smlua_push_object(L, LOT_CUSTOMLEVELINFO, smlua_level_util_get_info_from_course_num(courseNum), NULL);
+    smlua_push_object(L, LOT_CUSTOMLEVELINFO, smlua_level_util_get_info_from_course_num(courseNum), NULL, false);
 
     return 1;
 }
@@ -32976,40 +33020,6 @@ int smlua_func_get_area_update_counter(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_temp_s32_pointer(lua_State* L) {
-    if (L == NULL) { return 0; }
-
-    int top = lua_gettop(L);
-    if (top != 1) {
-        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "get_temp_s32_pointer", 1, top);
-        return 0;
-    }
-
-    s32 initialValue = smlua_to_integer(L, 1);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "get_temp_s32_pointer"); return 0; }
-
-    smlua_push_pointer(L, LVT_S32_P, (void*)get_temp_s32_pointer(initialValue), NULL);
-
-    return 1;
-}
-
-int smlua_func_deref_s32_pointer(lua_State* L) {
-    if (L == NULL) { return 0; }
-
-    int top = lua_gettop(L);
-    if (top != 1) {
-        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "deref_s32_pointer", 1, top);
-        return 0;
-    }
-
-    s32* pointer = (s32*)smlua_to_cpointer(L, 1, LVT_S32_P);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "deref_s32_pointer"); return 0; }
-
-    lua_pushinteger(L, deref_s32_pointer(pointer));
-
-    return 1;
-}
-
 int smlua_func_djui_popup_create_global(lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -33161,7 +33171,7 @@ int smlua_func_djui_menu_get_theme(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_DJUITHEME, djui_menu_get_theme(), NULL);
+    smlua_push_object(L, LOT_DJUITHEME, djui_menu_get_theme(), NULL, false);
 
     return 1;
 }
@@ -33991,7 +34001,11 @@ int smlua_func_get_date_and_time(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_DATETIME, get_date_and_time(), NULL);
+
+    struct DateTime *p = malloc(sizeof(struct DateTime));
+    if (!p) { LOG_LUA("Cannot allocate pointer for the return value of function '%s'", "get_date_and_time"); return 0; }
+    *p = get_date_and_time();
+    smlua_push_object(L, LOT_DATETIME, p, NULL, true);
 
     return 1;
 }
@@ -34296,7 +34310,7 @@ int smlua_func_get_active_mod(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_MOD, get_active_mod(), NULL);
+    smlua_push_object(L, LOT_MOD, get_active_mod(), NULL, false);
 
     return 1;
 }
@@ -34358,7 +34372,7 @@ int smlua_func_geo_get_current_root(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_GRAPHNODEROOT, geo_get_current_root(), NULL);
+    smlua_push_object(L, LOT_GRAPHNODEROOT, geo_get_current_root(), NULL, false);
 
     return 1;
 }
@@ -34373,7 +34387,7 @@ int smlua_func_geo_get_current_master_list(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_GRAPHNODEMASTERLIST, geo_get_current_master_list(), NULL);
+    smlua_push_object(L, LOT_GRAPHNODEMASTERLIST, geo_get_current_master_list(), NULL, false);
 
     return 1;
 }
@@ -34388,7 +34402,7 @@ int smlua_func_geo_get_current_perspective(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_GRAPHNODEPERSPECTIVE, geo_get_current_perspective(), NULL);
+    smlua_push_object(L, LOT_GRAPHNODEPERSPECTIVE, geo_get_current_perspective(), NULL, false);
 
     return 1;
 }
@@ -34403,7 +34417,7 @@ int smlua_func_geo_get_current_camera(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_GRAPHNODECAMERA, geo_get_current_camera(), NULL);
+    smlua_push_object(L, LOT_GRAPHNODECAMERA, geo_get_current_camera(), NULL, false);
 
     return 1;
 }
@@ -34418,7 +34432,7 @@ int smlua_func_geo_get_current_held_object(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_GRAPHNODEHELDOBJECT, geo_get_current_held_object(), NULL);
+    smlua_push_object(L, LOT_GRAPHNODEHELDOBJECT, geo_get_current_held_object(), NULL, false);
 
     return 1;
 }
@@ -34523,7 +34537,7 @@ int smlua_func_spawn_sync_object(lua_State* L) {
     LuaFunction objSetupFunction = smlua_to_lua_function(L, 6);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 6, "spawn_sync_object"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, spawn_sync_object(behaviorId, modelId, x, y, z, objSetupFunction), NULL);
+    smlua_push_object(L, LOT_OBJECT, spawn_sync_object(behaviorId, modelId, x, y, z, objSetupFunction), NULL, false);
 
     return 1;
 }
@@ -34550,7 +34564,7 @@ int smlua_func_spawn_non_sync_object(lua_State* L) {
     LuaFunction objSetupFunction = smlua_to_lua_function(L, 6);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 6, "spawn_non_sync_object"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, spawn_non_sync_object(behaviorId, modelId, x, y, z, objSetupFunction), NULL);
+    smlua_push_object(L, LOT_OBJECT, spawn_non_sync_object(behaviorId, modelId, x, y, z, objSetupFunction), NULL, false);
 
     return 1;
 }
@@ -34656,7 +34670,7 @@ int smlua_func_geo_get_current_object(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_OBJECT, geo_get_current_object(), NULL);
+    smlua_push_object(L, LOT_OBJECT, geo_get_current_object(), NULL, false);
 
     return 1;
 }
@@ -34671,7 +34685,7 @@ int smlua_func_get_current_object(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_OBJECT, get_current_object(), NULL);
+    smlua_push_object(L, LOT_OBJECT, get_current_object(), NULL, false);
 
     return 1;
 }
@@ -34686,7 +34700,7 @@ int smlua_func_get_dialog_object(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_OBJECT, get_dialog_object(), NULL);
+    smlua_push_object(L, LOT_OBJECT, get_dialog_object(), NULL, false);
 
     return 1;
 }
@@ -34701,7 +34715,7 @@ int smlua_func_get_cutscene_focus(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_OBJECT, get_cutscene_focus(), NULL);
+    smlua_push_object(L, LOT_OBJECT, get_cutscene_focus(), NULL, false);
 
     return 1;
 }
@@ -34716,7 +34730,7 @@ int smlua_func_get_secondary_camera_focus(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_OBJECT, get_secondary_camera_focus(), NULL);
+    smlua_push_object(L, LOT_OBJECT, get_secondary_camera_focus(), NULL, false);
 
     return 1;
 }
@@ -34767,7 +34781,7 @@ int smlua_func_obj_get_first(lua_State* L) {
     int objList = smlua_to_integer(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "obj_get_first"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, obj_get_first(objList), NULL);
+    smlua_push_object(L, LOT_OBJECT, obj_get_first(objList), NULL, false);
 
     return 1;
 }
@@ -34784,7 +34798,7 @@ int smlua_func_obj_get_first_with_behavior_id(lua_State* L) {
     int behaviorId = smlua_to_integer(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "obj_get_first_with_behavior_id"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, obj_get_first_with_behavior_id(behaviorId), NULL);
+    smlua_push_object(L, LOT_OBJECT, obj_get_first_with_behavior_id(behaviorId), NULL, false);
 
     return 1;
 }
@@ -34805,7 +34819,7 @@ int smlua_func_obj_get_first_with_behavior_id_and_field_s32(lua_State* L) {
     s32 value = smlua_to_integer(L, 3);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "obj_get_first_with_behavior_id_and_field_s32"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, obj_get_first_with_behavior_id_and_field_s32(behaviorId, fieldIndex, value), NULL);
+    smlua_push_object(L, LOT_OBJECT, obj_get_first_with_behavior_id_and_field_s32(behaviorId, fieldIndex, value), NULL, false);
 
     return 1;
 }
@@ -34826,7 +34840,7 @@ int smlua_func_obj_get_first_with_behavior_id_and_field_f32(lua_State* L) {
     f32 value = smlua_to_number(L, 3);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "obj_get_first_with_behavior_id_and_field_f32"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, obj_get_first_with_behavior_id_and_field_f32(behaviorId, fieldIndex, value), NULL);
+    smlua_push_object(L, LOT_OBJECT, obj_get_first_with_behavior_id_and_field_f32(behaviorId, fieldIndex, value), NULL, false);
 
     return 1;
 }
@@ -34843,7 +34857,7 @@ int smlua_func_obj_get_next(lua_State* L) {
     struct Object* o = (struct Object*)smlua_to_cobject(L, 1, LOT_OBJECT);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "obj_get_next"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, obj_get_next(o), NULL);
+    smlua_push_object(L, LOT_OBJECT, obj_get_next(o), NULL, false);
 
     return 1;
 }
@@ -34860,7 +34874,7 @@ int smlua_func_obj_get_next_with_same_behavior_id(lua_State* L) {
     struct Object* o = (struct Object*)smlua_to_cobject(L, 1, LOT_OBJECT);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "obj_get_next_with_same_behavior_id"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, obj_get_next_with_same_behavior_id(o), NULL);
+    smlua_push_object(L, LOT_OBJECT, obj_get_next_with_same_behavior_id(o), NULL, false);
 
     return 1;
 }
@@ -34881,7 +34895,7 @@ int smlua_func_obj_get_next_with_same_behavior_id_and_field_s32(lua_State* L) {
     s32 value = smlua_to_integer(L, 3);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "obj_get_next_with_same_behavior_id_and_field_s32"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, obj_get_next_with_same_behavior_id_and_field_s32(o, fieldIndex, value), NULL);
+    smlua_push_object(L, LOT_OBJECT, obj_get_next_with_same_behavior_id_and_field_s32(o, fieldIndex, value), NULL, false);
 
     return 1;
 }
@@ -34902,7 +34916,7 @@ int smlua_func_obj_get_next_with_same_behavior_id_and_field_f32(lua_State* L) {
     f32 value = smlua_to_number(L, 3);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "obj_get_next_with_same_behavior_id_and_field_f32"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, obj_get_next_with_same_behavior_id_and_field_f32(o, fieldIndex, value), NULL);
+    smlua_push_object(L, LOT_OBJECT, obj_get_next_with_same_behavior_id_and_field_f32(o, fieldIndex, value), NULL, false);
 
     return 1;
 }
@@ -34921,7 +34935,7 @@ int smlua_func_obj_get_nearest_object_with_behavior_id(lua_State* L) {
     int behaviorId = smlua_to_integer(L, 2);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "obj_get_nearest_object_with_behavior_id"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, obj_get_nearest_object_with_behavior_id(o, behaviorId), NULL);
+    smlua_push_object(L, LOT_OBJECT, obj_get_nearest_object_with_behavior_id(o, behaviorId), NULL, false);
 
     return 1;
 }
@@ -34957,7 +34971,7 @@ int smlua_func_obj_get_collided_object(lua_State* L) {
     s16 index = smlua_to_integer(L, 2);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "obj_get_collided_object"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, obj_get_collided_object(o, index), NULL);
+    smlua_push_object(L, LOT_OBJECT, obj_get_collided_object(o, index), NULL, false);
 
     return 1;
 }
@@ -35138,7 +35152,11 @@ int smlua_func_obj_get_temp_spawn_particles_info(lua_State* L) {
     int modelId = smlua_to_integer(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "obj_get_temp_spawn_particles_info"); return 0; }
 
-    smlua_push_object(L, LOT_SPAWNPARTICLESINFO, obj_get_temp_spawn_particles_info(modelId), NULL);
+
+    struct SpawnParticlesInfo *p = malloc(sizeof(struct SpawnParticlesInfo));
+    if (!p) { LOG_LUA("Cannot allocate pointer for the return value of function '%s'", "obj_get_temp_spawn_particles_info"); return 0; }
+    *p = obj_get_temp_spawn_particles_info(modelId);
+    smlua_push_object(L, LOT_SPAWNPARTICLESINFO, p, NULL, true);
 
     return 1;
 }
@@ -35157,7 +35175,11 @@ int smlua_func_obj_get_temp_water_droplet_params(lua_State* L) {
     int behaviorId = smlua_to_integer(L, 2);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "obj_get_temp_water_droplet_params"); return 0; }
 
-    smlua_push_object(L, LOT_WATERDROPLETPARAMS, obj_get_temp_water_droplet_params(modelId, behaviorId), NULL);
+
+    struct WaterDropletParams *p = malloc(sizeof(struct WaterDropletParams));
+    if (!p) { LOG_LUA("Cannot allocate pointer for the return value of function '%s'", "obj_get_temp_water_droplet_params"); return 0; }
+    *p = obj_get_temp_water_droplet_params(modelId, behaviorId);
+    smlua_push_object(L, LOT_WATERDROPLETPARAMS, p, NULL, true);
 
     return 1;
 }
@@ -35172,7 +35194,11 @@ int smlua_func_get_temp_object_hitbox(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_OBJECTHITBOX, get_temp_object_hitbox(), NULL);
+
+    struct ObjectHitbox *p = malloc(sizeof(struct ObjectHitbox));
+    if (!p) { LOG_LUA("Cannot allocate pointer for the return value of function '%s'", "get_temp_object_hitbox"); return 0; }
+    *p = get_temp_object_hitbox();
+    smlua_push_object(L, LOT_OBJECTHITBOX, p, NULL, true);
 
     return 1;
 }
@@ -35516,7 +35542,7 @@ int smlua_func_smlua_text_utils_dialog_get(lua_State* L) {
     int dialogId = smlua_to_integer(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "smlua_text_utils_dialog_get"); return 0; }
 
-    smlua_push_object(L, LOT_DIALOGENTRY, smlua_text_utils_dialog_get(dialogId), NULL);
+    smlua_push_object(L, LOT_DIALOGENTRY, smlua_text_utils_dialog_get(dialogId), NULL, false);
 
     return 1;
 }
@@ -36351,7 +36377,7 @@ int smlua_func_find_ceil(lua_State* L) {
 
     lua_pushnumber(L, find_ceil(posX, posY, posZ, &pceil));
 
-    smlua_push_object(L, LOT_SURFACE, pceil, NULL);
+    smlua_push_object(L, LOT_SURFACE, pceil, NULL, false);
 
     return 2;
 }
@@ -36443,7 +36469,7 @@ int smlua_func_find_floor(lua_State* L) {
 
     lua_pushnumber(L, find_floor(xPos, yPos, zPos, &pfloor));
 
-    smlua_push_object(L, LOT_SURFACE, pfloor, NULL);
+    smlua_push_object(L, LOT_SURFACE, pfloor, NULL, false);
 
     return 2;
 }
@@ -36598,7 +36624,7 @@ int smlua_func_load_static_object_collision(UNUSED lua_State* L) {
     }
 
 
-    smlua_push_object(L, LOT_STATICOBJECTCOLLISION, load_static_object_collision(), NULL);
+    smlua_push_object(L, LOT_STATICOBJECTCOLLISION, load_static_object_collision(), NULL, false);
 
     return 1;
 }
@@ -36636,7 +36662,7 @@ int smlua_func_get_static_object_surface(lua_State* L) {
     u32 index = smlua_to_integer(L, 2);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "get_static_object_surface"); return 0; }
 
-    smlua_push_object(L, LOT_SURFACE, get_static_object_surface(col, index), NULL);
+    smlua_push_object(L, LOT_SURFACE, get_static_object_surface(col, index), NULL, false);
 
     return 1;
 }
@@ -36655,7 +36681,7 @@ int smlua_func_obj_get_surface_from_index(lua_State* L) {
     u32 index = smlua_to_integer(L, 2);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "obj_get_surface_from_index"); return 0; }
 
-    smlua_push_object(L, LOT_SURFACE, obj_get_surface_from_index(o, index), NULL);
+    smlua_push_object(L, LOT_SURFACE, obj_get_surface_from_index(o, index), NULL, false);
 
     return 1;
 }
@@ -36693,7 +36719,7 @@ int smlua_func_sync_object_get_object(lua_State* L) {
     u32 syncId = smlua_to_integer(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "sync_object_get_object"); return 0; }
 
-    smlua_push_object(L, LOT_OBJECT, sync_object_get_object(syncId), NULL);
+    smlua_push_object(L, LOT_OBJECT, sync_object_get_object(syncId), NULL, false);
 
     return 1;
 }
@@ -38521,6 +38547,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "camera_set_checking_surfaces", smlua_func_camera_set_checking_surfaces);
 
     // smlua_collision_utils.h
+    smlua_bind_function(L, "collision_find_surface_on_ray", smlua_func_collision_find_surface_on_ray);
     smlua_bind_function(L, "collision_find_floor", smlua_func_collision_find_floor);
     smlua_bind_function(L, "collision_find_ceil", smlua_func_collision_find_ceil);
     smlua_bind_function(L, "get_water_surface_pseudo_floor", smlua_func_get_water_surface_pseudo_floor);
@@ -38606,8 +38633,6 @@ void smlua_bind_functions_autogen(void) {
     // smlua_misc_utils.h
     smlua_bind_function(L, "get_network_area_timer", smlua_func_get_network_area_timer);
     smlua_bind_function(L, "get_area_update_counter", smlua_func_get_area_update_counter);
-    smlua_bind_function(L, "get_temp_s32_pointer", smlua_func_get_temp_s32_pointer);
-    smlua_bind_function(L, "deref_s32_pointer", smlua_func_deref_s32_pointer);
     smlua_bind_function(L, "djui_popup_create_global", smlua_func_djui_popup_create_global);
     smlua_bind_function(L, "djui_is_popup_disabled", smlua_func_djui_is_popup_disabled);
     smlua_bind_function(L, "djui_set_popup_disabled_override", smlua_func_djui_set_popup_disabled_override);

--- a/src/pc/lua/smlua_hook_events_autogen.inl
+++ b/src/pc/lua/smlua_hook_events_autogen.inl
@@ -319,7 +319,7 @@ bool smlua_call_event_hooks_HOOK_ALLOW_INTERACT(struct MarioState *m, struct Obj
         lua_remove(L, -2);
 
         // push obj
-        smlua_push_object(L, LOT_OBJECT, obj, NULL);
+        smlua_push_object(L, LOT_OBJECT, obj, NULL, false);
 
         // push interactType
         lua_pushinteger(L, interactType);
@@ -360,7 +360,7 @@ bool smlua_call_event_hooks_HOOK_ON_INTERACT(struct MarioState *m, struct Object
         lua_remove(L, -2);
 
         // push obj
-        smlua_push_object(L, LOT_OBJECT, obj, NULL);
+        smlua_push_object(L, LOT_OBJECT, obj, NULL, false);
 
         // push interactType
         lua_pushinteger(L, interactType);
@@ -495,7 +495,7 @@ bool smlua_call_event_hooks_HOOK_ON_OBJECT_UNLOAD(struct Object *obj) {
         lua_rawgeti(L, LUA_REGISTRYINDEX, hook->reference[i]);
 
         // push obj
-        smlua_push_object(L, LOT_OBJECT, obj, NULL);
+        smlua_push_object(L, LOT_OBJECT, obj, NULL, false);
 
         // call the callback
         if (0 != smlua_call_hook(L, 1, 0, 0, hook->mod[i], hook->modFile[i])) {
@@ -522,7 +522,7 @@ bool smlua_call_event_hooks_HOOK_ON_SYNC_OBJECT_UNLOAD(struct Object *obj) {
         lua_rawgeti(L, LUA_REGISTRYINDEX, hook->reference[i]);
 
         // push obj
-        smlua_push_object(L, LOT_OBJECT, obj, NULL);
+        smlua_push_object(L, LOT_OBJECT, obj, NULL, false);
 
         // call the callback
         if (0 != smlua_call_hook(L, 1, 0, 0, hook->mod[i], hook->modFile[i])) {
@@ -609,7 +609,7 @@ bool smlua_call_event_hooks_HOOK_ON_SET_CAMERA_MODE(struct Camera *c, s16 mode, 
         lua_rawgeti(L, LUA_REGISTRYINDEX, hook->reference[i]);
 
         // push c
-        smlua_push_object(L, LOT_CAMERA, c, NULL);
+        smlua_push_object(L, LOT_CAMERA, c, NULL, false);
 
         // push mode
         lua_pushinteger(L, mode);
@@ -647,7 +647,7 @@ bool smlua_call_event_hooks_HOOK_ON_OBJECT_RENDER(struct Object *obj) {
         lua_rawgeti(L, LUA_REGISTRYINDEX, hook->reference[i]);
 
         // push obj
-        smlua_push_object(L, LOT_OBJECT, obj, NULL);
+        smlua_push_object(L, LOT_OBJECT, obj, NULL, false);
 
         // call the callback
         if (0 != smlua_call_hook(L, 1, 0, 0, hook->mod[i], hook->modFile[i])) {
@@ -909,7 +909,7 @@ bool smlua_call_event_hooks_HOOK_OBJECT_SET_MODEL(struct Object *obj, s32 modelI
         lua_rawgeti(L, LUA_REGISTRYINDEX, hook->reference[i]);
 
         // push obj
-        smlua_push_object(L, LOT_OBJECT, obj, NULL);
+        smlua_push_object(L, LOT_OBJECT, obj, NULL, false);
 
         // push modelID
         lua_pushinteger(L, modelID);
@@ -1045,7 +1045,7 @@ bool smlua_call_event_hooks_HOOK_ON_OBJECT_ANIM_UPDATE(struct Object *obj) {
         lua_rawgeti(L, LUA_REGISTRYINDEX, hook->reference[i]);
 
         // push obj
-        smlua_push_object(L, LOT_OBJECT, obj, NULL);
+        smlua_push_object(L, LOT_OBJECT, obj, NULL, false);
 
         // call the callback
         if (0 != smlua_call_hook(L, 1, 0, 0, hook->mod[i], hook->modFile[i])) {
@@ -1195,7 +1195,7 @@ bool smlua_call_event_hooks_HOOK_MIRROR_MARIO_RENDER(struct GraphNodeObject *mir
         lua_rawgeti(L, LUA_REGISTRYINDEX, hook->reference[i]);
 
         // push mirrorMario
-        smlua_push_object(L, LOT_GRAPHNODEOBJECT, mirrorMario, NULL);
+        smlua_push_object(L, LOT_GRAPHNODEOBJECT, mirrorMario, NULL, false);
 
         // push playerIndex
         lua_pushinteger(L, playerIndex);
@@ -1259,7 +1259,7 @@ bool smlua_call_event_hooks_HOOK_ON_OBJECT_LOAD(struct Object *obj) {
         lua_rawgeti(L, LUA_REGISTRYINDEX, hook->reference[i]);
 
         // push obj
-        smlua_push_object(L, LOT_OBJECT, obj, NULL);
+        smlua_push_object(L, LOT_OBJECT, obj, NULL, false);
 
         // call the callback
         if (0 != smlua_call_hook(L, 1, 0, 0, hook->mod[i], hook->modFile[i])) {
@@ -1366,7 +1366,7 @@ bool smlua_call_event_hooks_HOOK_ON_ATTACK_OBJECT(struct MarioState *m, struct O
         lua_remove(L, -2);
 
         // push obj
-        smlua_push_object(L, LOT_OBJECT, obj, NULL);
+        smlua_push_object(L, LOT_OBJECT, obj, NULL, false);
 
         // push interaction
         lua_pushinteger(L, interaction);
@@ -1471,7 +1471,7 @@ bool smlua_call_event_hooks_HOOK_ON_GEO_PROCESS(struct GraphNode *node, s32 matS
         lua_rawgeti(L, LUA_REGISTRYINDEX, hook->reference[i]);
 
         // push node
-        smlua_push_object(L, LOT_GRAPHNODE, node, NULL);
+        smlua_push_object(L, LOT_GRAPHNODE, node, NULL, false);
 
         // push matStackIndex
         lua_pushinteger(L, matStackIndex);
@@ -1501,7 +1501,7 @@ bool smlua_call_event_hooks_HOOK_BEFORE_GEO_PROCESS(struct GraphNode *node, s32 
         lua_rawgeti(L, LUA_REGISTRYINDEX, hook->reference[i]);
 
         // push node
-        smlua_push_object(L, LOT_GRAPHNODE, node, NULL);
+        smlua_push_object(L, LOT_GRAPHNODE, node, NULL, false);
 
         // push matStackIndex
         lua_pushinteger(L, matStackIndex);
@@ -1531,7 +1531,7 @@ bool smlua_call_event_hooks_HOOK_ON_GEO_PROCESS_CHILDREN(struct GraphNode *paren
         lua_rawgeti(L, LUA_REGISTRYINDEX, hook->reference[i]);
 
         // push parent
-        smlua_push_object(L, LOT_GRAPHNODE, parent, NULL);
+        smlua_push_object(L, LOT_GRAPHNODE, parent, NULL, false);
 
         // push matStackIndex
         lua_pushinteger(L, matStackIndex);
@@ -1795,7 +1795,7 @@ bool smlua_call_event_hooks_HOOK_ON_ADD_SURFACE(struct Surface *surface, bool dy
         lua_rawgeti(L, LUA_REGISTRYINDEX, hook->reference[i]);
 
         // push surface
-        smlua_push_object(L, LOT_SURFACE, surface, NULL);
+        smlua_push_object(L, LOT_SURFACE, surface, NULL, false);
 
         // push dynamic
         lua_pushboolean(L, dynamic);

--- a/src/pc/lua/smlua_hooks.c
+++ b/src/pc/lua/smlua_hooks.c
@@ -689,7 +689,7 @@ bool smlua_call_behavior_hook(const BehaviorScript** behavior, struct Object* ob
         lua_rawgeti(L, LUA_REGISTRYINDEX, reference);
 
         // push object
-        smlua_push_object(L, LOT_OBJECT, object, NULL);
+        smlua_push_object(L, LOT_OBJECT, object, NULL, false);
 
         // call the callback
         if (0 != smlua_call_hook(L, 1, 0, 0, hooked->mod, hooked->modFile)) {

--- a/src/pc/lua/smlua_utils.c
+++ b/src/pc/lua/smlua_utils.c
@@ -408,7 +408,7 @@ inline static uintptr_t smlua_get_pointer_key(void *ptr, u16 lt) {
     return (lt * 0x9E3779B97F4A7C15) ^ ((uintptr_t) ptr >> 3);
 }
 
-CObject *smlua_push_object(lua_State* L, u16 lot, void* p, void *extraInfo) {
+CObject *smlua_push_object(lua_State* L, u16 lot, void* p, void *extraInfo, bool dynamic) {
     if (p == NULL) {
         lua_pushnil(L);
         return NULL;
@@ -433,11 +433,17 @@ CObject *smlua_push_object(lua_State* L, u16 lot, void* p, void *extraInfo) {
     cobject->lot = lot;
     cobject->freed = false;
     cobject->info = extraInfo;
+    cobject->dynamic = dynamic;
     lua_rawgeti(L, LUA_REGISTRYINDEX, gSmLuaCObjectMetatable);
     lua_setmetatable(L, -2);
-    lua_pushinteger(L, key);
-    lua_pushvalue(L, -2); // Duplicate userdata
-    lua_settable(L, -4);
+
+    // Don't push the cobject to the gSmLuaCObjects table if it's dynamic allocation
+    // Its data pointer is never the same and it will prevent the GC to collect it
+    if (!dynamic) {
+        lua_pushinteger(L, key);
+        lua_pushvalue(L, -2); // Duplicate userdata
+        lua_settable(L, -4);
+    }
     lua_remove(L, -2); // Remove gSmLuaCObjects table
 
     LUA_STACK_CHECK_END(L);

--- a/src/pc/lua/smlua_utils.h
+++ b/src/pc/lua/smlua_utils.h
@@ -38,7 +38,7 @@ struct TextureInfo *smlua_to_texture_info(lua_State *L, int index);
 bool packet_write_lnt(struct Packet* p, struct LSTNetworkType* lnt);
 bool packet_read_lnt(struct Packet* p, struct LSTNetworkType* lnt);
 
-CObject *smlua_push_object(lua_State* L, u16 lot, void* p, void *extraInfo);
+CObject *smlua_push_object(lua_State* L, u16 lot, void* p, void *extraInfo, bool dynamic);
 CPointer *smlua_push_pointer(lua_State* L, u16 lvt, void* p, void *extraInfo);
 void smlua_push_integer_field(int index, const char* name, lua_Integer val);
 void smlua_push_number_field(int index, const char* name, lua_Number val);

--- a/src/pc/lua/utils/smlua_collision_utils.c
+++ b/src/pc/lua/utils/smlua_collision_utils.c
@@ -159,12 +159,13 @@ struct GlobalObjectCollisionData gGlobalObjectCollisionData = {
     .wooden_signpost_seg3_collision_0302DD80         = (Collision*) wooden_signpost_seg3_collision_0302DD80,
 };
 
-struct RayIntersectionInfo* collision_find_surface_on_ray(f32 startX, f32 startY, f32 startZ, f32 dirX, f32 dirY, f32 dirZ, f32 precision) {
-    static struct RayIntersectionInfo info = { 0 };
+struct RayIntersectionInfo collision_find_surface_on_ray(f32 startX, f32 startY, f32 startZ, f32 dirX, f32 dirY, f32 dirZ, OPTIONAL f32 precision) {
+    if (precision <= 0.f) { precision = 3.f; }
+    struct RayIntersectionInfo info = { 0 };
     Vec3f orig = { startX, startY, startZ };
     Vec3f dir = { dirX, dirY, dirZ };
     find_surface_on_ray(orig, dir, &info.surface, info.hitPos, precision);
-    return &info;
+    return info;
 }
 
 struct Surface* collision_find_floor(f32 x, f32 y, f32 z) {
@@ -187,10 +188,9 @@ Collision* smlua_collision_util_get(const char* name) {
     return dynos_collision_get(name);
 }
 
-struct WallCollisionData* collision_get_temp_wall_collision_data(void) {
-    static struct WallCollisionData sTmpWcd = { 0 };
-    memset(&sTmpWcd, 0, sizeof(struct WallCollisionData));
-    return &sTmpWcd;
+struct WallCollisionData collision_get_temp_wall_collision_data(void) {
+    struct WallCollisionData wcd = { 0 };
+    return wcd;
 }
 
 struct Surface* get_surface_from_wcd_index(struct WallCollisionData* wcd, s8 index) {

--- a/src/pc/lua/utils/smlua_collision_utils.h
+++ b/src/pc/lua/utils/smlua_collision_utils.h
@@ -114,7 +114,9 @@ struct GlobalObjectCollisionData {
 
 extern struct GlobalObjectCollisionData gGlobalObjectCollisionData;
 
-struct RayIntersectionInfo* collision_find_surface_on_ray(f32 startX, f32 startY, f32 startZ, f32 dirX, f32 dirY, f32 dirZ, f32 precision);
+/* |description|Shoots a raycast from `startX`, `startY`, and `startZ` in the direction of `dirX`, `dirY`, and `dirZ`, with a non-zero `precision`|descriptionEnd| */
+struct RayIntersectionInfo collision_find_surface_on_ray(f32 startX, f32 startY, f32 startZ, f32 dirX, f32 dirY, f32 dirZ, OPTIONAL f32 precision);
+
 /* |description|Finds a potential floor at the given `x`, `y`, and `z` values|descriptionEnd| */
 struct Surface* collision_find_floor(f32 x, f32 y, f32 z);
 
@@ -128,7 +130,7 @@ struct Surface* get_water_surface_pseudo_floor(void);
 Collision* smlua_collision_util_get(const char* name);
 
 /* |description|Returns a temporary wall collision data pointer|descriptionEnd| */
-struct WallCollisionData* collision_get_temp_wall_collision_data(void);
+struct WallCollisionData collision_get_temp_wall_collision_data(void);
 
 /* |description|Gets the surface corresponding to `index` from `wcd`|descriptionEnd| */
 struct Surface* get_surface_from_wcd_index(struct WallCollisionData* wcd, s8 index);

--- a/src/pc/lua/utils/smlua_gfx_utils.c
+++ b/src/pc/lua/utils/smlua_gfx_utils.c
@@ -192,7 +192,7 @@ void gfx_parse(Gfx* cmd, LuaFunction func) {
 
             default:
                 lua_rawgeti(L, LUA_REGISTRYINDEX, func);
-                smlua_push_object(L, LOT_GFX, cmd, NULL);
+                smlua_push_object(L, LOT_GFX, cmd, NULL, false);
                 lua_pushinteger(L, op);
                 if (smlua_pcall(L, 2, 1, 0) != 0) {
                     LOG_LUA("Failed to call the gfx_parse callback: %u", func);

--- a/src/pc/lua/utils/smlua_misc_utils.c
+++ b/src/pc/lua/utils/smlua_misc_utils.c
@@ -40,8 +40,6 @@
 #include "pc/network/coopnet/coopnet.h"
 #endif
 
-static struct DateTime sDateTime;
-
 ///
 
 u32 get_network_area_timer(void) {
@@ -50,22 +48,6 @@ u32 get_network_area_timer(void) {
 
 u16 get_area_update_counter(void) {
     return gAreaUpdateCounter;
-}
-
-///
-
-s32* get_temp_s32_pointer(s32 initialValue) {
-    static s32 value = 0;
-    value = initialValue;
-    return &value;
-}
-
-s32 deref_s32_pointer(s32* pointer) {
-    if (pointer == NULL) {
-        LOG_LUA_LINE("Tried to dereference null pointer!");
-        return 0;
-    }
-    return *pointer;
 }
 
 ///
@@ -452,18 +434,19 @@ s64 get_time(void) {
     return time(NULL);
 }
 
-struct DateTime* get_date_and_time(void) {
+struct DateTime get_date_and_time(void) {
     time_t currentTime;
     time(&currentTime);
     struct tm *lt = localtime(&currentTime);
 
-    sDateTime.year = lt->tm_year;
-    sDateTime.month = lt->tm_mon;
-    sDateTime.day = lt->tm_mday;
-    sDateTime.hour = lt->tm_hour;
-    sDateTime.minute = lt->tm_min;
-    sDateTime.second = lt->tm_sec;
-    return &sDateTime;
+    struct DateTime dt = {0};
+    dt.year = lt->tm_year;
+    dt.month = lt->tm_mon;
+    dt.day = lt->tm_mday;
+    dt.hour = lt->tm_hour;
+    dt.minute = lt->tm_min;
+    dt.second = lt->tm_sec;
+    return dt;
 }
 
 ///

--- a/src/pc/lua/utils/smlua_misc_utils.h
+++ b/src/pc/lua/utils/smlua_misc_utils.h
@@ -57,11 +57,6 @@ u32 get_network_area_timer(void);
 /* |description|Gets the area update counter incremented when objects are updated|descriptionEnd| */
 u16 get_area_update_counter(void);
 
-/* |description|Returns a temporary signed 32-bit integer pointer with its value set to `initialValue`|descriptionEnd| */
-s32* get_temp_s32_pointer(s32 initialValue);
-/* |description|Gets the signed 32-bit integer value from `pointer`|descriptionEnd| */
-s32 deref_s32_pointer(s32* pointer);
-
 /* |description|Creates a DJUI popup that is broadcasted to every client|descriptionEnd| */
 void djui_popup_create_global(const char* message, int lines);
 /* |description|Returns if popups are disabled|descriptionEnd| */
@@ -199,7 +194,7 @@ void set_ttc_speed_setting(s16 speed);
 /* |description|Gets the Unix Timestamp|descriptionEnd| */
 s64 get_time(void);
 /* |description|Gets the system clock's date and time|descriptionEnd| */
-struct DateTime* get_date_and_time(void);
+struct DateTime get_date_and_time(void);
 
 /* |description|Gets the non overridden environment effect (e.g. snow)|descriptionEnd| */
 u16 get_envfx(void);

--- a/src/pc/lua/utils/smlua_obj_utils.c
+++ b/src/pc/lua/utils/smlua_obj_utils.c
@@ -56,7 +56,7 @@ static struct Object* spawn_object_internal(enum BehaviorId behaviorId, enum Mod
     if (objSetupFunction != 0) {
         lua_State* L = gLuaState;
         lua_rawgeti(L, LUA_REGISTRYINDEX, objSetupFunction);
-        smlua_push_object(L, LOT_OBJECT, obj, NULL);
+        smlua_push_object(L, LOT_OBJECT, obj, NULL, false);
         if (0 != smlua_pcall(L, 1, 0, 0)) {
             LOG_LUA("Failed to call the object setup callback: %u", objSetupFunction);
         }
@@ -357,34 +357,31 @@ void obj_set_field_s16(struct Object *o, s32 fieldIndex, s32 fieldSubIndex, s16 
 // Misc object helpers
 //
 
-struct SpawnParticlesInfo* obj_get_temp_spawn_particles_info(enum ModelExtendedId modelId) {
-    static struct SpawnParticlesInfo sTmpSpi = { 0 };
-    memset(&sTmpSpi, 0, sizeof(struct SpawnParticlesInfo));
+struct SpawnParticlesInfo obj_get_temp_spawn_particles_info(enum ModelExtendedId modelId) {
+    struct SpawnParticlesInfo spi = { 0 };
 
     u16 loadedModelId = smlua_model_util_load(modelId);
-    sTmpSpi.model = loadedModelId;
+    spi.model = loadedModelId;
 
-    return &sTmpSpi;
+    return spi;
 }
 
-struct WaterDropletParams* obj_get_temp_water_droplet_params(enum ModelExtendedId modelId, enum BehaviorId behaviorId) {
-    static struct WaterDropletParams sTmpWdp = { 0 };
-    memset(&sTmpWdp, 0, sizeof(struct WaterDropletParams));
+struct WaterDropletParams obj_get_temp_water_droplet_params(enum ModelExtendedId modelId, enum BehaviorId behaviorId) {
+    struct WaterDropletParams wdp = { 0 };
 
     s16 loadedModelId = smlua_model_util_load(modelId);
-    sTmpWdp.model = loadedModelId;
+    wdp.model = loadedModelId;
 
     const BehaviorScript *behavior = get_behavior_from_id(behaviorId);
     behavior = smlua_override_behavior(behavior);
-    sTmpWdp.behavior = behavior;
+    wdp.behavior = behavior;
 
-    return &sTmpWdp;
+    return wdp;
 }
 
-struct ObjectHitbox* get_temp_object_hitbox(void) {
-    static struct ObjectHitbox sTmpHitbox = { 0 };
-    memset(&sTmpHitbox, 0, sizeof(struct ObjectHitbox));
-    return &sTmpHitbox;
+struct ObjectHitbox get_temp_object_hitbox(void) {
+    struct ObjectHitbox hitbox = { 0 };
+    return hitbox;
 }
 
 bool obj_is_attackable(struct Object *o) {

--- a/src/pc/lua/utils/smlua_obj_utils.h
+++ b/src/pc/lua/utils/smlua_obj_utils.h
@@ -117,11 +117,11 @@ void obj_set_field_s16(struct Object *o, s32 fieldIndex, s32 fieldSubIndex, s16 
 //
 
 /* |description|Returns a temporary particle spawn info pointer with its model loaded in from `modelId`|descriptionEnd| */
-struct SpawnParticlesInfo* obj_get_temp_spawn_particles_info(enum ModelExtendedId modelId);
+struct SpawnParticlesInfo obj_get_temp_spawn_particles_info(enum ModelExtendedId modelId);
 /* |description|Returns a temporary water droplet params pointer with its model and behavior loaded in from `modelId` and `behaviorId`|descriptionEnd| */
-struct WaterDropletParams* obj_get_temp_water_droplet_params(enum ModelExtendedId modelId, enum BehaviorId behaviorId);
+struct WaterDropletParams obj_get_temp_water_droplet_params(enum ModelExtendedId modelId, enum BehaviorId behaviorId);
 /* |description|Returns a temporary object hitbox pointer|descriptionEnd| */
-struct ObjectHitbox* get_temp_object_hitbox(void);
+struct ObjectHitbox get_temp_object_hitbox(void);
 
 /* |description|Checks if `o` is attackable|descriptionEnd| */
 bool obj_is_attackable(struct Object *o);


### PR DESCRIPTION
- Fixes the `temp` functions always returning the same CObject, that was making it impossible to work with multiple instances (like calling `resolve_and_return_wall_collisions_data` with two different `WallCollisionData`).
- Makes these objects temporary. They're deleted as soon as the GC picks up the underlying Lua object. The GC behavior had to be changed a little to be able to identify and collect unused userdata.
- Removes now obsolete `get_temp_s32_pointer` and `deref_s32_pointer`.