### PR TITLE
Fix issue with mouse buttons being applied to pad

### DIFF
--- a/src/pc/controller/controller_sdl2.c
+++ b/src/pc/controller/controller_sdl2.c
@@ -284,7 +284,6 @@ static void controller_sdl_read(OSContPad *pad) {
     update_button(VK_LTRIGGER - VK_BASE_SDL_GAMEPAD, ltrig > AXIS_THRESHOLD);
     update_button(VK_RTRIGGER - VK_BASE_SDL_GAMEPAD, rtrig > AXIS_THRESHOLD);
 
-    buttons_down = 0;
     for (u32 i = 0; i < num_joy_binds; ++i)
         if (joy_buttons[joy_binds[i][0]])
             buttons_down |= joy_binds[i][1];

--- a/src/pc/controller/controller_sdl2.c
+++ b/src/pc/controller/controller_sdl2.c
@@ -196,6 +196,7 @@ static void controller_sdl_read(OSContPad *pad) {
             if (mouse & SDL_BUTTON(mouse_binds[i][0]))
                 buttons_down |= mouse_binds[i][1];
     }
+    pad->button |= buttons_down;
     // remember buttons that changed from 0 to 1
     last_mouse = (mouse_prev ^ mouse) & mouse;
 
@@ -283,6 +284,7 @@ static void controller_sdl_read(OSContPad *pad) {
     update_button(VK_LTRIGGER - VK_BASE_SDL_GAMEPAD, ltrig > AXIS_THRESHOLD);
     update_button(VK_RTRIGGER - VK_BASE_SDL_GAMEPAD, rtrig > AXIS_THRESHOLD);
 
+    buttons_down = 0;
     for (u32 i = 0; i < num_joy_binds; ++i)
         if (joy_buttons[joy_binds[i][0]])
             buttons_down |= joy_binds[i][1];


### PR DESCRIPTION
This one's a one liner. This resolves an issue introduced in #835, that being mouse inputs weren't applied to the pad's buttons if:

- `configDisableGamepads` was true
- A controller was not connected to the device

Simple fix was to assign the buttons down to the pad directly after set.

Scroll binds were tested and are still working, and the issue is fixed.