### PR TITLE
Control the Lighting Engine with le_set_enabled in real time

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -5155,13 +5155,9 @@ function le_set_max_lights_per_vertex(count)
     -- ...
 end
 
---- Tells the system to disable the lighting engine when it's currently enabled.
-function le_disable()
-    -- ...
-end
-
---- Tells the system to enable the lighting engine when it's currently disabled.
-function le_enable()
+--- @param value boolean
+--- This will let the user control the lighting engine in real time to disable or enable it.
+function le_set_active(value)
     -- ...
 end
 

--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -5157,7 +5157,7 @@ end
 
 --- @param value boolean
 --- This will let the user control the lighting engine in real time to disable or enable it.
-function le_set_active(value)
+function le_set_enabled(value)
     -- ...
 end
 

--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -5155,6 +5155,16 @@ function le_set_max_lights_per_vertex(count)
     -- ...
 end
 
+--- Tells the system to disable the lightning engine when it's currently enabled.
+function le_disable()
+    -- ...
+end
+
+--- Tells the system to enable the lightning engine when it's currently disabled.
+function le_enable()
+    -- ...
+end
+
 --- @param pos Vec3f
 --- @param out Color
 --- @param lightIntensityScalar number

--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -5155,12 +5155,12 @@ function le_set_max_lights_per_vertex(count)
     -- ...
 end
 
---- Tells the system to disable the lightning engine when it's currently enabled.
+--- Tells the system to disable the lighting engine when it's currently enabled.
 function le_disable()
     -- ...
 end
 
---- Tells the system to enable the lightning engine when it's currently disabled.
+--- Tells the system to enable the lighting engine when it's currently disabled.
 function le_enable()
     -- ...
 end

--- a/docs/lua/functions-4.md
+++ b/docs/lua/functions-4.md
@@ -170,13 +170,13 @@ Sets the max amount of lights that can affect a vertex
 
 <br />
 
-## [le_set_active](#le_set_active)
+## [le_set_enabled](#le_set_enabled)
 
 ### Description
 This will let the user control the lighting engine in real time to disable or enable it.
 
 ### Lua Example
-`le_set_active(value)`
+`le_set_enabled(value)`
 
 ### Parameters
 | Field | Type |
@@ -187,7 +187,7 @@ This will let the user control the lighting engine in real time to disable or en
 - None
 
 ### C Prototype
