### PR TITLE
Fix sync valid packet issues for the server

### DIFF
--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -617,7 +617,7 @@ void network_update(void) {
             bool inCredits = (np->currActNum == 99);
             if (gNetworkType == NT_SERVER && (npAny == NULL || inCredits)) {
                 // no NetworkPlayer in the level
-                network_send_sync_valid(np, np->currCourseNum, np->currActNum, np->currLevelNum, np->currAreaIndex);
+                network_send_sync_valid(np, np->currCourseNum, np->currActNum, np->currLevelNum, np->currAreaIndex, false);
                 return;
             }
 

--- a/src/pc/network/packets/packet.h
+++ b/src/pc/network/packets/packet.h
@@ -315,7 +315,7 @@ void network_send_area(struct NetworkPlayer* toNp);
 void network_receive_area(struct Packet* p);
 
 // packet_sync_valid.c
-void network_send_sync_valid(struct NetworkPlayer* toNp, s16 courseNum, s16 actNum, s16 levelNum, s16 areaIndex);
+void network_send_sync_valid(struct NetworkPlayer* toNp, s16 courseNum, s16 actNum, s16 levelNum, s16 areaIndex, bool informServer);
 void network_receive_sync_valid(struct Packet* p);
 
 // packet_level_spawn_info.c

--- a/src/pc/network/packets/packet_area.c
+++ b/src/pc/network/packets/packet_area.c
@@ -121,7 +121,7 @@ void network_send_area(struct NetworkPlayer* toNp) {
         }
 
         // send sync valid
-        network_send_sync_valid(toNp, gCurrCourseNum, gCurrActStarNum, gCurrLevelNum, gCurrAreaIndex);
+        network_send_sync_valid(toNp, gCurrCourseNum, gCurrActStarNum, gCurrLevelNum, gCurrAreaIndex, false);
     }
     packet_ordered_end();
 

