### PR TITLE
Fix mod storage load/save number

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -7763,9 +7763,17 @@ function mod_storage_save(key, value)
 end
 
 --- @param key string
+--- @param value integer
+--- @return boolean
+--- Saves a `key` corresponding to an integer `value` to mod storage
+function mod_storage_save_integer(key, value)
+    -- ...
+end
+
+--- @param key string
 --- @param value number
 --- @return boolean
---- Saves a `key` corresponding to a float `value` to mod storage
+--- Saves a `key` corresponding to a number `value` to mod storage
 function mod_storage_save_number(key, value)
     -- ...
 end
@@ -7786,8 +7794,15 @@ function mod_storage_load(key)
 end
 
 --- @param key string
+--- @return integer
+--- Loads an integer `value` from a `key` in mod storage
+function mod_storage_load_integer(key)
+    -- ...
+end
+
+--- @param key string
 --- @return number
---- Loads a float `value` from a `key` in mod storage
+--- Loads a number `value` from a `key` in mod storage
 function mod_storage_load_number(key)
     -- ...
 end

--- a/docs/lua/functions-5.md
+++ b/docs/lua/functions-5.md
@@ -2191,10 +2191,34 @@ Saves a `key` corresponding to a string `value` to mod storage
 
 <br />
 
+## [mod_storage_save_integer](#mod_storage_save_integer)
+
+### Description
+Saves a `key` corresponding to an integer `value` to mod storage
+
+### Lua Example
+`local booleanValue = mod_storage_save_integer(key, value)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| key | `string` |
+| value | `integer` |
+
+### Returns
+- `boolean`
+
+### C Prototype
+`bool mod_storage_save_integer(const char* key, lua_Integer value);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ## [mod_storage_save_number](#mod_storage_save_number)
 
 ### Description
-Saves a `key` corresponding to a float `value` to mod storage
+Saves a `key` corresponding to a number `value` to mod storage
 
 ### Lua Example
 `local booleanValue = mod_storage_save_number(key, value)`
@@ -2209,7 +2233,7 @@ Saves a `key` corresponding to a float `value` to mod storage
 - `boolean`
 
 ### C Prototype
-`bool mod_storage_save_number(const char* key, f32 value);`
+`bool mod_storage_save_number(const char* key, lua_Number value);`
 
 [:arrow_up_small:](#)
 
@@ -2262,10 +2286,33 @@ Loads a string `value` from a `key` in mod storage
 
 <br />
 
+## [mod_storage_load_integer](#mod_storage_load_integer)
+
+### Description
+Loads an integer `value` from a `key` in mod storage
+
+### Lua Example
+`local integerValue = mod_storage_load_integer(key)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| key | `string` |
+
+### Returns
+- `integer`
+
+### C Prototype
+`lua_Integer mod_storage_load_integer(const char* key);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ## [mod_storage_load_number](#mod_storage_load_number)
 
 ### Description
-Loads a float `value` from a `key` in mod storage
+Loads a number `value` from a `key` in mod storage
 
 ### Lua Example
 `local numberValue = mod_storage_load_number(key)`
@@ -2279,7 +2326,7 @@ Loads a float `value` from a `key` in mod storage
 - `number`
 
 ### C Prototype
-`f32 mod_storage_load_number(const char* key);`
+`lua_Number mod_storage_load_number(const char* key);`
 
 [:arrow_up_small:](#)
 

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -1403,9 +1403,11 @@
 
 - mod_storage.h
    - [mod_storage_save](functions-5.md#mod_storage_save)
+   - [mod_storage_save_integer](functions-5.md#mod_storage_save_integer)
    - [mod_storage_save_number](functions-5.md#mod_storage_save_number)
    - [mod_storage_save_bool](functions-5.md#mod_storage_save_bool)
    - [mod_storage_load](functions-5.md#mod_storage_load)
+   - [mod_storage_load_integer](functions-5.md#mod_storage_load_integer)
    - [mod_storage_load_number](functions-5.md#mod_storage_load_number)
    - [mod_storage_load_bool](functions-5.md#mod_storage_load_bool)
    - [mod_storage_load_all](functions-5.md#mod_storage_load_all)

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -23045,6 +23045,25 @@ int smlua_func_mod_storage_save(lua_State* L) {
     return 1;
 }
 
+int smlua_func_mod_storage_save_integer(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 2) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "mod_storage_save_integer", 2, top);
+        return 0;
+    }
+
+    const char* key = smlua_to_string(L, 1);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "mod_storage_save_integer"); return 0; }
+    lua_Integer value = smlua_to_integer(L, 2);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "mod_storage_save_integer"); return 0; }
+
+    lua_pushboolean(L, mod_storage_save_integer(key, value));
+
+    return 1;
+}
+
 int smlua_func_mod_storage_save_number(lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -23056,7 +23075,7 @@ int smlua_func_mod_storage_save_number(lua_State* L) {
 
     const char* key = smlua_to_string(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "mod_storage_save_number"); return 0; }
-    f32 value = smlua_to_number(L, 2);
+    lua_Number value = smlua_to_number(L, 2);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "mod_storage_save_number"); return 0; }
 
     lua_pushboolean(L, mod_storage_save_number(key, value));
@@ -23096,6 +23115,23 @@ int smlua_func_mod_storage_load(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "mod_storage_load"); return 0; }
 
     lua_pushstring(L, mod_storage_load(key));
+
+    return 1;
+}
+
+int smlua_func_mod_storage_load_integer(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 1) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "mod_storage_load_integer", 1, top);
+        return 0;
+    }
+
+    const char* key = smlua_to_string(L, 1);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "mod_storage_load_integer"); return 0; }
+
+    lua_pushinteger(L, mod_storage_load_integer(key));
 
     return 1;
 }