-`void le_set_active(bool value);`
+`void le_set_enabled(bool value);`
 
 [:arrow_up_small:](#)
 

--- a/docs/lua/functions-4.md
+++ b/docs/lua/functions-4.md
@@ -170,6 +170,29 @@ Sets the max amount of lights that can affect a vertex
 
 <br />
 
+## [le_set_active](#le_set_active)
+
+### Description
+This will let the user control the lighting engine in real time to disable or enable it.
+
+### Lua Example
+`le_set_active(value)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| value | `boolean` |
+
+### Returns
+- None
+
+### C Prototype
+`void le_set_active(bool value);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ## [le_calculate_lighting_color](#le_calculate_lighting_color)
 
 ### Description

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -983,7 +983,7 @@
    - [le_get_ambient_color](functions-4.md#le_get_ambient_color)
    - [le_set_ambient_color](functions-4.md#le_set_ambient_color)
    - [le_set_max_lights_per_vertex](functions-4.md#le_set_max_lights_per_vertex)
-   - [le_set_active](functions-4.md#le_set_active)
+   - [le_set_enabled](functions-4.md#le_set_enabled)
    - [le_calculate_lighting_color](functions-4.md#le_calculate_lighting_color)
    - [le_calculate_lighting_color_with_normal](functions-4.md#le_calculate_lighting_color_with_normal)
    - [le_calculate_lighting_dir](functions-4.md#le_calculate_lighting_dir)

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -983,6 +983,7 @@
    - [le_get_ambient_color](functions-4.md#le_get_ambient_color)
    - [le_set_ambient_color](functions-4.md#le_set_ambient_color)
    - [le_set_max_lights_per_vertex](functions-4.md#le_set_max_lights_per_vertex)
+   - [le_set_active](functions-4.md#le_set_active)
    - [le_calculate_lighting_color](functions-4.md#le_calculate_lighting_color)
    - [le_calculate_lighting_color_with_normal](functions-4.md#le_calculate_lighting_color_with_normal)
    - [le_calculate_lighting_dir](functions-4.md#le_calculate_lighting_dir)

--- a/src/engine/lighting_engine.cpp
+++ b/src/engine/lighting_engine.cpp
@@ -92,14 +92,8 @@ C_FIELD void le_set_max_lights_per_vertex(u8 count) {
     sMaxLightsPerVertex = count;
 }
 
-C_FIELD void le_disable(void) {
-    // Use this if you don't need the lighting engine at all
-    sEnabled = false;
-}
-
-C_FIELD void le_enable(void) {
-    // Use this to re-enable the engine
-    sEnabled = true;
+C_FIELD void le_set_active(bool value) {
+    sEnabled = value;
 }
 
 static inline void le_tone_map_total_weighted(Color out, Color inAmbient, Vec3f inColor, f32 weight) {

--- a/src/engine/lighting_engine.cpp
+++ b/src/engine/lighting_engine.cpp
@@ -92,6 +92,16 @@ C_FIELD void le_set_max_lights_per_vertex(u8 count) {
     sMaxLightsPerVertex = count;
 }
 
+C_FIELD void le_disable(void) {
+    // Use this if you don't need the lighting engine at all
+    sEnabled = false;
+}
+
+C_FIELD void le_enable(void) {
+    // Use this to re-enable the engine
+    sEnabled = true;
+}
+
 static inline void le_tone_map_total_weighted(Color out, Color inAmbient, Vec3f inColor, f32 weight) {
     out[0] = clamp_u8((inAmbient[0] + inColor[0]) / weight);
     out[1] = clamp_u8((inAmbient[1] + inColor[1]) / weight);

--- a/src/engine/lighting_engine.cpp
+++ b/src/engine/lighting_engine.cpp
@@ -92,7 +92,7 @@ C_FIELD void le_set_max_lights_per_vertex(u8 count) {
     sMaxLightsPerVertex = count;
 }
 
-C_FIELD void le_set_active(bool value) {
+C_FIELD void le_set_enabled(bool value) {
     sEnabled = value;
 }
 

--- a/src/engine/lighting_engine.h
+++ b/src/engine/lighting_engine.h
@@ -37,10 +37,8 @@ void le_get_ambient_color(VEC_OUT Color out);
 void le_set_ambient_color(u8 r, u8 g, u8 b);
 /* |description|Sets the max amount of lights that can affect a vertex|descriptionEnd| */
 void le_set_max_lights_per_vertex(u8 count);
-/* |description|Tells the system to disable the lighting engine when it's currently enabled. |descriptionEnd|*/
-void le_disable(void);
-/* |description|Tells the system to enable the lighting engine when it's currently disabled. |descriptionEnd|*/
-void le_enable(void);
+/* |description|This will let the user control the lighting engine in real time to disable or enable it. |descriptionEnd|*/
+void le_set_active(bool value);
 
 void le_calculate_vertex_lighting(const Vtx_t* v, Vec3f pos, VEC_OUT Color out);
 /* |description|Calculates the lighting with `lightIntensityScalar` at a position and outputs the color in `out`|descriptionEnd|*/

--- a/src/engine/lighting_engine.h
+++ b/src/engine/lighting_engine.h
@@ -37,6 +37,10 @@ void le_get_ambient_color(VEC_OUT Color out);
 void le_set_ambient_color(u8 r, u8 g, u8 b);
 /* |description|Sets the max amount of lights that can affect a vertex|descriptionEnd| */
 void le_set_max_lights_per_vertex(u8 count);
+/* |description|Tells the system to disable the lightning engine when it's currently enabled. |descriptionEnd|*/
+void le_disable(void);
+/* |description|Tells the system to enable the lightning engine when it's currently disabled. |descriptionEnd|*/
+void le_enable(void);
 
 void le_calculate_vertex_lighting(const Vtx_t* v, Vec3f pos, VEC_OUT Color out);
 /* |description|Calculates the lighting with `lightIntensityScalar` at a position and outputs the color in `out`|descriptionEnd|*/

--- a/src/engine/lighting_engine.h
+++ b/src/engine/lighting_engine.h
@@ -38,7 +38,7 @@ void le_set_ambient_color(u8 r, u8 g, u8 b);
 /* |description|Sets the max amount of lights that can affect a vertex|descriptionEnd| */
 void le_set_max_lights_per_vertex(u8 count);
 /* |description|This will let the user control the lighting engine in real time to disable or enable it. |descriptionEnd|*/
-void le_set_active(bool value);
+void le_set_enabled(bool value);
 
 void le_calculate_vertex_lighting(const Vtx_t* v, Vec3f pos, VEC_OUT Color out);
 /* |description|Calculates the lighting with `lightIntensityScalar` at a position and outputs the color in `out`|descriptionEnd|*/

--- a/src/engine/lighting_engine.h
+++ b/src/engine/lighting_engine.h
@@ -37,9 +37,9 @@ void le_get_ambient_color(VEC_OUT Color out);
 void le_set_ambient_color(u8 r, u8 g, u8 b);
 /* |description|Sets the max amount of lights that can affect a vertex|descriptionEnd| */
 void le_set_max_lights_per_vertex(u8 count);
-/* |description|Tells the system to disable the lightning engine when it's currently enabled. |descriptionEnd|*/
+/* |description|Tells the system to disable the lighting engine when it's currently enabled. |descriptionEnd|*/
 void le_disable(void);
-/* |description|Tells the system to enable the lightning engine when it's currently disabled. |descriptionEnd|*/
+/* |description|Tells the system to enable the lighting engine when it's currently disabled. |descriptionEnd|*/
 void le_enable(void);
 
 void le_calculate_vertex_lighting(const Vtx_t* v, Vec3f pos, VEC_OUT Color out);

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -15657,19 +15657,19 @@ int smlua_func_le_set_max_lights_per_vertex(lua_State* L) {
     return 1;
 }
 
-int smlua_func_le_set_active(lua_State* L) {
+int smlua_func_le_set_enabled(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
     if (top != 1) {
-        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "le_set_active", 1, top);
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "le_set_enabled", 1, top);
         return 0;
     }
 
     bool value = smlua_to_boolean(L, 1);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "le_set_active"); return 0; }
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "le_set_enabled"); return 0; }
 
-    le_set_active(value);
+    le_set_enabled(value);
 
     return 1;
 }
@@ -37787,7 +37787,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "le_get_ambient_color", smlua_func_le_get_ambient_color);
     smlua_bind_function(L, "le_set_ambient_color", smlua_func_le_set_ambient_color);
     smlua_bind_function(L, "le_set_max_lights_per_vertex", smlua_func_le_set_max_lights_per_vertex);
-    smlua_bind_function(L, "le_set_active", smlua_func_le_set_active);
+    smlua_bind_function(L, "le_set_enabled", smlua_func_le_set_enabled);
     smlua_bind_function(L, "le_calculate_lighting_color", smlua_func_le_calculate_lighting_color);
     smlua_bind_function(L, "le_calculate_lighting_color_with_normal", smlua_func_le_calculate_lighting_color_with_normal);
     smlua_bind_function(L, "le_calculate_lighting_dir", smlua_func_le_calculate_lighting_dir);

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -15657,6 +15657,23 @@ int smlua_func_le_set_max_lights_per_vertex(lua_State* L) {
     return 1;
 }
 
+int smlua_func_le_set_active(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 1) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "le_set_active", 1, top);
+        return 0;
+    }
+
+    bool value = smlua_to_boolean(L, 1);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "le_set_active"); return 0; }
+
+    le_set_active(value);
+
+    return 1;
+}
+
 int smlua_func_le_calculate_lighting_color(lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -37770,6 +37787,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "le_get_ambient_color", smlua_func_le_get_ambient_color);
     smlua_bind_function(L, "le_set_ambient_color", smlua_func_le_set_ambient_color);
     smlua_bind_function(L, "le_set_max_lights_per_vertex", smlua_func_le_set_max_lights_per_vertex);
+    smlua_bind_function(L, "le_set_active", smlua_func_le_set_active);
     smlua_bind_function(L, "le_calculate_lighting_color", smlua_func_le_calculate_lighting_color);
     smlua_bind_function(L, "le_calculate_lighting_color_with_normal", smlua_func_le_calculate_lighting_color_with_normal);
     smlua_bind_function(L, "le_calculate_lighting_dir", smlua_func_le_calculate_lighting_dir);


### PR DESCRIPTION
This is my very first PR ever so if I mess anything up, that's on myself.. (I had to redo the entire fork because I hate git desktop and I honestly hate myself.)

This PR is to create two new functions to control the lighting engine in real time: le_disable and le_enable

The lighting engine in coop was made to only work without turning it off at all. It stays on until the host disconnects the server. Modders had to use a really weird ambient settings in order to lower the lighting engine's properties when using it, but that didn't solve the issue entirely either. So I took the dive to remedy this myself, as I wanted to contribute to coop in some form. (This was WAY too long of a dive. I am really terrible at coding and I learn slower than anyone else...)

Below is a vod preview of the functions working in bitdw.

https://github.com/user-attachments/assets/88b6bf7d-bfc7-4a87-926a-b86bedffe6ef

I'm aware there's some description errors and I forgot to literally fix those again, but I will update this commit with fixing them anyway.