### PR TITLE
Fix camera language and allow shot from cannon switch

### DIFF
--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -3195,8 +3195,9 @@ void update_camera(struct Camera *c) {
 
     u8 isEnabled = update_romhack_camera_override(c);
     if (gRomhackCameraSettings.switchable && isEnabled && sCurrPlayMode != PLAY_MODE_PAUSED) {
-        u8 inValidActions = ((gMarioStates[0].action & ACT_GROUP_MASK) == ACT_GROUP_SUBMERGED) ||
-                            (gMarioStates[0].action == ACT_FLYING);
+        struct MarioState* m = &gMarioStates[0];
+        u8 inValidActions = ((m->action & ACT_GROUP_MASK) == ACT_GROUP_SUBMERGED) ||
+                            (m->action == ACT_FLYING) || (m->action == ACT_SHOT_FROM_CANNON);
         if (inValidActions && gMarioStates[0].controller->buttonPressed & L_TRIG) {
             sForceRomhackCamera = c->mode != CAMERA_MODE_ROM_HACK;
             set_camera_mode(c, sForceRomhackCamera ? CAMERA_MODE_ROM_HACK : CAMERA_MODE_BEHIND_MARIO, 0);

--- a/src/game/camera.c
+++ b/src/game/camera.c
@@ -3198,7 +3198,7 @@ void update_camera(struct Camera *c) {
         struct MarioState* m = &gMarioStates[0];
         u8 inValidActions = ((m->action & ACT_GROUP_MASK) == ACT_GROUP_SUBMERGED) ||
                             (m->action == ACT_FLYING) || (m->action == ACT_SHOT_FROM_CANNON);
-        if (inValidActions && gMarioStates[0].controller->buttonPressed & L_TRIG) {
+        if (inValidActions && m->controller->buttonPressed & L_TRIG) {
             sForceRomhackCamera = c->mode != CAMERA_MODE_ROM_HACK;
             set_camera_mode(c, sForceRomhackCamera ? CAMERA_MODE_ROM_HACK : CAMERA_MODE_BEHIND_MARIO, 0);
         }

--- a/src/pc/djui/djui_panel_camera.c
+++ b/src/pc/djui/djui_panel_camera.c
@@ -21,7 +21,7 @@ void djui_panel_free_camera_create(struct DjuiBase* caller) {
     {
         djui_checkbox_create(body, DLANG(CAMERA, FREE_CAMERA), &configEnableFreeCamera, djui_panel_free_camera_value_changed);
         djui_checkbox_create(body, DLANG(CAMERA, ANALOG_CAMERA), &configFreeCameraAnalog, djui_panel_free_camera_value_changed);
-        djui_checkbox_create(body, DLANG(CAMERA, ROMHACK_CAMERA_SWITCHABLE), &configFreeCameraLCentering, djui_panel_free_camera_value_changed);
+        djui_checkbox_create(body, DLANG(CAMERA, FREE_CAMERA_L_CENTERING), &configFreeCameraLCentering, djui_panel_free_camera_value_changed);
         djui_checkbox_create(body, DLANG(CAMERA, FREE_CAMERA_USE_DPAD), &configFreeCameraDPadBehavior, djui_panel_free_camera_value_changed);
         djui_checkbox_create(body, DLANG(CAMERA, FREE_CAMERA_COLLISION), &configFreeCameraHasCollision, djui_panel_free_camera_value_changed);
         djui_checkbox_create(body, DLANG(CAMERA, MOUSE_LOOK), &configFreeCameraMouse, djui_panel_free_camera_value_changed);


### PR DESCRIPTION
When I originally made the romhack camera PR, it appears I have accidentally used the wrong language variable for the free camera L centering option. This now fixes that.

This PR fixes another oversight where I forgot that cannons can be used to start flying. It would be disorienting if the camera suddenly switched to romhack camera from flying after shooting out of a cannon, so this deals with that by allowing the switch to happen during cannon shot as well.