### PR TITLE
Add HiDPI display support for SDL2

### DIFF
--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -77,6 +77,7 @@ ConfigWindow configWindow = {
     .exiting_fullscreen = false,
     .settings_changed = false,
     .msaa = 0,
+    .hidpi = false,
 };
 
 ConfigStick configStick = { 0 };
@@ -227,6 +228,7 @@ static const struct ConfigOption options[] = {
     {.name = "window_h",                       .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.h},
     {.name = "vsync",                          .type = CONFIG_TYPE_BOOL, .boolValue = &configWindow.vsync},
     {.name = "msaa",                           .type = CONFIG_TYPE_UINT, .uintValue = &configWindow.msaa},
+    {.name = "hidpi",                          .type = CONFIG_TYPE_BOOL, .boolValue = &configWindow.hidpi},
     // display settings
     {.name = "graphics_backend",               .type = CONFIG_TYPE_UINT, .uintValue = &configGraphicsBackend},
     {.name = "texture_filtering",              .type = CONFIG_TYPE_UINT, .uintValue = &configFiltering},

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -25,6 +25,7 @@ typedef struct {
     bool exiting_fullscreen;
     bool settings_changed;
     unsigned int msaa;
+    bool hidpi;
 } ConfigWindow;
 
 typedef struct {

--- a/src/pc/controller/controller_mouse.c
+++ b/src/pc/controller/controller_mouse.c
@@ -12,6 +12,8 @@ extern HWND gfx_dxgi_get_h_wnd(void);
 static bool mouse_relative_prev_cursor_state;
 #endif
 
+extern void gfx_sdl_get_hidpi_scale(float *sx, float *sy);
+
 bool mouse_init_ok;
 
 u32 mouse_buttons;
@@ -85,7 +87,6 @@ void controller_mouse_read_window(void) {
     }
 #else
     mouse_window_buttons = SDL_GetMouseState(&mouse_window_x, &mouse_window_y);
-    extern void gfx_sdl_get_hidpi_scale(float *sx, float *sy);
     float hidpi_sx = 1.0f, hidpi_sy = 1.0f;
     gfx_sdl_get_hidpi_scale(&hidpi_sx, &hidpi_sy);
     mouse_window_x = (s32)(mouse_window_x * hidpi_sx);

--- a/src/pc/controller/controller_mouse.c
+++ b/src/pc/controller/controller_mouse.c
@@ -85,6 +85,11 @@ void controller_mouse_read_window(void) {
     }
 #else
     mouse_window_buttons = SDL_GetMouseState(&mouse_window_x, &mouse_window_y);
+    extern void gfx_sdl_get_hidpi_scale(float *sx, float *sy);
+    float hidpi_sx = 1.0f, hidpi_sy = 1.0f;
+    gfx_sdl_get_hidpi_scale(&hidpi_sx, &hidpi_sy);
+    mouse_window_x = (s32)(mouse_window_x * hidpi_sx);
+    mouse_window_y = (s32)(mouse_window_y * hidpi_sy);
     mouse_window_x -= gfx_current_dimensions.x_adjust_4by3;
 #endif
 }

--- a/src/pc/djui/djui_panel_display.c
+++ b/src/pc/djui/djui_panel_display.c
@@ -14,6 +14,8 @@ static struct DjuiText* sRestartText = NULL;
 static u32 sMsaaSelection = 0;
 static u32 sMsaaOriginal = OPTION_ORIGINAL_UNSET;
 static u32 sGfxBackendOriginal = OPTION_ORIGINAL_UNSET;
+static bool sHidpiOriginal = false;
+static bool sHidpiOriginalSet = false;
 
 static void djui_panel_display_apply(UNUSED struct DjuiBase* caller) {
     configWindow.settings_changed = true;
@@ -37,7 +39,8 @@ static void djui_panel_display_frame_limit_text_change(struct DjuiBase* caller) 
 }
 
 static void djui_panel_display_update_restart_text(UNUSED struct DjuiBase* caller) {
-    if (sMsaaOriginal != configWindow.msaa || sGfxBackendOriginal != configGraphicsBackend) {
+    bool hidpiChanged = sHidpiOriginalSet && (sHidpiOriginal != configWindow.hidpi);
+    if (sMsaaOriginal != configWindow.msaa || sGfxBackendOriginal != configGraphicsBackend || hidpiChanged) {
         djui_text_set_text(sRestartText, DLANG(DISPLAY, MUST_RESTART));
     } else {
         djui_text_set_text(sRestartText, "");
@@ -56,6 +59,10 @@ static void djui_panel_display_msaa_change(struct DjuiBase* caller) {
     djui_panel_display_update_restart_text(caller);
 }
 
+static void djui_panel_display_hidpi_change(struct DjuiBase* caller) {
+    djui_panel_display_update_restart_text(caller);
+}
+
 void djui_panel_display_create(struct DjuiBase* caller) {
     struct DjuiThreePanel* panel = djui_panel_menu_create(DLANG(DISPLAY, DISPLAY), false);
     struct DjuiBase* body = djui_three_panel_get_body(panel);
@@ -69,6 +76,11 @@ void djui_panel_display_create(struct DjuiBase* caller) {
         djui_checkbox_create(body, DLANG(DISPLAY, FORCE_4BY3), &configForce4By3, djui_panel_display_apply);
         djui_checkbox_create(body, DLANG(DISPLAY, SHOW_FPS), &configShowFPS, NULL);
         djui_checkbox_create(body, DLANG(DISPLAY, VSYNC), &configWindow.vsync, djui_panel_display_apply);
+        extern bool gfx_sdl_hidpi_supported(void);
+        if (gfx_sdl_hidpi_supported()) {
+            if (!sHidpiOriginalSet) { sHidpiOriginal = configWindow.hidpi; sHidpiOriginalSet = true; }
+            djui_checkbox_create(body, "HiDPI", &configWindow.hidpi, djui_panel_display_hidpi_change);
+        }
 
         if (GAPI_MAX > 1) {
             char* gfxBackendChoices[2] = {

--- a/src/pc/djui/djui_panel_display.c
+++ b/src/pc/djui/djui_panel_display.c
@@ -6,6 +6,8 @@
 #include "pc/utils/misc.h"
 #include "pc/configfile.h"
 
+extern bool gfx_sdl_hidpi_supported(void);
+
 #define OPTION_ORIGINAL_UNSET ((u32)-1)
 
 static struct DjuiInputbox* sFrameLimitInput = NULL;
@@ -76,7 +78,6 @@ void djui_panel_display_create(struct DjuiBase* caller) {
         djui_checkbox_create(body, DLANG(DISPLAY, FORCE_4BY3), &configForce4By3, djui_panel_display_apply);
         djui_checkbox_create(body, DLANG(DISPLAY, SHOW_FPS), &configShowFPS, NULL);
         djui_checkbox_create(body, DLANG(DISPLAY, VSYNC), &configWindow.vsync, djui_panel_display_apply);
-        extern bool gfx_sdl_hidpi_supported(void);
         if (gfx_sdl_hidpi_supported()) {
             if (!sHidpiOriginalSet) { sHidpiOriginal = configWindow.hidpi; sHidpiOriginalSet = true; }
             djui_checkbox_create(body, "HiDPI", &configWindow.hidpi, djui_panel_display_hidpi_change);

--- a/src/pc/gfx/gfx_sdl.c
+++ b/src/pc/gfx/gfx_sdl.c
@@ -57,6 +57,7 @@
 static SDL_Window *wnd;
 static SDL_GLContext ctx = NULL;
 static bool sHidpiSupported = false;
+static bool sHidpiActive = false;
 
 static kb_callback_t kb_key_down = NULL;
 static kb_callback_t kb_key_up = NULL;
@@ -158,6 +159,15 @@ static void gfx_sdl_init(const char *window_title) {
     );
     ctx = SDL_GL_CreateContext(wnd);
 
+    // Record actual HiDPI state — drives rendering decisions for this window's lifetime.
+    // Toggling the config takes effect only on restart.
+    {
+        int dw = 0, dh = 0, ww = 0, wh = 0;
+        SDL_GL_GetDrawableSize(wnd, &dw, &dh);
+        SDL_GetWindowSize(wnd, &ww, &wh);
+        sHidpiActive = (dw > ww) || (dh > wh);
+    }
+
     gfx_sdl_set_vsync(configWindow.vsync);
 
     gfx_sdl_set_fullscreen();
@@ -174,7 +184,7 @@ static void gfx_sdl_main_loop(void (*run_one_game_iter)(void)) {
 
 static void gfx_sdl_get_dimensions(uint32_t *width, uint32_t *height) {
     int w, h;
-    if (configWindow.hidpi) {
+    if (sHidpiActive) {
         SDL_GL_GetDrawableSize(wnd, &w, &h);
     } else {
         SDL_GetWindowSize(wnd, &w, &h);
@@ -189,7 +199,7 @@ bool gfx_sdl_hidpi_supported(void) {
 
 void gfx_sdl_get_hidpi_scale(float *sx, float *sy) {
     int dw = 1, dh = 1, ww = 1, wh = 1;
-    if (wnd && configWindow.hidpi) {
+    if (wnd && sHidpiActive) {
         SDL_GL_GetDrawableSize(wnd, &dw, &dh);
         SDL_GetWindowSize(wnd, &ww, &wh);
     }

--- a/src/pc/gfx/gfx_sdl.c
+++ b/src/pc/gfx/gfx_sdl.c
@@ -141,7 +141,7 @@ static void gfx_sdl_init(const char *window_title) {
     wnd = SDL_CreateWindow(
         window_title,
         xpos, ypos, configWindow.w, configWindow.h,
-        SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE
+        SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI
     );
     ctx = SDL_GL_CreateContext(wnd);
 
@@ -161,9 +161,19 @@ static void gfx_sdl_main_loop(void (*run_one_game_iter)(void)) {
 
 static void gfx_sdl_get_dimensions(uint32_t *width, uint32_t *height) {
     int w, h;
-    SDL_GetWindowSize(wnd, &w, &h);
+    SDL_GL_GetDrawableSize(wnd, &w, &h);
     if (width) *width = w;
     if (height) *height = h;
+}
+
+void gfx_sdl_get_hidpi_scale(float *sx, float *sy) {
+    int dw = 1, dh = 1, ww = 1, wh = 1;
+    if (wnd) {
+        SDL_GL_GetDrawableSize(wnd, &dw, &dh);
+        SDL_GetWindowSize(wnd, &ww, &wh);
+    }
+    if (sx) *sx = (ww > 0) ? ((float)dw / (float)ww) : 1.0f;
+    if (sy) *sy = (wh > 0) ? ((float)dh / (float)wh) : 1.0f;
 }
 
 static void gfx_sdl_onkeydown(int scancode) {

--- a/src/pc/gfx/gfx_sdl.c
+++ b/src/pc/gfx/gfx_sdl.c
@@ -56,6 +56,7 @@
 
 static SDL_Window *wnd;
 static SDL_GLContext ctx = NULL;
+static bool sHidpiSupported = false;
 
 static kb_callback_t kb_key_down = NULL;
 static kb_callback_t kb_key_up = NULL;
@@ -138,10 +139,22 @@ static void gfx_sdl_init(const char *window_title) {
     int xpos = (configWindow.x == WAPI_WIN_CENTERPOS) ? SDL_WINDOWPOS_CENTERED : configWindow.x;
     int ypos = (configWindow.y == WAPI_WIN_CENTERPOS) ? SDL_WINDOWPOS_CENTERED : configWindow.y;
 
+    // Probe whether this display actually scales drawable > window under HIGHDPI.
+    SDL_Window *probe = SDL_CreateWindow("", 0, 0, 64, 64, SDL_WINDOW_HIDDEN | SDL_WINDOW_ALLOW_HIGHDPI);
+    if (probe) {
+        int pdw = 64, pdh = 64, pww = 64, pwh = 64;
+        SDL_GL_GetDrawableSize(probe, &pdw, &pdh);
+        SDL_GetWindowSize(probe, &pww, &pwh);
+        sHidpiSupported = (pdw > pww) || (pdh > pwh);
+        SDL_DestroyWindow(probe);
+    }
+
+    Uint32 windowFlags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE;
+    if (configWindow.hidpi) { windowFlags |= SDL_WINDOW_ALLOW_HIGHDPI; }
     wnd = SDL_CreateWindow(
         window_title,
         xpos, ypos, configWindow.w, configWindow.h,
-        SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI
+        windowFlags
     );
     ctx = SDL_GL_CreateContext(wnd);
 
@@ -161,14 +174,22 @@ static void gfx_sdl_main_loop(void (*run_one_game_iter)(void)) {
 
 static void gfx_sdl_get_dimensions(uint32_t *width, uint32_t *height) {
     int w, h;
-    SDL_GL_GetDrawableSize(wnd, &w, &h);
+    if (configWindow.hidpi) {
+        SDL_GL_GetDrawableSize(wnd, &w, &h);
+    } else {
+        SDL_GetWindowSize(wnd, &w, &h);
+    }
     if (width) *width = w;
     if (height) *height = h;
 }
 
+bool gfx_sdl_hidpi_supported(void) {
+    return sHidpiSupported;
+}
+
 void gfx_sdl_get_hidpi_scale(float *sx, float *sy) {
     int dw = 1, dh = 1, ww = 1, wh = 1;
-    if (wnd) {
+    if (wnd && configWindow.hidpi) {
         SDL_GL_GetDrawableSize(wnd, &dw, &dh);
         SDL_GetWindowSize(wnd, &ww, &wh);
     }


### PR DESCRIPTION
Adds HiDPI display support so the game renders at native resolution on high-density screens (Retina Macs, 4K/scaled Windows laptops, Linux with fractional scaling) instead of being upscaled by the OS, making some elements (especially menus and game characters) look a bit pixalated.

- [x] Sharp rendering on HiDPI displays
- [x] Mouse input still lines up with window geometry
- [x] No change on regular (non-HiDPI) displays

The differences are not so noticeable on medium or big size screens like laptops or monitors, but when developing the iOS port the difference was huge.

**Tests on Macbook Pro M5:**

Before:
<img width="1511" height="831" alt="image" src="https://github.com/user-attachments/assets/cfe20972-19a6-4774-82e2-e0f4c1aa25d9" /> (game logo borders, castle towers)
<img width="1508" height="831" alt="image" src="https://github.com/user-attachments/assets/b998f98a-d2ee-4472-9e1f-62609b0f3386" /> (stars borders)
<img width="1505" height="833" alt="image" src="https://github.com/user-attachments/assets/dbb0f2c5-f888-48c4-ae43-2f883c842662" /> (mario's hair)


After:
<img width="1508" height="833" alt="image" src="https://github.com/user-attachments/assets/5ecf43a1-a3d7-41c8-83ce-ca616998f14e" />

<img width="1505" height="828" alt="image" src="https://github.com/user-attachments/assets/1e418b5a-1c8a-457e-9ccb-923e9b8dbe2d" />

<img width="1503" height="834" alt="image" src="https://github.com/user-attachments/assets/5d2232e9-d539-4808-955c-29b0942eb090" />


**Tests on iOS port:**

Before:
<img width="2868" height="1320" alt="image" src="https://github.com/user-attachments/assets/98672b40-acf7-406e-97d3-07a7de53c604" /> (game logo borders, castle towers)


<img width="2868" height="1320" alt="image" src="https://github.com/user-attachments/assets/c8f18e19-9269-4bc2-a13f-ab6ce2359810" /> (mario's hair, mario's body)

After:
<img width="2868" height="1320" alt="image" src="https://github.com/user-attachments/assets/0175cde7-1743-4378-bbc5-0ac5679d1130" />

<img width="2868" height="1320" alt="image" src="https://github.com/user-attachments/assets/a0fdf7af-f310-4846-a026-656a4f36d609" />
