### PR TITLE
fix lingering kick pvp interaction

### DIFF
--- a/src/game/interaction.c
+++ b/src/game/interaction.c
@@ -1516,7 +1516,7 @@ u32 interact_player_pvp(struct MarioState* attacker, struct MarioState* victim) 
     // see if it was an attack
     u32 interaction = determine_interaction(attacker, cVictim->marioObj);
     // Specfically override jump kicks to prevent low damage and low knockback kicks
-    if (attacker->action == ACT_JUMP_KICK) { interaction = INT_KICK; }
+    if (attacker->action == ACT_JUMP_KICK && attacker->flags & MARIO_KICKING) { interaction = INT_KICK; }
     // Allow rollouts to attack
     else if (PLAYER_IN_ROLLOUT_FLIP(attacker)) { interaction = INT_HIT_FROM_BELOW; }
     if (!(interaction & INT_ANY_ATTACK) || (interaction & INT_HIT_FROM_ABOVE) || !passes_pvp_interaction_checks(attacker, cVictim)) {


### PR DESCRIPTION
kicks now check for the MARIO_KICKING flag, meaning a kick will only hit another player for the first 8 frames

first video is before last is after

https://github.com/user-attachments/assets/7e8b765c-82d3-4f81-9007-8ed068af0187


https://github.com/user-attachments/assets/befbfe65-e731-4837-a211-5f784684a94b

