### PR TITLE
fix audio engine crash from reloading banks that are already loaded

### DIFF
--- a/src/audio/heap.c
+++ b/src/audio/heap.c
@@ -228,6 +228,13 @@ void discard_bank(s32 bankId) {
                 note->parentLayer->finished = TRUE;
             }
             note_disable(note);
+
+            // Reset sample state
+            note->sound = NULL;
+            note->samplePosInt = 0;
+            note->samplePosFrac = 0;
+            note->sampleDmaIndex = 0;
+
             audio_list_remove(&note->listItem);
             audio_list_push_back(&gNoteFreeLists.disabled, &note->listItem);
         }

--- a/src/audio/load.c
+++ b/src/audio/load.c
@@ -1595,7 +1595,7 @@ void load_sequence_internal(u32 player, u32 seqId, s32 loadAsync) {
             // Check if the bank is already loaded in the temporary cache
             if (get_bank_or_seq(&gBankLoadedPool, 0, bankId) == NULL) {
                 if (!bank_load_immediate(bankId, 0)) { return; }
-            } else {
+            } else if (gBankLoadStatus[bankId] == SOUND_LOAD_STATUS_DISCARDABLE) {
                 // This bank is still available, so just mark it as loaded again
                 gBankLoadStatus[bankId] = SOUND_LOAD_STATUS_COMPLETE;
             }

--- a/src/audio/load.c
+++ b/src/audio/load.c
@@ -1591,7 +1591,15 @@ void load_sequence_internal(u32 player, u32 seqId, s32 loadAsync) {
         if (smlua_audio_utils_override(seqId, &bankId, &sequenceData)) {
             sequence_player_disable(seqPlayer);
             seqPlayer->defaultBank[0] = bankId;
-            if (!bank_load_immediate(bankId, 0)) { return; }
+
+            // Check if the bank is already loaded in the temporary cache
+            if (get_bank_or_seq(&gBankLoadedPool, 0, bankId) == NULL) {
+                if (!bank_load_immediate(bankId, 0)) { return; }
+            } else {
+                // This bank is still available, so just mark it as loaded again
+                gBankLoadStatus[bankId] = SOUND_LOAD_STATUS_COMPLETE;
+            }
+
             seqPlayer->seqId = seqId;
             gSeqLoadStatus[seqId] = SOUND_LOAD_STATUS_COMPLETE;
             init_sequence_player(player);


### PR DESCRIPTION
When a custom sequence is loaded, the sound bank is loaded into a temporary cache slot, but we weren't checking if the bank was already loaded in the cache, so we attempted to load it again.

Some romhacks use the same sound bank for multiple sequences. When a new sequence played that uses the same bank, the game would repeatedly reload the same bank into the temporary cache slots. This could cause the currently active copy of the bank to be unloaded while notes were still using it, crashes from stale audio pointers.

This fix checks if the bank is already available before loading it, but if it's loaded we just mark the bank as loaded again.
I put the fix in the custom sequence loading block. The fix I added can actually be found in other places in the sm64 sound engine, we just lacked it specifically for custom sequences.
I also included a safety fix to avoid the crash if a situation like this arises again, which resets the pointers that were going stale.

Old screenshot of the crash screen:
<img width="933" height="750" alt="image" src="https://github.com/user-attachments/assets/13eb2127-07b1-4736-9160-d5cdfd9b1684" />

The way I was testing this fix is by using the [sm64 decades later romhack port](https://github.com/Isaac0-dev/decades-later-coop), which loads every custom sequence to the extended sound bank (0x2A).
I triggered the crash by going to the first main level (bobomb valley, overrides BOB) and collecting a star to trigger the star celebration fanfare.