### PR TITLE
fix frame pacing code

### DIFF
--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -281,6 +281,7 @@ void produce_interpolation_frames_and_delay(void) {
     // make sure to draw at least one frame to prevent the game from freezing completely
     // (including inputs and window events) if the game update duration is greater than 33ms
     do {
+        curTime = clock_elapsed_f64();
         ++framesDrawn;
 
         // when we know how many frames to draw, use a precise delta
@@ -293,6 +294,7 @@ void produce_interpolation_frames_and_delay(void) {
         if (!gSkipInterpolationTitleScreen) { patch_interpolations(delta); }
         send_display_list(gGfxSPTask);
         gfx_end_frame_render();
+        gfx_display_frame();
 
         // delay if our framerate is capped
         if (shouldDelay) {
@@ -305,8 +307,6 @@ void produce_interpolation_frames_and_delay(void) {
             }
         }
 
-        // send the frame to the screen (should be directly after the delay for good frame pacing)
-        gfx_display_frame();
         sDrawnFrames++;
         if (shouldDelay) { numFramesToDraw--; }
     } while ((curTime = clock_elapsed_f64()) < targetTime && numFramesToDraw > 0);


### PR DESCRIPTION
I've made a lot of changes to the frame pacing code in the past, but I still experience poor frame pacing on my computer: https://github.com/coop-deluxe/sm64coopdx/issues/933.
But now I understand why. By using a tool called Tracy profiler (https://github.com/wolfpld/tracy), I was able to understand where the issues actually lie in the frame pacing.
Previously, I assumed we should swap buffers immediately after delaying, because how can we expect the timing to be right after delaying if the sm64 update loop is called every other frame, causing inconsistent timing? 
This PR takes the industry standard approach, where the buffers are swapped before delaying, so that the GPU has as much time as possible to display the frame. 

Of course, when I initially changed this code some time ago, I did it for a reason - lagging!
But I now know that this is not the frame pacing code (as of this PR), it is the code responsible for interpreting the display lists.

Even with this PR code enabled, I was able to trigger frame drops just by moving around in the game with power saving mode enabled on my laptop to reduce system performance. Here's a screenshot of Tracy, focused on one of those frame drops. You can see that the `send_display_list` call took 35ms alone in the first `produce_one_frame` call. That's way too much, the frame pacing code can't save us from that situation!
<img width="1920" height="245" alt="Screenshot From 2026-05-20 01-40-30" src="https://github.com/user-attachments/assets/97a06bae-6cb7-42bd-96b2-85c1c2411e63" />

So I'm opening this PR because I believe it's the right fix for the frame pacing, but we'll need to look into optimising the display list interpreter if we want to fix these further frame drops. For now, this patch fixes the frame pacing code.