### PR TITLE
Resolve issue with windows compilation due to use of `strcasestr`

### DIFF
--- a/src/pc/djui/djui_panel_dynos.c
+++ b/src/pc/djui/djui_panel_dynos.c
@@ -50,7 +50,7 @@ static void djui_panel_dynos_add_packs(struct DjuiBase* base) {
         // filter results
         if (sSearchInputbox != NULL &&
             sSearchInputbox->buffer != NULL &&
-            !strcasestr(djui_text_get_uncolored_string(NULL, strlen(pack) + 1, pack), sSearchInputbox->buffer)
+            !strstr_lowercased(djui_text_get_uncolored_string(NULL, strlen(pack) + 1, pack), sSearchInputbox->buffer)
         ) {
             continue;
         }

--- a/src/pc/djui/djui_panel_dynos.c
+++ b/src/pc/djui/djui_panel_dynos.c
@@ -50,7 +50,7 @@ static void djui_panel_dynos_add_packs(struct DjuiBase* base) {
         // filter results
         if (sSearchInputbox != NULL &&
             sSearchInputbox->buffer != NULL &&
-            !strstr_lowercased(djui_text_get_uncolored_string(NULL, strlen(pack) + 1, pack), sSearchInputbox->buffer)
+            !sys_strcasecmp(djui_text_get_uncolored_string(NULL, strlen(pack) + 1, pack), sSearchInputbox->buffer)
         ) {
             continue;
         }

--- a/src/pc/djui/djui_panel_dynos.c
+++ b/src/pc/djui/djui_panel_dynos.c
@@ -50,7 +50,7 @@ static void djui_panel_dynos_add_packs(struct DjuiBase* base) {
         // filter results
         if (sSearchInputbox != NULL &&
             sSearchInputbox->buffer != NULL &&
-            !sys_strcasecmp(djui_text_get_uncolored_string(NULL, strlen(pack) + 1, pack), sSearchInputbox->buffer)
+            !strstr_lowercased(djui_text_get_uncolored_string(NULL, strlen(pack) + 1, pack), sSearchInputbox->buffer)
         ) {
             continue;
         }

--- a/src/pc/djui/djui_panel_host_mods.c
+++ b/src/pc/djui/djui_panel_host_mods.c
@@ -143,7 +143,7 @@ void djui_panel_host_mods_add_mods(struct DjuiBase* layoutBase) {
         if (category != NULL) {
             category = !strcmp(category, "cs") ? "character" : category;
         }
-        
+
         switch (sSelectedCategory) {
             case MOD_CATEGORY_ALL: { break; }
             case MOD_CATEGORY_MISC: {
@@ -169,7 +169,7 @@ void djui_panel_host_mods_add_mods(struct DjuiBase* layoutBase) {
         // filter results
         if (sSearchInputbox != NULL &&
             sSearchInputbox->buffer != NULL &&
-            !strcasestr(djui_text_get_uncolored_string(NULL, strlen(mod->name) + 1, mod->name), sSearchInputbox->buffer)
+            !strstr_lowercased(djui_text_get_uncolored_string(NULL, strlen(mod->name) + 1, mod->name), sSearchInputbox->buffer)
         ) {
             continue;
         }

--- a/src/pc/djui/djui_panel_host_mods.c
+++ b/src/pc/djui/djui_panel_host_mods.c
@@ -169,7 +169,7 @@ void djui_panel_host_mods_add_mods(struct DjuiBase* layoutBase) {
         // filter results
         if (sSearchInputbox != NULL &&
             sSearchInputbox->buffer != NULL &&
-            !sys_strcasecmp(djui_text_get_uncolored_string(NULL, strlen(mod->name) + 1, mod->name), sSearchInputbox->buffer)
+            !strstr_lowercased(djui_text_get_uncolored_string(NULL, strlen(mod->name) + 1, mod->name), sSearchInputbox->buffer)
         ) {
             continue;
         }

--- a/src/pc/djui/djui_panel_host_mods.c
+++ b/src/pc/djui/djui_panel_host_mods.c
@@ -169,7 +169,7 @@ void djui_panel_host_mods_add_mods(struct DjuiBase* layoutBase) {
         // filter results
         if (sSearchInputbox != NULL &&
             sSearchInputbox->buffer != NULL &&
-            !strstr_lowercased(djui_text_get_uncolored_string(NULL, strlen(mod->name) + 1, mod->name), sSearchInputbox->buffer)
+            !sys_strcasecmp(djui_text_get_uncolored_string(NULL, strlen(mod->name) + 1, mod->name), sSearchInputbox->buffer)
         ) {
             continue;
         }

--- a/src/pc/utils/misc.c
+++ b/src/pc/utils/misc.c
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 #include <time.h>
 #include <float.h>
+#include <ctype.h>
 
 #include "misc.h"
 
@@ -600,6 +601,31 @@ void str_seperator_concat(char *output_buffer, int buffer_size, char** strings, 
             buffer_index += seperator_length;
         }
     }
+}
+
+const char *strstr_lowercased(const char *haystack, const char *needle) {
+    // sanity check
+    if (!*needle) {
+        return haystack;
+    }
+
+    while (*haystack) {
+        const char *h = haystack;
+        const char *n = needle;
+
+        while (*h && *n && tolower((unsigned char)*h) == tolower((unsigned char)*n)) {
+            ++h;
+            ++n;
+        }
+
+        if (!*n) {
+            return haystack;
+        }
+
+        ++haystack;
+    }
+
+    return NULL;
 }
 
 static char *get_update_path(void) {

--- a/src/pc/utils/misc.c
+++ b/src/pc/utils/misc.c
@@ -602,31 +602,6 @@ void str_seperator_concat(char *output_buffer, int buffer_size, char** strings, 
     }
 }
 
-const char *strstr_lowercased(const char *haystack, const char *needle) {
-    // sanity check
-    if (!*needle) {
-        return haystack;
-    }
-
-    while (*haystack) {
-        const char *h = haystack;
-        const char *n = needle;
-
-        while (*h && *n && tolower((unsigned char)*h) == tolower((unsigned char)*n)) {
-            ++h;
-            ++n;
-        }
-
-        if (!*n) {
-            return haystack;
-        }
-
-        ++haystack;
-    }
-
-    return NULL;
-}
-
 static char *get_update_path(void) {
 #ifdef _WIN32
     char updateExecFilename[] = "coopdx_updater.exe";

--- a/src/pc/utils/misc.c
+++ b/src/pc/utils/misc.c
@@ -602,6 +602,31 @@ void str_seperator_concat(char *output_buffer, int buffer_size, char** strings, 
     }
 }
 
+const char *strstr_lowercased(const char *haystack, const char *needle) {
+    // sanity check
+    if (!*needle) {
+        return haystack;
+    }
+
+    while (*haystack) {
+        const char *h = haystack;
+        const char *n = needle;
+
+        while (*h && *n && tolower((unsigned char)*h) == tolower((unsigned char)*n)) {
+            ++h;
+            ++n;
+        }
+
+        if (!*n) {
+            return haystack;
+        }
+
+        ++haystack;
+    }
+
+    return NULL;
+}
+
 static char *get_update_path(void) {
 #ifdef _WIN32
     char updateExecFilename[] = "coopdx_updater.exe";

--- a/src/pc/utils/misc.h
+++ b/src/pc/utils/misc.h
@@ -37,6 +37,7 @@ void delta_interpolate_mtx(Mtx* out, Mtx* a, Mtx* b, f32 delta);
 void detect_and_skip_mtx_interpolation(Mtx** mtxPrev, Mtx** mtx);
 
 void str_seperator_concat(char *output_buffer, int buffer_size, char** strings, int num_strings, char* seperator);
+const char *strstr_lowercased(const char *haystack, const char *needle);
 
 bool can_update_game(void);
 void update_game(void);

--- a/src/pc/utils/misc.h
+++ b/src/pc/utils/misc.h
@@ -37,7 +37,6 @@ void delta_interpolate_mtx(Mtx* out, Mtx* a, Mtx* b, f32 delta);
 void detect_and_skip_mtx_interpolation(Mtx** mtxPrev, Mtx** mtx);
 
 void str_seperator_concat(char *output_buffer, int buffer_size, char** strings, int num_strings, char* seperator);
-const char *strstr_lowercased(const char *haystack, const char *needle);
 
 bool can_update_game(void);
 void update_game(void);


### PR DESCRIPTION
Fixes issue introduced by https://github.com/coop-deluxe/sm64coopdx/commit/bb142d5769a2b24e8b3b2db0b5edb3c240992fbe because someone didn't check the C standard to verify it was ok to use (it was me).

`strcasestr` is not apart of the C standard and is a GNU extension. Windows does not play well with this. The solution was to define a quite simple custom function partially based on the glibc implementation. Function should be reviewed.