### PR TITLE
Fix syntax error in _clock_gettime POSIX fallback

### DIFF
--- a/src/pc/utils/misc.c
+++ b/src/pc/utils/misc.c
@@ -36,7 +36,7 @@ static void _clock_gettime(struct timespec* clock_time) {
     clock_gettime(CLOCK_MONOTONIC, clock_time);
 #else
     if (clock_gettime(CLOCK_MONOTONIC, clock_time))
-        clock_gettime(CLOCK_REALTIME, clock_time));
+        clock_gettime(CLOCK_REALTIME, clock_time);
 #endif
 
 #ifdef DEVELOPMENT


### PR DESCRIPTION
## Problem

I was getting this when compiling the game on Arch Linux ARM

<img width="2110" height="604" alt="image" src="https://github.com/user-attachments/assets/cb6dea2c-d4b3-46a5-897e-5e4410048d3d" />

## Analysis

Syntax error in `src/pc/utils/misc.c`, in the `#else` fallback branch of the `_POSIX_MONOTONIC_CLOCK` check. Present since 7044485 (2021), most platforms take the `#elif _POSIX_MONOTONIC_CLOCK > 0` branch, so the `#else` is rarely reached.

## Fix

```diff
 #if !defined _POSIX_MONOTONIC_CLOCK || _POSIX_MONOTONIC_CLOCK < 0
     clock_gettime(CLOCK_REALTIME, clock_time);
 #elif _POSIX_MONOTONIC_CLOCK > 0
     clock_gettime(CLOCK_MONOTONIC, clock_time);
 #else
     if (clock_gettime(CLOCK_MONOTONIC, clock_time))
-        clock_gettime(CLOCK_REALTIME, clock_time));
+        clock_gettime(CLOCK_REALTIME, clock_time);
 #endif
```