### PR TITLE
Fix custom character held objects and expose a new variable

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -11456,6 +11456,19 @@ function get_mario_anim_part_rot(m, animPart, rot)
     -- ...
 end
 
+--- @return boolean
+--- Retrieves the boolean value of the variable gOverrideHOLP.
+function get_character_holp_override()
+    -- ...
+end
+
+--- @param value boolean
+--- @return boolean
+--- Override's the HOLP position to be at a custom character's hand position instead of Mario's. Set at 'true' by default to prevent inconsistencies with custom characters.
+function set_character_holp_override(value)
+    -- ...
+end
+
 --- @return integer
 --- Gets the current save file number (1-indexed)
 function get_current_save_file_num()

--- a/docs/lua/functions-7.md
+++ b/docs/lua/functions-7.md
@@ -1441,6 +1441,50 @@ Retrieves the animated part rotation associated to `animPart` from the MarioStat
 
 <br />
 
+## [get_character_holp_override](#get_character_holp_override)
+
+### Description
+Retrieves the boolean value of the variable gOverrideHOLP.
+
+### Lua Example
+`local booleanValue = get_character_holp_override()`
+
+### Parameters
+- None
+
+### Returns
+- `boolean`
+
+### C Prototype
+`bool get_character_holp_override();`
+
+[:arrow_up_small:](#)
+
+<br />
+
+## [set_character_holp_override](#set_character_holp_override)
+
+### Description
+Override's the HOLP position to be at a custom character's hand position instead of Mario's. Set at 'true' by default to prevent inconsistencies with custom characters.
+
+### Lua Example
+`local booleanValue = set_character_holp_override(value)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| value | `boolean` |
+
+### Returns
+- `boolean`
+
+### C Prototype
+`bool set_character_holp_override(bool value);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ## [get_current_save_file_num](#get_current_save_file_num)
 
 ### Description

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -2041,6 +2041,8 @@
    - [get_hand_foot_pos_z](functions-7.md#get_hand_foot_pos_z)
    - [get_mario_anim_part_pos](functions-7.md#get_mario_anim_part_pos)
    - [get_mario_anim_part_rot](functions-7.md#get_mario_anim_part_rot)
+   - [get_character_holp_override](functions-7.md#get_character_holp_override)
+   - [set_character_holp_override](functions-7.md#set_character_holp_override)
    - [get_current_save_file_num](functions-7.md#get_current_save_file_num)
    - [save_file_get_using_backup_slot](functions-7.md#save_file_get_using_backup_slot)
    - [save_file_set_using_backup_slot](functions-7.md#save_file_set_using_backup_slot)

--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -93,6 +93,7 @@ static u8 sDisplayingDoorText = FALSE;
 static u8 sJustTeleported = FALSE;
 u8 gPssSlideStarted = FALSE;
 extern u8 gLastCollectedStarOrKey;
+bool gOverrideHOLP = true;
 
 /**
  * Returns the type of cap Mario is wearing.
@@ -346,14 +347,18 @@ void mario_drop_held_object(struct MarioState *m) {
         if (m->marioBodyState) {
             // Set HOLP to Mario's position to prevent the bugs with custom characters
             // holding objects. The held object will still appear at their hand visually.
-            m->marioBodyState->heldObjLastPosition[0] = m->pos[0] + 32.0f * sins(m->faceAngle[1]);
-            m->marioBodyState->heldObjLastPosition[1] = m->pos[1];
-            m->marioBodyState->heldObjLastPosition[2] = m->pos[2] + 22.0f * coss(m->faceAngle[1]);
-            
+            if (gOverrideHOLP == TRUE) {
+                m->marioBodyState->heldObjLastPosition[0] = m->pos[0] + 32.0f * sins(m->faceAngle[1]);
+                m->marioBodyState->heldObjLastPosition[1] = m->pos[1];
+                m->marioBodyState->heldObjLastPosition[2] = m->pos[2] + 22.0f * coss(m->faceAngle[1]); 
+            }
+
             m->heldObj->oPosX = m->marioBodyState->heldObjLastPosition[0];
             m->heldObj->oPosY = m->pos[1];
             m->heldObj->oPosZ = m->marioBodyState->heldObjLastPosition[2];
         }
+
+        
 
         m->heldObj->oMoveAngleYaw = m->faceAngle[1];
 
@@ -378,13 +383,20 @@ void mario_throw_held_object(struct MarioState *m) {
 
         if (m->marioBodyState) {
             // Set HOLP again
-            m->marioBodyState->heldObjLastPosition[0] = m->pos[0] + 32.0f * sins(m->faceAngle[1]);
-            m->marioBodyState->heldObjLastPosition[1] = m->pos[1] + 79.0f;
-            m->marioBodyState->heldObjLastPosition[2] = m->pos[2] + 22.0f * coss(m->faceAngle[1]);
-            
-            m->heldObj->oPosX = m->marioBodyState->heldObjLastPosition[0];
-            m->heldObj->oPosY = m->marioBodyState->heldObjLastPosition[1];
-            m->heldObj->oPosZ = m->marioBodyState->heldObjLastPosition[2];
+            if (gOverrideHOLP == TRUE) {
+                m->marioBodyState->heldObjLastPosition[0] = m->pos[0] + 32.0f * sins(m->faceAngle[1]);
+                m->marioBodyState->heldObjLastPosition[1] = m->pos[1];
+                m->marioBodyState->heldObjLastPosition[2] = m->pos[2] + 22.0f * coss(m->faceAngle[1]); 
+
+                m->heldObj->oPosX = m->marioBodyState->heldObjLastPosition[0];
+                m->heldObj->oPosY = m->marioBodyState->heldObjLastPosition[1];
+                m->heldObj->oPosZ = m->marioBodyState->heldObjLastPosition[2];
+
+            } else {
+                m->heldObj->oPosX = m->marioBodyState->heldObjLastPosition[0] + 32.0f * sins(m->faceAngle[1]);
+                m->heldObj->oPosY = m->marioBodyState->heldObjLastPosition[1];
+                m->heldObj->oPosZ = m->marioBodyState->heldObjLastPosition[2] + 32.0f * coss(m->faceAngle[1]);
+            }
         }
 
         m->heldObj->oMoveAngleYaw = m->faceAngle[1];

--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -347,7 +347,7 @@ void mario_drop_held_object(struct MarioState *m) {
         if (m->marioBodyState) {
             // Set HOLP to Mario's position to prevent the bugs with custom characters
             // holding objects. The held object will still appear at their hand visually.
-            if (gOverrideHOLP == TRUE) {
+            if (gOverrideHOLP == true) {
                 m->marioBodyState->heldObjLastPosition[0] = m->pos[0] + 32.0f * sins(m->faceAngle[1]);
                 m->marioBodyState->heldObjLastPosition[1] = m->pos[1];
                 m->marioBodyState->heldObjLastPosition[2] = m->pos[2] + 22.0f * coss(m->faceAngle[1]); 
@@ -383,7 +383,7 @@ void mario_throw_held_object(struct MarioState *m) {
 
         if (m->marioBodyState) {
             // Set HOLP again
-            if (gOverrideHOLP == TRUE) {
+            if (gOverrideHOLP == true) {
                 m->marioBodyState->heldObjLastPosition[0] = m->pos[0] + 32.0f * sins(m->faceAngle[1]);
                 m->marioBodyState->heldObjLastPosition[1] = m->pos[1];
                 m->marioBodyState->heldObjLastPosition[2] = m->pos[2] + 22.0f * coss(m->faceAngle[1]); 

--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -344,6 +344,12 @@ void mario_drop_held_object(struct MarioState *m) {
         // y-positon instead of the HOLP's y-position. This fact is often exploited when
         // cloning objects.
         if (m->marioBodyState) {
+            // Set HOLP to Mario's position to prevent the bugs with custom characters
+            // holding objects. The held object will still appear at their hand visually.
+            m->marioBodyState->heldObjLastPosition[0] = m->pos[0] + 32.0f * sins(m->faceAngle[1]);
+            m->marioBodyState->heldObjLastPosition[1] = m->pos[1];
+            m->marioBodyState->heldObjLastPosition[2] = m->pos[2] + 22.0f * coss(m->faceAngle[1]);
+            
             m->heldObj->oPosX = m->marioBodyState->heldObjLastPosition[0];
             m->heldObj->oPosY = m->pos[1];
             m->heldObj->oPosZ = m->marioBodyState->heldObjLastPosition[2];
@@ -371,9 +377,14 @@ void mario_throw_held_object(struct MarioState *m) {
         obj_set_held_state(m->heldObj, bhvCarrySomething5);
 
         if (m->marioBodyState) {
-            m->heldObj->oPosX = m->marioBodyState->heldObjLastPosition[0] + 32.0f * sins(m->faceAngle[1]);
+            // Set HOLP again
+            m->marioBodyState->heldObjLastPosition[0] = m->pos[0] + 32.0f * sins(m->faceAngle[1]);
+            m->marioBodyState->heldObjLastPosition[1] = m->pos[1] + 79.0f;
+            m->marioBodyState->heldObjLastPosition[2] = m->pos[2] + 22.0f * coss(m->faceAngle[1]);
+            
+            m->heldObj->oPosX = m->marioBodyState->heldObjLastPosition[0];
             m->heldObj->oPosY = m->marioBodyState->heldObjLastPosition[1];
-            m->heldObj->oPosZ = m->marioBodyState->heldObjLastPosition[2] + 32.0f * coss(m->faceAngle[1]);
+            m->heldObj->oPosZ = m->marioBodyState->heldObjLastPosition[2];
         }
 
         m->heldObj->oMoveAngleYaw = m->faceAngle[1];

--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -33,6 +33,7 @@
 #include "pc/network/lag_compensation.h"
 #include "pc/lua/smlua_hooks.h"
 #include "pc/lua/utils/smlua_obj_utils.h"
+#include "pc/lua/utils/smlua_misc_utils.h"
 
 u8 sDelayInvincTimer;
 s16 gInteractionInvulnerable;
@@ -93,7 +94,6 @@ static u8 sDisplayingDoorText = FALSE;
 static u8 sJustTeleported = FALSE;
 u8 gPssSlideStarted = FALSE;
 extern u8 gLastCollectedStarOrKey;
-bool gOverrideHOLP = true;
 
 /**
  * Returns the type of cap Mario is wearing.

--- a/src/game/interaction.h
+++ b/src/game/interaction.h
@@ -124,6 +124,7 @@ enum InteractionFlag {
 
 extern s16 gInteractionInvulnerable;
 extern u8 gPssSlideStarted;
+extern bool gOverrideHOLP;
 
 /* |description|
 Handles Mario's interaction with coins. Collecting a coin increases Mario's coin count and heals him slightly.

--- a/src/game/interaction.h
+++ b/src/game/interaction.h
@@ -124,7 +124,6 @@ enum InteractionFlag {
 
 extern s16 gInteractionInvulnerable;
 extern u8 gPssSlideStarted;
-extern bool gOverrideHOLP;
 
 /* |description|
 Handles Mario's interaction with coins. Collecting a coin increases Mario's coin count and heals him slightly.

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -33809,6 +33809,38 @@ int smlua_func_get_mario_anim_part_rot(lua_State* L) {
     return 1;
 }
 
+int smlua_func_get_character_holp_override(UNUSED lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 0) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "get_character_holp_override", 0, top);
+        return 0;
+    }
+
+
+    lua_pushboolean(L, get_character_holp_override());
+
+    return 1;
+}
+
+int smlua_func_set_character_holp_override(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 1) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "set_character_holp_override", 1, top);
+        return 0;
+    }
+
+    bool value = smlua_to_boolean(L, 1);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "set_character_holp_override"); return 0; }
+
+    lua_pushboolean(L, set_character_holp_override(value));
+
+    return 1;
+}
+
 int smlua_func_get_current_save_file_num(UNUSED lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -38677,6 +38709,8 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "get_hand_foot_pos_z", smlua_func_get_hand_foot_pos_z);
     smlua_bind_function(L, "get_mario_anim_part_pos", smlua_func_get_mario_anim_part_pos);
     smlua_bind_function(L, "get_mario_anim_part_rot", smlua_func_get_mario_anim_part_rot);
+    smlua_bind_function(L, "get_character_holp_override", smlua_func_get_character_holp_override);
+    smlua_bind_function(L, "set_character_holp_override", smlua_func_set_character_holp_override);
     smlua_bind_function(L, "get_current_save_file_num", smlua_func_get_current_save_file_num);
     smlua_bind_function(L, "save_file_get_using_backup_slot", smlua_func_save_file_get_using_backup_slot);
     smlua_bind_function(L, "save_file_set_using_backup_slot", smlua_func_save_file_set_using_backup_slot);

--- a/src/pc/lua/utils/smlua_misc_utils.c
+++ b/src/pc/lua/utils/smlua_misc_utils.c
@@ -384,7 +384,7 @@ bool get_mario_anim_part_rot(struct MarioState *m, u32 animPart, VEC_OUT Vec3s r
     return true;
 }
 
-extern bool gOverrideHOLP;
+bool gOverrideHOLP = true;
 bool get_character_holp_override() {
     return gOverrideHOLP;
 }

--- a/src/pc/lua/utils/smlua_misc_utils.c
+++ b/src/pc/lua/utils/smlua_misc_utils.c
@@ -389,7 +389,7 @@ bool get_character_holp_info() {
     return gOverrideHOLP;
 }
 
-bool set_character_holp_override(bool value) {
+bool set_character_holp_info(bool value) {
     gOverrideHOLP = value;
 }
 

--- a/src/pc/lua/utils/smlua_misc_utils.c
+++ b/src/pc/lua/utils/smlua_misc_utils.c
@@ -31,6 +31,7 @@
 #include "game/rumble_init.h"
 #include "game/sound_init.h"
 #include "pc/lua/utils/smlua_audio_utils.h"
+#include "game/interaction.h"
 
 #ifdef DISCORD_SDK
 #include "pc/discord/discord.h"
@@ -381,6 +382,15 @@ bool get_mario_anim_part_rot(struct MarioState *m, u32 animPart, VEC_OUT Vec3s r
     if (animPart >= MARIO_ANIM_PART_MAX) { return false; }
     vec3s_copy(rot, m->marioBodyState->animPartsRot[animPart]);
     return true;
+}
+
+extern bool gOverrideHOLP;
+bool get_character_holp_info() {
+    return gOverrideHOLP;
+}
+
+bool set_character_holp_override(bool value) {
+    gOverrideHOLP = value;
 }
 
 ///

--- a/src/pc/lua/utils/smlua_misc_utils.c
+++ b/src/pc/lua/utils/smlua_misc_utils.c
@@ -385,11 +385,11 @@ bool get_mario_anim_part_rot(struct MarioState *m, u32 animPart, VEC_OUT Vec3s r
 }
 
 extern bool gOverrideHOLP;
-bool get_character_holp_info() {
+bool get_character_holp_override() {
     return gOverrideHOLP;
 }
 
-bool set_character_holp_info(bool value) {
+bool set_character_holp_override(bool value) {
     gOverrideHOLP = value;
 }
 

--- a/src/pc/lua/utils/smlua_misc_utils.h
+++ b/src/pc/lua/utils/smlua_misc_utils.h
@@ -51,6 +51,7 @@ struct DateTime {
     s32 second;
 };
 
+extern bool gOverrideHOLP;
 
 /* |description|Gets the current area's networked timer|descriptionEnd| */
 u32 get_network_area_timer(void);

--- a/src/pc/lua/utils/smlua_misc_utils.h
+++ b/src/pc/lua/utils/smlua_misc_utils.h
@@ -180,7 +180,7 @@ bool get_character_holp_info();
 /* |description|
 Override's the HOLP position to be at a custom character's hand position instead of Mario's. Set at 'true' by default to prevent inconsistencies with custom characters.
 |descriptionEnd| */
-bool set_character_holp_override(bool value);
+bool set_character_holp_info(bool value);
 
 /* |description|Gets the current save file number (1-indexed)|descriptionEnd| */
 s16 get_current_save_file_num(void);

--- a/src/pc/lua/utils/smlua_misc_utils.h
+++ b/src/pc/lua/utils/smlua_misc_utils.h
@@ -176,11 +176,11 @@ bool get_mario_anim_part_rot(struct MarioState *m, u32 animPart, VEC_OUT Vec3s r
 /* |description|
 Retrieves the boolean value of the variable gOverrideHOLP.
 |descriptionEnd| */
-bool get_character_holp_info();
+bool get_character_holp_override();
 /* |description|
 Override's the HOLP position to be at a custom character's hand position instead of Mario's. Set at 'true' by default to prevent inconsistencies with custom characters.
 |descriptionEnd| */
-bool set_character_holp_info(bool value);
+bool set_character_holp_override(bool value);
 
 /* |description|Gets the current save file number (1-indexed)|descriptionEnd| */
 s16 get_current_save_file_num(void);

--- a/src/pc/lua/utils/smlua_misc_utils.h
+++ b/src/pc/lua/utils/smlua_misc_utils.h
@@ -173,6 +173,14 @@ bool get_mario_anim_part_pos(struct MarioState *m, u32 animPart, VEC_OUT Vec3f p
 Retrieves the animated part rotation associated to `animPart` from the MarioState `m` and stores it into `rot`. Returns `true` on success or `false` on failure
 |descriptionEnd| */
 bool get_mario_anim_part_rot(struct MarioState *m, u32 animPart, VEC_OUT Vec3s rot);
+/* |description|
+Retrieves the boolean value of the variable gOverrideHOLP.
+|descriptionEnd| */
+bool get_character_holp_info();
+/* |description|
+Override's the HOLP position to be at a custom character's hand position instead of Mario's. Set at 'true' by default to prevent inconsistencies with custom characters.
+|descriptionEnd| */
+bool set_character_holp_override(bool value);
 
 /* |description|Gets the current save file number (1-indexed)|descriptionEnd| */
 s16 get_current_save_file_num(void);

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -750,6 +750,7 @@ void network_shutdown(bool sendLeaving, bool exiting, bool popup, bool reconnect
     gLuaVolumeLevel = 127;
     gLuaVolumeSfx = 127;
     gLuaVolumeEnv = 127;
+    gOverrideHOLP = true;
 
     struct Controller* cnt = gPlayer1Controller;
     cnt->rawStickX = 0;


### PR DESCRIPTION
This PR fixes bugs occuring when holding objects with custom characters. For example, Waluigi's longer arms drop the object at a different point, making mips clip and bobomb clip impossible/almost impossible. Now, characters all throw objects from the same location Mario would. The Lua API now has `get_character_holp_override` and `set_character_holp_override`, which can be used to disable this feature.