### PR TITLE
Fix `ModAudio.file.relativePath` virtually

### DIFF
--- a/autogen/convert_structs.py
+++ b/autogen/convert_structs.py
@@ -105,6 +105,7 @@ override_field_invisible = {
 
 override_field_deprecated = {
     "NetworkPlayer": [ "paletteIndex", "overridePaletteIndex", "overridePaletteIndexLp" ],
+    "ModAudio": [ "file", "relativePath" ], # compatibility band-aid
 }
 
 override_field_immutable = {
@@ -503,6 +504,9 @@ def get_struct_field_info(struct, field):
     fimmutable = str(lvt == 'LVT_COBJECT' or 'const ' in ftype).lower()
     if lvt.startswith('LVT_') and lvt.endswith('_P') and 'OBJECT' not in lvt and 'COLLISION' not in lvt and 'TRAJECTORY' not in lvt:
         fimmutable = 'true'
+    
+    if field.get('get') and field['set'] == 'NULL':
+        fimmutable = 'true'
 
     if sid in override_field_immutable:
         if fid in override_field_immutable[sid] or '*' in override_field_immutable[sid]:
@@ -569,7 +573,9 @@ def build_struct(struct):
             row.append('.function = "%s"\\' % field['function'])
         elif field.get('get'):
             row.append('.get = "%s", ' % field['get'])
-            row.append('.set = "%s"\\' % field['set'])
+            if fimmutable != 'true':
+                row.append('.set = "%s"\\' % field['set'])
+            else: row[-1] = row[-1][:-2] + "\\"
         else:
             row.append('offsetof(%s%s, %s), ' % (struct_str, name, field['identifier']))
             row.append('%s, '       % fimmutable)

--- a/autogen/lua_definitions/structs.lua
+++ b/autogen/lua_definitions/structs.lua
@@ -1196,6 +1196,7 @@
 
 --- @class ModAudio
 --- @field public filepath string
+--- @field public relativePath string
 --- @field public isStream boolean
 --- @field public baseVolume number
 --- @field public loaded boolean
@@ -1203,6 +1204,7 @@
 --- @field public looping boolean
 --- @field public frequency number
 --- @field public volume number
+--- @field public file unction
 
 --- @class ModFs
 --- @field public mod Mod

--- a/src/pc/lua/smlua_autogen.h
+++ b/src/pc/lua/smlua_autogen.h
@@ -23,7 +23,7 @@
 
 // A macro to tell autogen the field `name` is a property member of the struct that calls `get` or `set` accessors
 // - get: fun(self) -> value
-// - set: fun(self, value)
+// - set: fun(self, value) (property immutable if NULL)
 #define PROPERTY(name, get, set)
 
 // A macro to tell autogen the field `name` is a function member of the struct that calls `c_function`

--- a/src/pc/lua/smlua_cobject.c
+++ b/src/pc/lua/smlua_cobject.c
@@ -644,12 +644,17 @@ static int smlua__set_field(lua_State* L) {
 
     // CObject property
     if (data->valueType == LVT_PROPERTY) {
-        lua_getglobal(L, data->set);
-        lua_pushvalue(L, 1);
-        lua_pushvalue(L, 3);
-        smlua_pcall(L, 2, 1, 0);
-        LUA_STACK_CHECK_END(L);
-        return 1;
+        if (data->set) {
+            lua_getglobal(L, data->set);
+            lua_pushvalue(L, 1);
+            lua_pushvalue(L, 3);
+            smlua_pcall(L, 2, 1, 0);
+            LUA_STACK_CHECK_END(L);
+            return 1;
+        } else {
+            LOG_LUA_LINE("_set_field on immutable key '%s'", key);
+            return 0;
+        }
     }
 
     if (data->immutable || data->valueType == LVT_FUNCTION) {

--- a/src/pc/lua/smlua_cobject_autogen.c
+++ b/src/pc/lua/smlua_cobject_autogen.c
@@ -1482,16 +1482,18 @@ static struct LuaObjectField sModFields[LUA_MOD_FIELD_COUNT] = {
     { "size",                 LVT_U64,      offsetof(struct Mod, size),                 true, LOT_NONE },
 };
 
-#define LUA_MOD_AUDIO_FIELD_COUNT 8
+#define LUA_MOD_AUDIO_FIELD_COUNT 10
 static struct LuaObjectField sModAudioFields[LUA_MOD_AUDIO_FIELD_COUNT] = {
-    { "baseVolume", LVT_F32,      offsetof(struct ModAudio, baseVolume), false, LOT_NONE },
-    { "filepath",   LVT_STRING_P, offsetof(struct ModAudio, filepath),   true,  LOT_NONE },
-    { "frequency",  LVT_PROPERTY, .get = "audio_stream_get_frequency",   .set = "audio_stream_set_frequency" },
-    { "isStream",   LVT_BOOL,     offsetof(struct ModAudio, isStream),   true,  LOT_NONE },
-    { "loaded",     LVT_BOOL,     offsetof(struct ModAudio, loaded),     true,  LOT_NONE },
-    { "looping",    LVT_PROPERTY, .get = "audio_stream_get_looping",     .set = "audio_stream_set_looping" },
-    { "position",   LVT_PROPERTY, .get = "audio_stream_get_position",    .set = "audio_stream_set_position" },
-    { "volume",     LVT_PROPERTY, .get = "audio_stream_get_volume",      .set = "audio_stream_set_volume" },
+    { "baseVolume",   LVT_F32,      offsetof(struct ModAudio, baseVolume),   false, LOT_NONE },
+    { "file",         LVT_PROPERTY, .get = "return_self"                                     },
+    { "filepath",     LVT_STRING_P, offsetof(struct ModAudio, filepath),     true,  LOT_NONE },
+    { "frequency",    LVT_PROPERTY, .get = "audio_stream_get_frequency",     .set = "audio_stream_set_frequency" },
+    { "isStream",     LVT_BOOL,     offsetof(struct ModAudio, isStream),     true,  LOT_NONE },
+    { "loaded",       LVT_BOOL,     offsetof(struct ModAudio, loaded),       true,  LOT_NONE },
+    { "looping",      LVT_PROPERTY, .get = "audio_stream_get_looping",       .set = "audio_stream_set_looping" },
+    { "position",     LVT_PROPERTY, .get = "audio_stream_get_position",      .set = "audio_stream_set_position" },
+    { "relativePath", LVT_STRING_P, offsetof(struct ModAudio, relativePath), true,  LOT_NONE },
+    { "volume",       LVT_PROPERTY, .get = "audio_stream_get_volume",        .set = "audio_stream_set_volume" },
 };
 
 #define LUA_MOD_FS_FIELD_COUNT 15

--- a/src/pc/lua/smlua_functions.c
+++ b/src/pc/lua/smlua_functions.c
@@ -1068,6 +1068,14 @@ int smlua_func_djui_hud_print_text_interpolated(lua_State* L) {
     return 1;
 }
 
+// compatibility band-aid
+int smlua_func_return_self(lua_State* L) {
+    if (!smlua_functions_valid_param_count(L, 1)) { return 0; }
+
+    lua_pushvalue(L, 1);
+    return 1;
+}
+
   //////////
  // bind //
 //////////
@@ -1101,4 +1109,5 @@ void smlua_bind_functions(void) {
     smlua_bind_function(L, "gfx_set_command", smlua_func_gfx_set_command);
     smlua_bind_function(L, "djui_hud_print_text", smlua_func_djui_hud_print_text);
     smlua_bind_function(L, "djui_hud_print_text_interpolated", smlua_func_djui_hud_print_text_interpolated);
+    smlua_bind_function(L, "return_self", smlua_func_return_self); // compatibility band-aid
 }

--- a/src/pc/lua/utils/smlua_audio_utils.h
+++ b/src/pc/lua/utils/smlua_audio_utils.h
@@ -24,7 +24,10 @@ struct ModAudioSampleCopies {
 };
 
 struct ModAudio {
-    const char *filepath;
+    union {
+        const char *filepath;
+        const char *relativePath; // compatibility band-aid
+    };
     ma_sound sound;
     ma_decoder decoder;
     void *buffer;
@@ -38,6 +41,8 @@ struct ModAudio {
     PROPERTY(looping,   audio_stream_get_looping,   audio_stream_set_looping);
     PROPERTY(frequency, audio_stream_get_frequency, audio_stream_set_frequency);
     PROPERTY(volume,    audio_stream_get_volume,    audio_stream_set_volume);
+
+    PROPERTY(file, return_self, NULL); // compatibility band-aid
 };
 
 /* |description|Loads an `audio` stream by `filename` (with extension)|descriptionEnd| */


### PR DESCRIPTION
Applied a compatibility band-aid for `ModAudio.file.relativePath` using unions and properties. The only real thing here is the new hidden `return_self` function I had to make for this to work

unction