@@ -38078,9 +38114,11 @@ void smlua_bind_functions_autogen(void) {
 
     // mod_storage.h
     smlua_bind_function(L, "mod_storage_save", smlua_func_mod_storage_save);
+    smlua_bind_function(L, "mod_storage_save_integer", smlua_func_mod_storage_save_integer);
     smlua_bind_function(L, "mod_storage_save_number", smlua_func_mod_storage_save_number);
     smlua_bind_function(L, "mod_storage_save_bool", smlua_func_mod_storage_save_bool);
     smlua_bind_function(L, "mod_storage_load", smlua_func_mod_storage_load);
+    smlua_bind_function(L, "mod_storage_load_integer", smlua_func_mod_storage_load_integer);
     smlua_bind_function(L, "mod_storage_load_number", smlua_func_mod_storage_load_number);
     smlua_bind_function(L, "mod_storage_load_bool", smlua_func_mod_storage_load_bool);
     smlua_bind_function(L, "mod_storage_load_all", smlua_func_mod_storage_load_all);

--- a/src/pc/lua/smlua_utils.c
+++ b/src/pc/lua/smlua_utils.c
@@ -102,7 +102,7 @@ lua_Integer smlua_to_integer(lua_State* L, int index) {
     }
     gSmLuaConvertSuccess = true;
     lua_Integer val = lua_tointeger(L, index);
-    return (val == 0) ? lua_tonumber(L, index) : val;
+    return (val == 0) ? (lua_Integer) lua_tonumber(L, index) : val;
 }
 
 lua_Number smlua_to_number(lua_State* L, int index) {

--- a/src/pc/mods/mod_storage.cpp
+++ b/src/pc/mods/mod_storage.cpp
@@ -134,11 +134,18 @@ C_FIELD const char* mod_storage_load(const char* key) {
     return value;
 }
 
-C_FIELD f32 mod_storage_load_number(const char* key) {
+C_FIELD lua_Integer mod_storage_load_integer(const char* key) {
     const char* value = mod_storage_load(key);
     if (value == NULL) { return 0; }
 
-    return std::strtof(value, nullptr);
+    return std::strtoll(value, NULL, 10);
+}
+
+C_FIELD lua_Number mod_storage_load_number(const char* key) {
+    const char* value = mod_storage_load(key);
+    if (value == NULL) { return 0.0; }
+
+    return std::strtod(value, NULL);
 }
 
 C_FIELD bool mod_storage_load_bool(const char* key) {
@@ -199,17 +206,14 @@ C_FIELD bool mod_storage_save(const char* key, const char* value) {
     return true;
 }
 
-C_FIELD bool mod_storage_save_number(const char* key, f32 value) {
-    // Store string results in a temporary buffer
-    // this assumes mod_storage_load will only ever be called by Lua
-    static char str[MAX_KEY_VALUE_LENGTH];
-    if (floor(value) == value) {
-        snprintf(str, MAX_KEY_VALUE_LENGTH, "%lld", (s64)value);
-    } else {
-        snprintf(str, MAX_KEY_VALUE_LENGTH, "%f", value);
-    }
+C_FIELD bool mod_storage_save_integer(const char* key, lua_Integer value) {
+    std::string valueStr = std::to_string(value);
+    return mod_storage_save(key, valueStr.c_str());
+}
 
-    return mod_storage_save(key, str);
+C_FIELD bool mod_storage_save_number(const char* key, lua_Number value) {
+    std::string valueStr = std::to_string(value);
+    return mod_storage_save(key, valueStr.c_str());
 }
 
 C_FIELD bool mod_storage_save_bool(const char* key, bool value) {

--- a/src/pc/mods/mod_storage.h
+++ b/src/pc/mods/mod_storage.h
@@ -15,15 +15,19 @@ extern "C" {
 
 /* |description|Saves a `key` corresponding to a string `value` to mod storage|descriptionEnd| */
 bool mod_storage_save(const char* key, const char* value);
-/* |description|Saves a `key` corresponding to a float `value` to mod storage|descriptionEnd| */
-bool mod_storage_save_number(const char* key, f32 value);
+/* |description|Saves a `key` corresponding to an integer `value` to mod storage|descriptionEnd| */
+bool mod_storage_save_integer(const char* key, lua_Integer value);
+/* |description|Saves a `key` corresponding to a number `value` to mod storage|descriptionEnd| */
+bool mod_storage_save_number(const char* key, lua_Number value);
 /* |description|Saves a `key` corresponding to a bool `value` to mod storage|descriptionEnd| */
 bool mod_storage_save_bool(const char* key, bool value);
 
 /* |description|Loads a string `value` from a `key` in mod storage|descriptionEnd| */
 const char *mod_storage_load(const char* key);
-/* |description|Loads a float `value` from a `key` in mod storage|descriptionEnd| */
-f32 mod_storage_load_number(const char* key);
+/* |description|Loads an integer `value` from a `key` in mod storage|descriptionEnd| */
+lua_Integer mod_storage_load_integer(const char* key);
+/* |description|Loads a number `value` from a `key` in mod storage|descriptionEnd| */
+lua_Number mod_storage_load_number(const char* key);
 /* |description|Loads a bool `value` from a `key` in mod storage|descriptionEnd| */
 bool mod_storage_load_bool(const char* key);
 /* |description|Loads all keys and values in mod storage as strings and returns them as a table|descriptionEnd| */


### PR DESCRIPTION
- Fix `mod_storage_load/save_number` incorrect behavior. These functions should now be used only with numbers, not integers (see next point). The `mod_storage_load_number` can still load integer values from existing mod storage files.
- Add `mod_storage_load/save_integer` for integer values.
- Expand the range of savable values to `double` (64-bit float) and `long long` (64-bit integer) for respectively `number` and `integer` mod storage functions.
- Fix an obscure bug with `smlua_to_integer` that truncated very high integer values due to an implicit cast to double, causing floating-point imprecision issues. Thanks @yoshiweegee for the explanation.

Test mod:
```lua
local key_index
local function save_test(func, value)
    print(value)
    func("key_" .. tostring(key_index), value)
    key_index = key_index + 1
end
local function load_test(func, value)
    local loaded = func("key_" .. tostring(key_index))
    print(value, "->", loaded, value == loaded)
    key_index = key_index + 1
end

key_index = 0
print("======= SAVE =======")
print("----- integers -----")
save_test(mod_storage_save_integer, 0)
save_test(mod_storage_save_integer, 0x7FFFFFFF)
save_test(mod_storage_save_integer, 0xF0001000)
save_test(mod_storage_save_integer, 0xF0001001)
save_test(mod_storage_save_integer, 0xFFFFFFFF)
save_test(mod_storage_save_integer, 0x100000000)
save_test(mod_storage_save_integer, 0x1000000000000000)
save_test(mod_storage_save_integer, 0x7FFFFFFFFFFFFFFF)
save_test(mod_storage_save_integer, 0x8000000000000000)
save_test(mod_storage_save_integer, 0xFFFFFFFFFFFFFFFF)
save_test(mod_storage_save_integer, -1)
save_test(mod_storage_save_integer, -0xFFFFFFFF)
save_test(mod_storage_save_integer, -0x100000000)
save_test(mod_storage_save_integer, -0x1000000000000000)
save_test(mod_storage_save_integer, -0x7FFFFFFFFFFFFFFF)
print("------ floats ------")
save_test(mod_storage_save_number, 0.0 + 0)
save_test(mod_storage_save_number, 0.0 + 0x7FFFFFFF)
save_test(mod_storage_save_number, 0.0 + 0xF0001000)
save_test(mod_storage_save_number, 0.0 + 0xF0001001)
save_test(mod_storage_save_number, 0.0 + 0xFFFFFFFF)
save_test(mod_storage_save_number, 0.0 + 0x100000000)
save_test(mod_storage_save_number, 0.0 + 0x1000000000000000)
save_test(mod_storage_save_number, 0.0 + 0x7FFFFFFFFFFFFFFF)
save_test(mod_storage_save_number, 0.0 + 0x8000000000000000)
save_test(mod_storage_save_number, 0.0 + 0xFFFFFFFFFFFFFFFF)
save_test(mod_storage_save_number, 0.0 + -1)
save_test(mod_storage_save_number, 0.0 + -0xFFFFFFFF)
save_test(mod_storage_save_number, 0.0 + -0x100000000)
save_test(mod_storage_save_number, 0.0 + -0x1000000000000000)
save_test(mod_storage_save_number, 0.0 + -0x7FFFFFFFFFFFFFFF)

key_index = 0
print("======= LOAD =======")
print("----- integers -----")
load_test(mod_storage_load_integer, 0)
load_test(mod_storage_load_integer, 0x7FFFFFFF)
load_test(mod_storage_load_integer, 0xF0001000)
load_test(mod_storage_load_integer, 0xF0001001)
load_test(mod_storage_load_integer, 0xFFFFFFFF)
load_test(mod_storage_load_integer, 0x100000000)
load_test(mod_storage_load_integer, 0x1000000000000000)
load_test(mod_storage_load_integer, 0x7FFFFFFFFFFFFFFF)
load_test(mod_storage_load_integer, 0x8000000000000000)
load_test(mod_storage_load_integer, 0xFFFFFFFFFFFFFFFF)
load_test(mod_storage_load_integer, -1)
load_test(mod_storage_load_integer, -0xFFFFFFFF)
load_test(mod_storage_load_integer, -0x100000000)
load_test(mod_storage_load_integer, -0x1000000000000000)
load_test(mod_storage_load_integer, -0x7FFFFFFFFFFFFFFF)
print("------ floats ------")
load_test(mod_storage_load_number, 0.0 + 0)
load_test(mod_storage_load_number, 0.0 + 0x7FFFFFFF)
load_test(mod_storage_load_number, 0.0 + 0xF0001000)
load_test(mod_storage_load_number, 0.0 + 0xF0001001)
load_test(mod_storage_load_number, 0.0 + 0xFFFFFFFF)
load_test(mod_storage_load_number, 0.0 + 0x100000000)
load_test(mod_storage_load_number, 0.0 + 0x1000000000000000)
load_test(mod_storage_load_number, 0.0 + 0x7FFFFFFFFFFFFFFF)
load_test(mod_storage_load_number, 0.0 + 0x8000000000000000)
load_test(mod_storage_load_number, 0.0 + 0xFFFFFFFFFFFFFFFF)
load_test(mod_storage_load_number, 0.0 + -1)
load_test(mod_storage_load_number, 0.0 + -0xFFFFFFFF)
load_test(mod_storage_load_number, 0.0 + -0x100000000)
load_test(mod_storage_load_number, 0.0 + -0x1000000000000000)
load_test(mod_storage_load_number, 0.0 + -0x7FFFFFFFFFFFFFFF)
```