### PR TITLE
Multiple dx11 fixes

### DIFF
--- a/src/pc/gfx/gfx_direct3d11.cpp
+++ b/src/pc/gfx/gfx_direct3d11.cpp
@@ -342,14 +342,14 @@ static struct ShaderProgram *gfx_d3d11_create_and_load_new_shader(struct ColorCo
     UINT compile_flags = D3DCOMPILE_OPTIMIZATION_LEVEL2;
 #endif
 
-    HRESULT hr = d3d.D3DCompile(buf, len, nullptr, nullptr, nullptr, "VSMain", "vs_4_0_level_9_1", compile_flags, 0, vs.GetAddressOf(), error_blob.GetAddressOf());
+    HRESULT hr = d3d.D3DCompile(buf, len, nullptr, nullptr, nullptr, "VSMain", "vs_4_0", compile_flags, 0, vs.GetAddressOf(), error_blob.GetAddressOf());
 
     if (FAILED(hr)) {
         MessageBox(gfx_dxgi_get_h_wnd(), (char *) error_blob->GetBufferPointer(), "Error", MB_OK | MB_ICONERROR);
         throw hr;
     }
 
-    hr = d3d.D3DCompile(buf, len, nullptr, nullptr, nullptr, "PSMain", "ps_4_0_level_9_1", compile_flags, 0, ps.GetAddressOf(), error_blob.GetAddressOf());
+    hr = d3d.D3DCompile(buf, len, nullptr, nullptr, nullptr, "PSMain", "ps_4_0", compile_flags, 0, ps.GetAddressOf(), error_blob.GetAddressOf());
 
     if (FAILED(hr)) {
         MessageBox(gfx_dxgi_get_h_wnd(), (char *) error_blob->GetBufferPointer(), "Error", MB_OK | MB_ICONERROR);

--- a/src/pc/gfx/gfx_direct3d11.cpp
+++ b/src/pc/gfx/gfx_direct3d11.cpp
@@ -368,7 +368,7 @@ static struct ShaderProgram *gfx_d3d11_create_and_load_new_shader(struct ColorCo
     D3D11_INPUT_ELEMENT_DESC ied[16];
     uint8_t ied_index = 0;
     ied[ied_index++] = { "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 };
-    for (int t = 0; t < 2; t++) {
+    for (unsigned int t = 0; t < 2; t++) {
         if (cc_features.used_textures[t]) {
             ied[ied_index++] = { "TEXCOORD", t, DXGI_FORMAT_R32G32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 };
         }

--- a/src/pc/gfx/gfx_direct3d11.cpp
+++ b/src/pc/gfx/gfx_direct3d11.cpp
@@ -370,9 +370,7 @@ static struct ShaderProgram *gfx_d3d11_create_and_load_new_shader(struct ColorCo
     ied[ied_index++] = { "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 };
     for (int t = 0; t < 2; t++) {
         if (cc_features.used_textures[t]) {
-            char buffer[16];
-            snprintf(buffer, sizeof(buffer), "TEXCOORD%d", t);
-            ied[ied_index++] = { buffer, 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 };
+            ied[ied_index++] = { "TEXCOORD", t, DXGI_FORMAT_R32G32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 };
         }
     }
     if (cc->cm.use_fog) {

--- a/src/pc/gfx/gfx_direct3d11.cpp
+++ b/src/pc/gfx/gfx_direct3d11.cpp
@@ -77,12 +77,12 @@ struct ShaderProgramD3D11 {
 static struct {
     HMODULE d3d11_module;
     PFN_D3D11_CREATE_DEVICE D3D11CreateDevice;
-    
+
     HMODULE d3dcompiler_module;
     pD3DCompile D3DCompile;
-    
+
     D3D_FEATURE_LEVEL feature_level;
-    
+
     ComPtr<ID3D11Device> device;
     ComPtr<IDXGISwapChain1> swap_chain;
     ComPtr<ID3D11DeviceContext> context;
@@ -272,7 +272,7 @@ static void gfx_d3d11_init(void) {
     ZeroMemory(&vertex_buffer_desc, sizeof(D3D11_BUFFER_DESC));
 
     vertex_buffer_desc.Usage = D3D11_USAGE_DYNAMIC;
-    vertex_buffer_desc.ByteWidth = 256 * 26 * 3 * sizeof(float); // Same as buf_vbo size in gfx_pc
+    vertex_buffer_desc.ByteWidth = 256 * 28 * 3 * sizeof(float); // Same as buf_vbo size in gfx_pc
     vertex_buffer_desc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
     vertex_buffer_desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
     vertex_buffer_desc.MiscFlags = 0;
@@ -365,11 +365,15 @@ static struct ShaderProgram *gfx_d3d11_create_and_load_new_shader(struct ColorCo
 
     // Input Layout
 
-    D3D11_INPUT_ELEMENT_DESC ied[7];
+    D3D11_INPUT_ELEMENT_DESC ied[16];
     uint8_t ied_index = 0;
     ied[ied_index++] = { "POSITION", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 };
-    if (cc_features.used_textures[0] || cc_features.used_textures[1]) {
-        ied[ied_index++] = { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 };
+    for (int t = 0; t < 2; t++) {
+        if (cc_features.used_textures[t]) {
+            char buffer[16];
+            snprintf(buffer, sizeof(buffer), "TEXCOORD%d", t);
+            ied[ied_index++] = { buffer, 0, DXGI_FORMAT_R32G32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 };
+        }
     }
     if (cc->cm.use_fog) {
         ied[ied_index++] = { "FOG", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 };

--- a/src/pc/gfx/gfx_direct3d_common.cpp
+++ b/src/pc/gfx/gfx_direct3d_common.cpp
@@ -222,7 +222,7 @@ void gfx_direct3d_common_build_shader(char buf[4096], size_t& len, size_t& num_f
     append_str(buf, &len, "PSInput VSMain(float4 position : POSITION");
     for (int t = 0; t < 2; t++) {
         if (ccf.used_textures[t]) {
-            len += sprintf(buf + len, ", float2 uv%d : TEXCOORD%d;", t, t);
+            len += sprintf(buf + len, ", float2 uv%d : TEXCOORD%d", t, t);
         }
     }
     if (cc.cm.use_fog) {

--- a/src/pc/gfx/gfx_direct3d_common.cpp
+++ b/src/pc/gfx/gfx_direct3d_common.cpp
@@ -148,7 +148,7 @@ void gfx_direct3d_common_build_shader(char buf[4096], size_t& len, size_t& num_f
     append_line(buf, &len, "    float4 position : SV_POSITION;");
     for (int t = 0; t < 2; t++) {
         if (ccf.used_textures[t]) {
-            buf_len += sprintf(buf + buf_len, "    float2 uv%d : TEXCOORD%d;", t, t);
+            len += sprintf(buf + len, "    float2 uv%d : TEXCOORD%d;", t, t);
             num_floats += 2;
         }
     }
@@ -222,7 +222,7 @@ void gfx_direct3d_common_build_shader(char buf[4096], size_t& len, size_t& num_f
     append_str(buf, &len, "PSInput VSMain(float4 position : POSITION");
     for (int t = 0; t < 2; t++) {
         if (ccf.used_textures[t]) {
-            buf_len += sprintf(buf + buf_len, ", float2 uv%d : TEXCOORD%d;", t, t);
+            len += sprintf(buf + len, ", float2 uv%d : TEXCOORD%d;", t, t);
         }
     }
     if (cc.cm.use_fog) {
@@ -242,7 +242,7 @@ void gfx_direct3d_common_build_shader(char buf[4096], size_t& len, size_t& num_f
     }
     for (int t = 0; t < 2; t++) {
         if (ccf.used_textures[t]) {
-            buf_len += sprintf(buf + buf_len, "    result.uv%d = uv%d;", t, t);
+            len += sprintf(buf + len, "    result.uv%d = uv%d;", t, t);
         }
     }
     if (cc.cm.use_fog) {

--- a/src/pc/gfx/gfx_direct3d_common.cpp
+++ b/src/pc/gfx/gfx_direct3d_common.cpp
@@ -146,9 +146,11 @@ void gfx_direct3d_common_build_shader(char buf[4096], size_t& len, size_t& num_f
 
     append_line(buf, &len, "struct PSInput {");
     append_line(buf, &len, "    float4 position : SV_POSITION;");
-    if (ccf.used_textures[0] || ccf.used_textures[1]) {
-        append_line(buf, &len, "    float2 uv : TEXCOORD;");
-        num_floats += 2;
+    for (int t = 0; t < 2; t++) {
+        if (ccf.used_textures[t]) {
+            buf_len += sprintf(buf + buf_len, "    float2 uv%d : TEXCOORD%d;", t, t);
+            num_floats += 2;
+        }
     }
     if ((cc.cm.use_alpha && cc.cm.use_dither) || ccf.do_noise) {
         append_line(buf, &len, "    float4 screenPos : TEXCOORD1;");
@@ -218,8 +220,10 @@ void gfx_direct3d_common_build_shader(char buf[4096], size_t& len, size_t& num_f
     // Vertex shader
 
     append_str(buf, &len, "PSInput VSMain(float4 position : POSITION");
-    if (ccf.used_textures[0] || ccf.used_textures[1]) {
-        append_str(buf, &len, ", float2 uv : TEXCOORD");
+    for (int t = 0; t < 2; t++) {
+        if (ccf.used_textures[t]) {
+            buf_len += sprintf(buf + buf_len, ", float2 uv%d : TEXCOORD%d;", t, t);
+        }
     }
     if (cc.cm.use_fog) {
         append_str(buf, &len, ", float4 fog : FOG");
@@ -236,8 +240,10 @@ void gfx_direct3d_common_build_shader(char buf[4096], size_t& len, size_t& num_f
     if ((cc.cm.use_alpha && cc.cm.use_dither) || ccf.do_noise) {
         append_line(buf, &len, "    result.screenPos = position;");
     }
-    if (ccf.used_textures[0] || ccf.used_textures[1]) {
-        append_line(buf, &len, "    result.uv = uv;");
+    for (int t = 0; t < 2; t++) {
+        if (ccf.used_textures[t]) {
+            buf_len += sprintf(buf + buf_len, "    result.uv%d = uv%d;", t, t);
+        }
     }
     if (cc.cm.use_fog) {
         append_line(buf, &len, "    result.fog = fog;");
@@ -266,11 +272,11 @@ void gfx_direct3d_common_build_shader(char buf[4096], size_t& len, size_t& num_f
         if (three_point_filtering) {
             append_line(buf, &len, "    float4 texVal0;");
             append_line(buf, &len, "    if (textures[0].linear_filtering)");
-            append_line(buf, &len, "        texVal0 = tex2D3PointFilter(g_texture0, g_sampler0, input.uv, float2(textures[0].width, textures[0].height));");
+            append_line(buf, &len, "        texVal0 = tex2D3PointFilter(g_texture0, g_sampler0, input.uv0, float2(textures[0].width, textures[0].height));");
             append_line(buf, &len, "    else");
-            append_line(buf, &len, "        texVal0 = g_texture0.Sample(g_sampler0, input.uv);");
+            append_line(buf, &len, "        texVal0 = g_texture0.Sample(g_sampler0, input.uv0);");
         } else {
-            append_line(buf, &len, "    float4 texVal0 = g_texture0.Sample(g_sampler0, input.uv);");
+            append_line(buf, &len, "    float4 texVal0 = g_texture0.Sample(g_sampler0, input.uv0);");
         }
     }
     if (ccf.used_textures[1]) {
@@ -289,11 +295,11 @@ void gfx_direct3d_common_build_shader(char buf[4096], size_t& len, size_t& num_f
             if (three_point_filtering) {
                 append_line(buf, &len, "    float4 texVal1;");
                 append_line(buf, &len, "    if (textures[1].linear_filtering)");
-                append_line(buf, &len, "        texVal1 = tex2D3PointFilter(g_texture1, g_sampler1, input.uv, float2(textures[1].width, textures[1].height));");
+                append_line(buf, &len, "        texVal1 = tex2D3PointFilter(g_texture1, g_sampler1, input.uv1, float2(textures[1].width, textures[1].height));");
                 append_line(buf, &len, "    else");
-                append_line(buf, &len, "        texVal1 = g_texture1.Sample(g_sampler1, input.uv);");
+                append_line(buf, &len, "        texVal1 = g_texture1.Sample(g_sampler1, input.uv1);");
             } else {
-                append_line(buf, &len, "    float4 texVal1 = g_texture1.Sample(g_sampler1, input.uv);");
+                append_line(buf, &len, "    float4 texVal1 = g_texture1.Sample(g_sampler1, input.uv1);");
             }
         }
     }


### PR DESCRIPTION
Hopefully this and the shader pr is the last time I have to touch this renderer lol

- Resolves a vertex stride mismatch introduced in https://github.com/coop-deluxe/sm64coopdx/commit/962ea72e41a837dd72448f7b63e1510b4e73e706
- Addresses previously possible overflow, along with bumping directx version due to the inputs allowed being too low

Tested by generally running the game, and multiple textures were tested via the bitdw painting in the main castle.

Also, vscode removed whitespaces because that's what I have it configured to do, hopefully that's fine