### PR TITLE
Fix crash when CG was loaded in main menu related to Yoshi

### DIFF
--- a/src/game/behaviors/yoshi.inc.c
+++ b/src/game/behaviors/yoshi.inc.c
@@ -104,9 +104,9 @@ void yoshi_idle_loop(void) {
     }
 
     // Credits; Yoshi appears at this position overlooking the castle near the end of the credits
-    if (gPlayerCameraState->cameraEvent == CAM_EVENT_START_ENDING
-        || gPlayerCameraState->cameraEvent == CAM_EVENT_START_END_WAVING
-        || gDjuiInMainMenu) {
+    if (gPlayerCameraState->cameraEvent == CAM_EVENT_START_ENDING ||
+        gPlayerCameraState->cameraEvent == CAM_EVENT_START_END_WAVING ||
+        gDjuiInMainMenu) {
         o->oAction = YOSHI_ACT_CREDITS;
         o->oPosX = -1798.0f;
         o->oPosY = 3174.0f;

--- a/src/game/behaviors/yoshi.inc.c
+++ b/src/game/behaviors/yoshi.inc.c
@@ -104,9 +104,7 @@ void yoshi_idle_loop(void) {
     }
 
     // Credits; Yoshi appears at this position overlooking the castle near the end of the credits
-    if (gPlayerCameraState->cameraEvent == CAM_EVENT_START_ENDING ||
-        gPlayerCameraState->cameraEvent == CAM_EVENT_START_END_WAVING ||
-        gDjuiInMainMenu) {
+    if (gPlayerCameraState->cameraEvent == CAM_EVENT_START_ENDING || gPlayerCameraState->cameraEvent == CAM_EVENT_START_END_WAVING || gDjuiInMainMenu) {
         o->oAction = YOSHI_ACT_CREDITS;
         o->oPosX = -1798.0f;
         o->oPosY = 3174.0f;
@@ -154,7 +152,7 @@ void yoshi_walk_and_jump_off_roof_loop(void) {
     o->oForwardVel = 10.0f;
     object_step();
     cur_obj_init_animation(1);
-    if (o->oTimer == 0
+    if (!gDjuiInMainMenu && o->oTimer == 0
     && o->globalPlayerIndex == gNetworkPlayerLocal->globalIndex
     && gMarioStates[0].interactObj == o
     && (gMarioStates[0].action == ACT_READING_NPC_DIALOG
@@ -270,6 +268,13 @@ void yoshi_reappear(void) {
 }
 
 void bhv_yoshi_loop(void) {
+    // sanity check main menu
+    if (gDjuiInMainMenu) {
+        cur_obj_init_animation(0);
+        yoshi_idle_loop();
+        return;
+    }
+
     switch (o->oAction) {
         case YOSHI_ACT_IDLE:
             yoshi_idle_loop();

--- a/src/game/behaviors/yoshi.inc.c
+++ b/src/game/behaviors/yoshi.inc.c
@@ -104,7 +104,9 @@ void yoshi_idle_loop(void) {
     }
 
     // Credits; Yoshi appears at this position overlooking the castle near the end of the credits
-    if (gPlayerCameraState->cameraEvent == CAM_EVENT_START_ENDING || gPlayerCameraState->cameraEvent == CAM_EVENT_START_END_WAVING || gDjuiInMainMenu) {
+    if (gPlayerCameraState->cameraEvent == CAM_EVENT_START_ENDING
+        || gPlayerCameraState->cameraEvent == CAM_EVENT_START_END_WAVING
+        || gDjuiInMainMenu) {
         o->oAction = YOSHI_ACT_CREDITS;
         o->oPosX = -1798.0f;
         o->oPosY = 3174.0f;

--- a/src/game/behaviors/yoshi.inc.c
+++ b/src/game/behaviors/yoshi.inc.c
@@ -272,7 +272,6 @@ void yoshi_reappear(void) {
 void bhv_yoshi_loop(void) {
     // sanity check main menu
     if (gDjuiInMainMenu) {
-        cur_obj_init_animation(0);
         yoshi_idle_loop();
         return;
     }

--- a/src/game/behaviors/yoshi.inc.c
+++ b/src/game/behaviors/yoshi.inc.c
@@ -152,7 +152,7 @@ void yoshi_walk_and_jump_off_roof_loop(void) {
     o->oForwardVel = 10.0f;
     object_step();
     cur_obj_init_animation(1);
-    if (!gDjuiInMainMenu && o->oTimer == 0
+    if (o->oTimer == 0
     && o->globalPlayerIndex == gNetworkPlayerLocal->globalIndex
     && gMarioStates[0].interactObj == o
     && (gMarioStates[0].action == ACT_READING_NPC_DIALOG


### PR DESCRIPTION
Caused by https://github.com/coop-deluxe/sm64coopdx/commit/6510f3928cab7ebc5fafe7480a574234147e3123 and pointed out by @kermeow 

The issue was `gNetworkPlayerLocal` being an invalid pointer when in the main menu.

Fix was to force main menu Yoshi to use the credit sequence and not do anything else.