### PR TITLE
Fixed Tab-Completion for the "/psc" command

### DIFF
--- a/mods/personal-starcount-ex.lua
+++ b/mods/personal-starcount-ex.lua
@@ -300,7 +300,7 @@ hook_event(HOOK_ON_INTERACT, star_counter_on_interact)
 hook_event(HOOK_ON_HUD_RENDER, hud_render_psc)
 hook_event(HOOK_ON_HUD_RENDER_BEHIND, behind_hud_render_psc)
 hook_event(HOOK_UPDATE, psc_update)
-hook_chat_command('psc', "On|Off - Displays stars you've collected. Default is On.", toggle_psc)
+hook_chat_command('psc', "[On|Off] - Displays stars you've collected. Default is On.", toggle_psc)
 
 -- Globalize functions for other mods to use
 -- Created by PeachyPeach


### PR DESCRIPTION
This fixes the Tab-Completion for the "/psc" command from the default mod "Personal Star Counter"