### PR TITLE
Fix DynOS packs Lua code execution

### DIFF
--- a/data/dynos.cpp.h
+++ b/data/dynos.cpp.h
@@ -22,7 +22,8 @@ extern "C" {
 #define FUNCTION_BHV    2
 #define FUNCTION_LVL    3
 
-#define MOD_PACK_INDEX 99
+#define MOD_PACK_INDEX 99 // the pack index for actors loaded from mods
+#define PACK_MOD_INDEX -1 // the mod index for actors loaded from packs
 
 //
 // Enums

--- a/data/dynos.cpp.h
+++ b/data/dynos.cpp.h
@@ -22,7 +22,7 @@ extern "C" {
 #define FUNCTION_BHV    2
 #define FUNCTION_LVL    3
 
-#define MOD_PACK_INDEX 99 // the pack index for actors loaded from mods
+#define MOD_PACK_INDEX -1 // the pack index for actors loaded from mods
 #define PACK_MOD_INDEX -1 // the mod index for actors loaded from packs
 
 //

--- a/data/dynos_bin_actor.cpp
+++ b/data/dynos_bin_actor.cpp
@@ -94,6 +94,9 @@ GfxData *DynOS_Actor_LoadFromBinary(const SysPath &aPackFolder, const char *aAct
     BinFile *_File = DynOS_Bin_Decompress(aFilename);
     if (_File) {
         _GfxData = New<GfxData>();
+        if (aAddToPack) {
+            _GfxData->mModIndex = PACK_MOD_INDEX;
+        }
         for (bool _Done = false; !_Done;) {
             switch (_File->Read<u8>()) {
                 case DATA_TYPE_LIGHT:           DynOS_Lights_Load    (_File, _GfxData); break;

--- a/data/dynos_bin_pointer.cpp
+++ b/data/dynos_bin_pointer.cpp
@@ -465,6 +465,10 @@ void *DynOS_Pointer_Load(BinFile *aFile, GfxData *aGfxData, u32 aValue, u8 aFunc
     // LUAV
     if (aValue == LUA_VAR_CODE) {
         String token; token.Read(aFile);
+        if (aGfxData->mModIndex == PACK_MOD_INDEX) {
+            sys_fatal("Invalid use of Lua function in DynOS pack: %s", token.begin());
+            return NULL;
+        }
         for (s32 i = 0; i < aGfxData->mLuaTokenList.Count(); i++) {
             if (token == aGfxData->mLuaTokenList[i]) {
                 return (void*)(uintptr_t)(i+1);

--- a/data/dynos_mgr_actor.cpp
+++ b/data/dynos_mgr_actor.cpp
@@ -220,7 +220,7 @@ void DynOS_Actor_Override(struct Object* obj, void** aSharedChild) {
             obj->behavior == smlua_override_behavior(bhvMetalCap) ||
             obj->behavior == smlua_override_behavior(bhvVanishCap))) {
         struct NetworkPlayer* np = network_player_from_global_index(obj->globalPlayerIndex);
-        if (np && np->localIndex > 0 && configDynosLocalPlayerModelOnly) {
+        if (np && np->localIndex > 0 && configDynosLocalPlayerModelOnly && it->second.mPackIndex != MOD_PACK_INDEX) {
             return;
         }
     }

--- a/data/dynos_mgr_builtin.cpp
+++ b/data/dynos_mgr_builtin.cpp
@@ -2087,7 +2087,7 @@ static String DynOS_Builtin_Func_CheckMisuse_Internal(s32 aIndex, const char* aD
         if (aFuncType != builtinFunc.type && (
             aIndex == i || (aDataName && strcmp(aDataName, builtinFunc.name) == 0) || aData == builtinFunc.func)) {
             return String(
-                "Invalid use of function %s: trying to assign %s function to %s",
+                "Invalid use of %s function in %s: %s",
                 builtinFunc.name,
                 sDynosBuiltinFuncTypeNames[builtinFunc.type],
                 sDynosBuiltinFuncTypeNames[aFuncType]


### PR DESCRIPTION
Fixes a critical issue that allows DynOS packs to run Lua code from any loaded mod using custom geo layout commands.
Also fixes an issue that makes mods player models affected by DynOS "Local Player Model Only" option.

The following video demonstrates the use of a local player DynOS pack crafted to trigger MarioHunt's debug commands in order to greatly help the runners to win the game.
No mods other than MarioHunt (v2.8) are used. This issue is also present in the Release build and can be exploited in public lobbies.
(The `/warp` command is from coopdx dev build and is not part of the demonstration. It is only used to quickly reach Bowser 3.)

https://github.com/user-attachments/assets/fb00c11e-eff5-479a-a199-0f9a8e22eade
