### PR TITLE
Ns_socket_get_id generates always empty string on linux

### DIFF
--- a/src/pc/network/socket/socket.c
+++ b/src/pc/network/socket/socket.c
@@ -201,7 +201,7 @@ static s64 ns_socket_get_id(UNUSED u8 localId) {
 static char* ns_socket_get_id_str(u8 localId) {
     if (localId == UNKNOWN_LOCAL_INDEX) { localId = 0; }
     static char id_str[INET6_ADDRSTRLEN] = { 0 };
-    snprintf(id_str, INET6_ADDRSTRLEN, "%s", inet_ntop(AF_INET6, &sAddr[localId].sin6_addr, id_str, sizeof(id_str)));
+    inet_ntop(AF_INET6, &sAddr[localId].sin6_addr, id_str, sizeof(id_str));
     return id_str;
 }
 


### PR DESCRIPTION
This pr fixes an issue on linux where the function ns_socket_get_id_str always returns empty string.
See glibc implementation of vsnprintf : [vsnprintf implementation](https://elixir.bootlin.com/glibc/glibc-2.36/source/libio/vsnprintf.c#L112). First string parameter is "emptied" before starting the copy.

And I suspect the original snprintf to rewrite twice the same value in id_str (except if I missed something) so we can just remove it.

This issue gives moderator access to all players when they connect/reconnect after adding one player as moderator because all players have the same id : "".

How to reproduce : 
Host server (via socket, not coopnet) on sm64coopdx linux version
Add moderator to one player
All new connected or reconnected player are promoted to moderator
 