--- a/src/pc/network/packets/packet_change_area.c
+++ b/src/pc/network/packets/packet_change_area.c
@@ -15,7 +15,7 @@ static void player_changed_area(struct NetworkPlayer *np, s16 courseNum, s16 act
     bool inCredits = (np->currActNum == 99);
     if (npLevelAreaMatch == NULL || inCredits) {
         // no NetworkPlayer in the level
-        network_send_sync_valid(np, courseNum, actNum, levelNum, areaIndex);
+        network_send_sync_valid(np, courseNum, actNum, levelNum, areaIndex, false);
         return;
     }
 

--- a/src/pc/network/packets/packet_change_level.c
+++ b/src/pc/network/packets/packet_change_level.c
@@ -17,7 +17,7 @@ static void player_changed_level(struct NetworkPlayer *np, s16 courseNum, s16 ac
     bool inCredits = (np->currActNum == 99);
     if (npAny == NULL || inCredits) {
         // no NetworkPlayer in the level
-        network_send_sync_valid(np, courseNum, actNum, levelNum, areaIndex);
+        network_send_sync_valid(np, courseNum, actNum, levelNum, areaIndex, false);
         return;
     }
 

--- a/src/pc/network/packets/packet_level.c
+++ b/src/pc/network/packets/packet_level.c
@@ -46,7 +46,7 @@ void network_send_level(struct NetworkPlayer* toNp, bool sendArea) {
             network_send_area(toNp);
         } else {
             // send sync valid
-            network_send_sync_valid(toNp, gCurrCourseNum, gCurrActStarNum, gCurrLevelNum, -1);
+            network_send_sync_valid(toNp, gCurrCourseNum, gCurrActStarNum, gCurrLevelNum, -1, false);
         }
     }
     packet_ordered_end();

--- a/src/pc/network/packets/packet_sync_valid.c
+++ b/src/pc/network/packets/packet_sync_valid.c
@@ -75,7 +75,7 @@ void network_receive_sync_valid(struct Packet* p) {
     }
 
     // inform server
-    if (isOurSyncValid && fromGlobalIndex != gNetworkPlayerServer->globalIndex) {
+    if (gNetworkType != NT_SERVER && fromGlobalIndex != gNetworkPlayerServer->globalIndex) {
         LOG_INFO("informing server of sync valid");
         network_send_sync_valid(np, courseNum, actNum, levelNum, areaIndex, true);
     }

--- a/src/pc/network/packets/packet_sync_valid.c
+++ b/src/pc/network/packets/packet_sync_valid.c
@@ -4,7 +4,7 @@
 //#define DISABLE_MODULE_LOG 1
 #include "pc/debuglog.h"
 
-void network_send_sync_valid(struct NetworkPlayer* toNp, s16 courseNum, s16 actNum, s16 levelNum, s16 areaIndex) {
+void network_send_sync_valid(struct NetworkPlayer* toNp, s16 courseNum, s16 actNum, s16 levelNum, s16 areaIndex, bool informServer) {
     bool wasSyncValid = (toNp->currLevelSyncValid && toNp->currAreaSyncValid);
 
     // set the NetworkPlayers sync valid
@@ -24,30 +24,34 @@ void network_send_sync_valid(struct NetworkPlayer* toNp, s16 courseNum, s16 actN
     }
 
     u8 myGlobalIndex = gNetworkPlayerLocal->globalIndex;
+    u8 forGlobalIndex = toNp->globalIndex;
     struct Packet p = { 0 };
     packet_init(&p, PACKET_SYNC_VALID, true, PLMT_NONE);
-    packet_write(&p, &courseNum,     sizeof(s16));
-    packet_write(&p, &actNum,        sizeof(s16));
-    packet_write(&p, &levelNum,      sizeof(s16));
-    packet_write(&p, &areaIndex,     sizeof(s16));
-    packet_write(&p, &myGlobalIndex, sizeof(u8));
-    network_send_to(toNp->localIndex, &p);
+    packet_write(&p, &courseNum,      sizeof(s16));
+    packet_write(&p, &actNum,         sizeof(s16));
+    packet_write(&p, &levelNum,       sizeof(s16));
+    packet_write(&p, &areaIndex,      sizeof(s16));
+    packet_write(&p, &myGlobalIndex,  sizeof(u8));
+    packet_write(&p, &forGlobalIndex, sizeof(u8));
+    network_send_to((informServer ? gNetworkPlayerServer->localIndex : toNp->localIndex), &p);
 
     LOG_INFO("tx sync valid");
 }
 
 void network_receive_sync_valid(struct Packet* p) {
-    LOG_INFO("rx sync valid");
-
     s16 courseNum, actNum, levelNum, areaIndex;
-    u8 fromGlobalIndex;
+    u8 fromGlobalIndex, forGlobalIndex;
     packet_read(p, &courseNum, sizeof(s16));
     packet_read(p, &actNum,    sizeof(s16));
     packet_read(p, &levelNum,  sizeof(s16));
     packet_read(p, &areaIndex, sizeof(s16));
     packet_read(p, &fromGlobalIndex, sizeof(u8));
+    packet_read(p, &forGlobalIndex, sizeof(u8));
+    
+    LOG_INFO("rx sync valid: from global %d, for global %d", fromGlobalIndex, forGlobalIndex);
 
-    if (gNetworkType != NT_SERVER) {
+    bool isOurSyncValid = (forGlobalIndex == gNetworkPlayerLocal->globalIndex);
+    if (isOurSyncValid) {
         extern s16 gCurrCourseNum, gCurrActStarNum, gCurrLevelNum, gCurrAreaIndex;
         if (courseNum != gCurrCourseNum || actNum != gCurrActStarNum || levelNum != gCurrLevelNum || (areaIndex != gCurrAreaIndex && areaIndex != -1)) {
             LOG_ERROR("rx sync valid: received an improper location");
@@ -55,7 +59,7 @@ void network_receive_sync_valid(struct Packet* p) {
         }
     }
 
-    struct NetworkPlayer* np = (gNetworkType != NT_SERVER) ? gNetworkPlayerLocal : &gNetworkPlayers[p->localIndex];
+    struct NetworkPlayer* np = network_player_from_global_index(forGlobalIndex);
     if (np == NULL || np->localIndex == UNKNOWN_LOCAL_INDEX || !np->connected) {
         LOG_ERROR("Receiving sync valid from inactive player!");
         return;
@@ -65,15 +69,15 @@ void network_receive_sync_valid(struct Packet* p) {
     np->currLevelSyncValid = true;
     np->currAreaSyncValid = true;
 
-    if (np == gNetworkPlayerLocal && !wasSyncValid) {
+    if (isOurSyncValid && !wasSyncValid) {
         network_player_update_course_level(np, courseNum, actNum, levelNum, areaIndex);
         smlua_call_event_hooks(HOOK_ON_SYNC_VALID);
     }
 
     // inform server
-    if (gNetworkType != NT_SERVER && fromGlobalIndex != gNetworkPlayerServer->globalIndex) {
+    if (isOurSyncValid && fromGlobalIndex != gNetworkPlayerServer->globalIndex) {
         LOG_INFO("informing server of sync valid");
-        network_send_sync_valid(gNetworkPlayerServer, courseNum, actNum, levelNum, areaIndex);
+        network_send_sync_valid(np, courseNum, actNum, levelNum, areaIndex, true);
     }
 
     // we're no longer syncing

--- a/src/pc/network/packets/packet_sync_valid.c
+++ b/src/pc/network/packets/packet_sync_valid.c
@@ -71,7 +71,7 @@ void network_receive_sync_valid(struct Packet* p) {
     }
 
     // inform server
-    if (fromGlobalIndex != gNetworkPlayerServer->globalIndex) {
+    if (gNetworkType != NT_SERVER && fromGlobalIndex != gNetworkPlayerServer->globalIndex) {
         LOG_INFO("informing server of sync valid");
         network_send_sync_valid(gNetworkPlayerServer, courseNum, actNum, levelNum, areaIndex);
     }


### PR DESCRIPTION
When the server received a sync valid packet from another player, it would also set the host player's level, due to some code that's meant to inform the host also running for the host themselves. While I'm unsure of the exact conditions in which this happens, it can be observed by playing certain mods like MarioHunt or Geoguessr where the issue commonly occurs and viewing debug_info:

```
Fri May 01 13:33:39 2026 [00] [INFO] packet_sync_valid.c: rx sync valid
Fri May 01 13:33:39 2026 [00] [INFO] packet_sync_valid.c: informing server of sync valid
Fri May 01 13:33:39 2026 [00] [INFO] packet_level_area_inform.c: tx level area inform for global 0: (6, 2, 7, 1)
```

The code in question will no longer run for the host, which should fix this issue. I don't think this necessarily fixes the infamous "objects despawning" bug, but at least this fixes another longstanding bug that I've been pulling my hair out over for the past 2 years.