### PR TITLE
fix sub pixel gaps on 2D visuals due to MSAA

### DIFF
--- a/src/pc/gfx/gfx_pc.c
+++ b/src/pc/gfx/gfx_pc.c
@@ -722,7 +722,7 @@ static float gfx_adjust_x_for_aspect_ratio(float x) {
 
     // Force 2D coordinates to be aligned perfectly on the nearest pixel
     // This prevents MSAA sub-pixel gaps (e.g. on vanilla dialog boxes)
-    if (rsp.P_matrix[3][3] > 0.5f) {
+    if (rsp.P_matrix[3][3] > 0.5f && rdp.viewport.width > 0.0f) {
         float pixelX = rdp.viewport.x + (adjusted + 1.0f) * 0.5f * rdp.viewport.width;
         pixelX = floorf(pixelX + 0.5f);
         adjusted = ((pixelX - rdp.viewport.x) / rdp.viewport.width) * 2.0f - 1.0f;

--- a/src/pc/gfx/gfx_pc.c
+++ b/src/pc/gfx/gfx_pc.c
@@ -133,7 +133,7 @@ int gShaderFlags[SHADER_FLAG_MAX] = { 0 };
 f32 gDefaultShaderFlagValues[SHADER_FLAG_MAX] = {
     [SHADER_FLAG_HUE] = 0.0f,
     [SHADER_FLAG_SATURATION] = 1.0f,
-    [SHADER_FLAG_BRIGHTNESS] = 1.0f, 
+    [SHADER_FLAG_BRIGHTNESS] = 1.0f,
     [SHADER_FLAG_CONTRAST] = 1.0f,
     [SHADER_FLAG_EXPOSURE] = 1.0f,
     [SHADER_FLAG_DITHERING] = 0.0f,
@@ -718,7 +718,17 @@ static void gfx_sp_pop_matrix(uint32_t count) {
 }
 
 static float gfx_adjust_x_for_aspect_ratio(float x) {
-    return x * gfx_current_dimensions.x_adjust_ratio;
+    float adjusted = x * gfx_current_dimensions.x_adjust_ratio;
+
+    // Force 2D coordinates to be aligned perfectly on the nearest pixel
+    // This prevents MSAA sub-pixel gaps (e.g. on vanilla dialog boxes)
+    if (rsp.P_matrix[3][3] > 0.5f) {
+        float pixelX = rdp.viewport.x + (adjusted + 1.0f) * 0.5f * rdp.viewport.width;
+        pixelX = floorf(pixelX + 0.5f);
+        adjusted = ((pixelX - rdp.viewport.x) / rdp.viewport.width) * 2.0f - 1.0f;
+    }
+
+    return adjusted;
 }
 
 static OPTIMIZE_O3 void gfx_local_to_world_space(VEC_OUT Vec3f pos, VEC_OUT Vec3f normal) {


### PR DESCRIPTION
There's an issue with the sm64 dialog boxes in coop if you use MSAA. You can see vertical lines 1 pixel in width (n64 resolution) around the characters in the dialog box. These pixels flicker in and out as you resize the window. Previous sm64 ports never had this issue.
Here's a comparison of sm64ex versus coop with MSAA 2x enabled (without this PR). 

sm64ex:

https://github.com/user-attachments/assets/12fcba82-ec2e-4dc8-a361-667ea864e7b9

sm64coopdx with MSAA 2x:

https://github.com/user-attachments/assets/63815c02-ef75-440a-9b63-b011f56d1d97


This bug is caused by MSAA (disabling it has no issue). Older sm64 ports didn't have MSAA options, so this wasn't a problem.
Here's why I believe this happens:

sm64 renders each dialog character as individual tiles with entirely separate draw calls.
sm64 US specifically renders each character as a 3D mesh (unlike sm64 EU for example which uses `SPTextureRectangle`, it will not have this bug), as seen in `dl_ia_text_tex_settings`. 
In the gfx interpreter, we're adjusting the X position of on screen elements to allow for widescreen. This means the vertex positions of the dialog characters are floating point, and in widescreen this causes them to be fractional, even though they represent physical pixel coordinates.
Since each character is rendered separately with semi-transparency (`G_RM_XLU_SURF`), 	the GPU lets 2 neighbour tiles to have a fractional sub pixel gap between the two tiles. 
Without MSAA, everything is snapped to the pixel grid.

To fix the issue, I've added a path to snap 2D coordinates to the pixel grid.
3D is not impacted by this fix. I've put a check if it's a being drawn in the 2D orthographic mode. 