### PR TITLE
fix custom level data memory leak

### DIFF
--- a/data/dynos.c.h
+++ b/data/dynos.c.h
@@ -68,6 +68,7 @@ u64 dynos_level_cmd_get(void *cmd, u64 offset);
 void dynos_level_cmd_next(void *cmd);
 void dynos_level_parse_script(const void *script, s32 (*aPreprocessFunction)(u8, void *));
 void* dynos_level_get_script(s32 level);
+const void *dynos_level_get_vanilla_script(s32 level);
 s32 dynos_level_get_mod_index(s32 level);
 bool dynos_level_is_vanilla_level(s32 level);
 Collision *dynos_level_get_collision(u32 level, u16 area);

--- a/data/dynos.cpp.h
+++ b/data/dynos.cpp.h
@@ -788,6 +788,7 @@ void DynOS_UpdateGfx();
 bool DynOS_IsTransitionActive();
 void DynOS_Mod_Update();
 void DynOS_Mod_Shutdown();
+bool DynOS_Mod_IsShuttingDown();
 
 //
 // Gfx
@@ -819,6 +820,7 @@ s8 DynOS_Level_GetCourse(s32 aLevel);
 void DynOS_Level_Override(void* originalScript, void* newScript, s32 modIndex);
 void DynOS_Level_Unoverride();
 const void *DynOS_Level_GetScript(s32 aLevel);
+const void *DynOS_Level_GetVanillaScript(s32 aLevel);
 s32 DynOS_Level_GetModIndex(s32 aLevel);
 bool DynOS_Level_IsVanillaLevel(s32 aLevel);
 Collision *DynOS_Level_GetCollision(u32 aLevel, u16 aArea);

--- a/data/dynos_c.cpp
+++ b/data/dynos_c.cpp
@@ -228,6 +228,10 @@ void* dynos_level_get_script(s32 level) {
     return (void *) DynOS_Level_GetScript(level);
 }
 
+const void *dynos_level_get_vanilla_script(s32 level) {
+    return DynOS_Level_GetVanillaScript(level);
+}
+
 s32 dynos_level_get_mod_index(s32 level) {
     return DynOS_Level_GetModIndex(level);
 }

--- a/data/dynos_level.cpp
+++ b/data/dynos_level.cpp
@@ -21,7 +21,7 @@ extern const BehaviorScript *sWarpBhvSpawnTable[];
 
 #define DYNOS_LEVEL_MARIO_POS_WARP_ID (-1)
 
-extern void *gDynosLevelScriptsOriginal[LEVEL_COUNT];
+extern const void *gDynosLevelScriptsOriginal[LEVEL_COUNT];
 
 void DynOS_Level_ParseScript(const void *aScript, s32 (*aPreprocessFunction)(u8, void *));
 
@@ -158,7 +158,7 @@ void DynOS_Level_Init() {
 
         // Level warps
         for (sDynosCurrentLevelNum = 0; sDynosCurrentLevelNum < LEVEL_COUNT; ++sDynosCurrentLevelNum) {
-            sDynosLevelScripts[sDynosCurrentLevelNum].mLevelScript = gDynosLevelScriptsOriginal[sDynosCurrentLevelNum];
+            sDynosLevelScripts[sDynosCurrentLevelNum].mLevelScript = (void *) gDynosLevelScriptsOriginal[sDynosCurrentLevelNum];
             sDynosLevelScripts[sDynosCurrentLevelNum].mModIndex = DYNOS_LEVEL_MOD_INDEX_VANILLA;
             if (sDynosLevelScripts[sDynosCurrentLevelNum].mLevelScript) {
                 DynOS_Level_ParseScript(sDynosLevelScripts[sDynosCurrentLevelNum].mLevelScript, DynOS_Level_PreprocessScript);
@@ -199,7 +199,7 @@ void DynOS_Level_Unoverride() {
     for (s32 i = 0; i < LEVEL_COUNT; i++) {
         sDynosCurrentLevelNum = i;
         sDynosLevelWarps[i].Clear();
-        sDynosLevelScripts[i].mLevelScript = gDynosLevelScriptsOriginal[i];
+        sDynosLevelScripts[i].mLevelScript = (void *) gDynosLevelScriptsOriginal[i];
         sDynosLevelScripts[i].mModIndex = DYNOS_LEVEL_MOD_INDEX_VANILLA;
         DynOS_Level_ParseScript(sDynosLevelScripts[i].mLevelScript, DynOS_Level_PreprocessScript);
     }
@@ -214,6 +214,10 @@ const void *DynOS_Level_GetScript(s32 aLevel) {
 
     DynOS_Level_Init();
     return sDynosLevelScripts[aLevel].mLevelScript;
+}
+
+const void *DynOS_Level_GetVanillaScript(s32 aLevel) {
+    return (const void *) gDynosLevelScriptsOriginal[aLevel];
 }
 
 s32 DynOS_Level_GetModIndex(s32 aLevel) {
@@ -231,7 +235,7 @@ bool DynOS_Level_IsVanillaLevel(s32 aLevel) {
     DynOS_Level_Init();
 
     if (aLevel >= LEVEL_MIN && aLevel < LEVEL_COUNT) {
-        return sDynosLevelScripts[aLevel].mLevelScript == gDynosLevelScriptsOriginal[aLevel];
+        return sDynosLevelScripts[aLevel].mLevelScript == (void *) gDynosLevelScriptsOriginal[aLevel];
     }
     return false;
 }

--- a/data/dynos_level.cpp
+++ b/data/dynos_level.cpp
@@ -217,6 +217,9 @@ const void *DynOS_Level_GetScript(s32 aLevel) {
 }
 
 const void *DynOS_Level_GetVanillaScript(s32 aLevel) {
+    if (aLevel < LEVEL_MIN || aLevel >= LEVEL_COUNT) {
+        return NULL;
+    }
     return (const void *) gDynosLevelScriptsOriginal[aLevel];
 }
 

--- a/data/dynos_main.cpp
+++ b/data/dynos_main.cpp
@@ -36,9 +36,7 @@ bool DynOS_IsTransitionActive() {
 //
 static bool sDynosModShutdown = false;
 
-void DynOS_Lvl_FreeScheduledLvlData();
 void DynOS_Mod_Update() {
-    DynOS_Lvl_FreeScheduledLvlData();
     if (sDynosModShutdown) {
         sDynosModShutdown = false;
         DynOS_Actor_ModShutdown();
@@ -53,4 +51,8 @@ void DynOS_Mod_Update() {
 
 void DynOS_Mod_Shutdown() {
     sDynosModShutdown = true;
+}
+
+bool DynOS_Mod_IsShuttingDown() {
+    return sDynosModShutdown;
 }

--- a/data/dynos_main.cpp
+++ b/data/dynos_main.cpp
@@ -36,7 +36,9 @@ bool DynOS_IsTransitionActive() {
 //
 static bool sDynosModShutdown = false;
 
+void DynOS_Lvl_FreeScheduledLvlData();
 void DynOS_Mod_Update() {
+    DynOS_Lvl_FreeScheduledLvlData();
     if (sDynosModShutdown) {
         sDynosModShutdown = false;
         DynOS_Actor_ModShutdown();

--- a/data/dynos_mgr_bhv.cpp
+++ b/data/dynos_mgr_bhv.cpp
@@ -36,7 +36,7 @@ void DynOS_Bhv_Activate(s32 modIndex, const SysPath &aFilename, const char *aBeh
 void DynOS_Bhv_ModShutdown() {
     auto &_CustomBehaviorScripts = DynOS_Bhv_GetArray();
     for (auto &pair : _CustomBehaviorScripts) {
-        Delete(pair.second);
+        DynOS_Gfx_Free(pair.second);
     }
     _CustomBehaviorScripts.clear();
 }

--- a/data/dynos_mgr_builtin.cpp
+++ b/data/dynos_mgr_builtin.cpp
@@ -185,9 +185,10 @@ static const void* sDynosBuiltinScriptPtrs[] = {
 };
 
 const void *gDynosLevelScriptsOriginal[] = {
-#define STUB_LEVEL(_0, _1, _2, _3, _4, _5, _6, _7, _8) NULL,
-#define DEFINE_LEVEL(_0, _1, _2, folder, _4, _5, _6, _7, _8, _9, _10) \
-    level_ ## folder ## _entry,
+    [LEVEL_NONE] = NULL,
+#define STUB_LEVEL(_0, levelNum, _2, _3, _4, _5, _6, _7, _8) [levelNum] = NULL,
+#define DEFINE_LEVEL(_0, levelNum, _2, folder, _4, _5, _6, _7, _8, _9, _10) \
+    [levelNum] = level_ ## folder ## _entry,
 #include "levels/level_defines.h"
 #undef STUB_LEVEL
 #undef DEFINE_LEVEL

--- a/data/dynos_mgr_builtin.cpp
+++ b/data/dynos_mgr_builtin.cpp
@@ -184,46 +184,13 @@ static const void* sDynosBuiltinScriptPtrs[] = {
     define_builtin(level_main_menu_entry_1),
 };
 
-#define define_level_original(lvl, script) (void*) script
-
-void* gDynosLevelScriptsOriginal[LEVEL_COUNT] = {
-    define_level_original(0, NULL),
-    define_level_original(LEVEL_UNKNOWN_1, NULL),
-    define_level_original(LEVEL_UNKNOWN_2, NULL),
-    define_level_original(LEVEL_UNKNOWN_3, NULL),
-    define_level_original(LEVEL_BBH, level_bbh_entry),
-    define_level_original(LEVEL_CCM, level_ccm_entry),
-    define_level_original(LEVEL_CASTLE, level_castle_inside_entry),
-    define_level_original(LEVEL_HMC, level_hmc_entry),
-    define_level_original(LEVEL_SSL, level_ssl_entry),
-    define_level_original(LEVEL_BOB, level_bob_entry),
-    define_level_original(LEVEL_SL, level_sl_entry),
-    define_level_original(LEVEL_WDW, level_wdw_entry),
-    define_level_original(LEVEL_JRB, level_jrb_entry),
-    define_level_original(LEVEL_THI, level_thi_entry),
-    define_level_original(LEVEL_TTC, level_ttc_entry),
-    define_level_original(LEVEL_RR, level_rr_entry),
-    define_level_original(LEVEL_CASTLE_GROUNDS, level_castle_grounds_entry),
-    define_level_original(LEVEL_BITDW, level_bitdw_entry),
-    define_level_original(LEVEL_VCUTM, level_vcutm_entry),
-    define_level_original(LEVEL_BITFS, level_bitfs_entry),
-    define_level_original(LEVEL_SA, level_sa_entry),
-    define_level_original(LEVEL_BITS, level_bits_entry),
-    define_level_original(LEVEL_LLL, level_lll_entry),
-    define_level_original(LEVEL_DDD, level_ddd_entry),
-    define_level_original(LEVEL_WF, level_wf_entry),
-    define_level_original(LEVEL_ENDING, level_ending_entry),
-    define_level_original(LEVEL_CASTLE_COURTYARD, level_castle_courtyard_entry),
-    define_level_original(LEVEL_PSS, level_pss_entry),
-    define_level_original(LEVEL_COTMC, level_cotmc_entry),
-    define_level_original(LEVEL_TOTWC, level_totwc_entry),
-    define_level_original(LEVEL_BOWSER_1, level_bowser_1_entry),
-    define_level_original(LEVEL_WMOTR, level_wmotr_entry),
-    define_level_original(LEVEL_UNKNOWN_32, NULL),
-    define_level_original(LEVEL_BOWSER_2, level_bowser_2_entry),
-    define_level_original(LEVEL_BOWSER_3, level_bowser_3_entry),
-    define_level_original(LEVEL_UNKNOWN_35, NULL),
-    define_level_original(LEVEL_TTM, level_ttm_entry),
+const void *gDynosLevelScriptsOriginal[] = {
+#define STUB_LEVEL(_0, _1, _2, _3, _4, _5, _6, _7, _8) NULL,
+#define DEFINE_LEVEL(_0, _1, _2, folder, _4, _5, _6, _7, _8, _9, _10) \
+    level_ ## folder ## _entry,
+#include "levels/level_defines.h"
+#undef STUB_LEVEL
+#undef DEFINE_LEVEL
 };
 
 const void* DynOS_Builtin_ScriptPtr_GetFromName(const char* aDataName) {

--- a/data/dynos_mgr_gfx.cpp
+++ b/data/dynos_mgr_gfx.cpp
@@ -350,7 +350,7 @@ void DynOS_Gfx_ModShutdown() {
     sModsDisplayLists.Clear();
     sModsVertexBuffers.Clear();
 
-    // Restore vanilla display lists
+    // Restore vanilla display lists and vertices
     for (auto &it : sRomToRamGfxVtxMap) {
         const void *original = it.second.gfxCopy ? it.second.gfxCopy : it.first;
         void *duplicate = it.second.duplicate;

--- a/data/dynos_mgr_lvl.cpp
+++ b/data/dynos_mgr_lvl.cpp
@@ -21,11 +21,6 @@ std::vector<std::pair<std::string, GfxData *>> &DynOS_Lvl_GetArray() {
     return sDynosCustomLevelScripts;
 }
 
-std::vector<GfxData *> &DynOS_Lvl_GetScheduledInvalidLevels() {
-    static std::vector<GfxData *> sDynosScheduledInvalidLevels;
-    return sDynosScheduledInvalidLevels;
-}
-
 LevelScript* DynOS_Lvl_GetScript(const char* aScriptEntryName) {
     auto& _CustomLevelScripts = DynOS_Lvl_GetArray();
     for (size_t i = 0; i < _CustomLevelScripts.size(); ++i) {
@@ -39,14 +34,6 @@ LevelScript* DynOS_Lvl_GetScript(const char* aScriptEntryName) {
     return NULL;
 }
 
-void DynOS_Lvl_FreeScheduledLvlData() {
-    auto& _ScheduledInvalidLevels = DynOS_Lvl_GetScheduledInvalidLevels();
-    for (auto& gfxData : _ScheduledInvalidLevels) {
-        DynOS_Gfx_Free(gfxData);
-    }
-    _ScheduledInvalidLevels.clear();
-}
-
 void DynOS_Lvl_ModShutdown() {
     DynOS_Level_Unoverride();
 
@@ -54,11 +41,7 @@ void DynOS_Lvl_ModShutdown() {
     if (!_CustomLevelScripts.empty()) {
         for (auto& pair : _CustomLevelScripts) {
             DynOS_Tex_Invalid(pair.second);
-
-            // we need to free all level data after the level script is
-            // no longer in circulation, as the level script VM
-            // may be processing commands in the level script still
-            DynOS_Lvl_GetScheduledInvalidLevels().push_back(pair.second);
+            DynOS_Gfx_Free(pair.second);
         }
         _CustomLevelScripts.clear();
     }
@@ -190,6 +173,10 @@ double_break:
 }
 
 void *DynOS_Lvl_Override(void *aCmd) {
+    if (DynOS_Mod_IsShuttingDown()) {
+        return aCmd;
+    }
+
     auto& _OverrideLevelScripts = DynosOverrideLevelScripts();
     for (auto& overrideStruct : _OverrideLevelScripts) {
         if (aCmd == overrideStruct.originalScript || aCmd == overrideStruct.newScript) {

--- a/data/dynos_mgr_lvl.cpp
+++ b/data/dynos_mgr_lvl.cpp
@@ -1,7 +1,9 @@
 #include "dynos.cpp.h"
 
 extern "C" {
+#include "include/level_table.h"
 #include "engine/level_script.h"
+#include "game/level_update.h"
 #include "game/skybox.h"
 }
 
@@ -173,16 +175,17 @@ double_break:
 }
 
 void *DynOS_Lvl_Override(void *aCmd) {
-    if (DynOS_Mod_IsShuttingDown()) {
-        return aCmd;
-    }
+    static bool sLevelIsVanilla = true;
 
     auto& _OverrideLevelScripts = DynosOverrideLevelScripts();
     for (auto& overrideStruct : _OverrideLevelScripts) {
         if (aCmd == overrideStruct.originalScript || aCmd == overrideStruct.newScript) {
-            aCmd = (void*)overrideStruct.newScript;
+            if (!DynOS_Mod_IsShuttingDown()) {
+                aCmd = (void*)overrideStruct.newScript;
+            }
             gLevelScriptModIndex = overrideStruct.gfxData->mModIndex;
             gLevelScriptActive = (LevelScript*)aCmd;
+            sLevelIsVanilla = false;
         }
     }
 
@@ -193,8 +196,24 @@ void *DynOS_Lvl_Override(void *aCmd) {
             if (aCmd == s->mData) {
                 gLevelScriptModIndex = script.second->mModIndex;
                 gLevelScriptActive = (LevelScript*)aCmd;
+                sLevelIsVanilla = false;
             }
         }
+    }
+
+    for (u16 i = 0; i < LEVEL_COUNT; ++i) {
+        const void *vanillaScript = DynOS_Level_GetVanillaScript(i);
+        if (vanillaScript == aCmd) {
+            gLevelScriptModIndex = -1;
+            gLevelScriptActive = (LevelScript*)aCmd;
+            sLevelIsVanilla = true;
+            break;
+        }
+    }
+
+    if (DynOS_Mod_IsShuttingDown() && !sLevelIsVanilla) {
+        sLevelIsVanilla = true;
+        return (void*) DynOS_Level_GetVanillaScript(get_menu_level());
     }
 
     return aCmd;

--- a/data/dynos_mgr_lvl.cpp
+++ b/data/dynos_mgr_lvl.cpp
@@ -211,9 +211,13 @@ void *DynOS_Lvl_Override(void *aCmd) {
         }
     }
 
+    // Evict the VM from any custom level scripts because we're about to delete it
     if (DynOS_Mod_IsShuttingDown() && !sLevelIsVanilla) {
+        LevelScript *vanillaScript = (LevelScript *) DynOS_Level_GetVanillaScript(get_menu_level());
+        gLevelScriptModIndex = -1;
+        gLevelScriptActive = vanillaScript;
         sLevelIsVanilla = true;
-        return (void*) DynOS_Level_GetVanillaScript(get_menu_level());
+        return vanillaScript;
     }
 
     return aCmd;

--- a/data/dynos_mgr_lvl.cpp
+++ b/data/dynos_mgr_lvl.cpp
@@ -211,7 +211,7 @@ void *DynOS_Lvl_Override(void *aCmd) {
         }
     }
 
-    // Evict the VM from any custom level scripts because we're about to delete it
+    // Evict the VM from any custom level scripts because we're about to delete them
     if (DynOS_Mod_IsShuttingDown() && !sLevelIsVanilla) {
         LevelScript *vanillaScript = (LevelScript *) DynOS_Level_GetVanillaScript(get_menu_level());
         gLevelScriptModIndex = -1;

--- a/data/dynos_mgr_lvl.cpp
+++ b/data/dynos_mgr_lvl.cpp
@@ -21,6 +21,11 @@ std::vector<std::pair<std::string, GfxData *>> &DynOS_Lvl_GetArray() {
     return sDynosCustomLevelScripts;
 }
 
+std::vector<GfxData *> &DynOS_Lvl_GetScheduledInvalidLevels() {
+    static std::vector<GfxData *> sDynosScheduledInvalidLevels;
+    return sDynosScheduledInvalidLevels;
+}
+
 LevelScript* DynOS_Lvl_GetScript(const char* aScriptEntryName) {
     auto& _CustomLevelScripts = DynOS_Lvl_GetArray();
     for (size_t i = 0; i < _CustomLevelScripts.size(); ++i) {
@@ -34,6 +39,14 @@ LevelScript* DynOS_Lvl_GetScript(const char* aScriptEntryName) {
     return NULL;
 }
 
+void DynOS_Lvl_FreeScheduledLvlData() {
+    auto& _ScheduledInvalidLevels = DynOS_Lvl_GetScheduledInvalidLevels();
+    for (auto& gfxData : _ScheduledInvalidLevels) {
+        DynOS_Gfx_Free(gfxData);
+    }
+    _ScheduledInvalidLevels.clear();
+}
+
 void DynOS_Lvl_ModShutdown() {
     DynOS_Level_Unoverride();
 
@@ -41,7 +54,11 @@ void DynOS_Lvl_ModShutdown() {
     if (!_CustomLevelScripts.empty()) {
         for (auto& pair : _CustomLevelScripts) {
             DynOS_Tex_Invalid(pair.second);
-            Delete(pair.second);
+
+            // we need to free all level data after the level script is
+            // no longer in circulation, as the level script VM
+            // may be processing commands in the level script still
+            DynOS_Lvl_GetScheduledInvalidLevels().push_back(pair.second);
         }
         _CustomLevelScripts.clear();
     }

--- a/data/dynos_mgr_movtexqc.cpp
+++ b/data/dynos_mgr_movtexqc.cpp
@@ -70,8 +70,5 @@ DataNode<MovtexQC>* DynOS_MovtexQC_GetFromIndex(s32 index) {
 
 void DynOS_MovtexQC_ModShutdown() {
     auto& _DynosRegisteredMovtexQCs = DynosRegisteredMovtexQCs();
-    for (auto &registered : _DynosRegisteredMovtexQCs) {
-        Delete(registered.dataNode);
-    }
     _DynosRegisteredMovtexQCs.clear();
 }

--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -576,6 +576,10 @@ void setup_game_memory(void) {
 
 static struct LevelCommand *levelCommandAddr;
 
+void force_level_script_change(const void *script) {
+    levelCommandAddr = (struct LevelCommand *) script;
+}
+
 // main game loop thread. runs forever as long as the game
 // continues.
 void thread5_game_loop(UNUSED void *arg) {

--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -576,10 +576,6 @@ void setup_game_memory(void) {
 
 static struct LevelCommand *levelCommandAddr;
 
-void force_level_script_change(const void *script) {
-    levelCommandAddr = (struct LevelCommand *) script;
-}
-
 // main game loop thread. runs forever as long as the game
 // continues.
 void thread5_game_loop(UNUSED void *arg) {

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -1542,25 +1542,28 @@ s32 update_current_play_mode() {
 }
 
 s16 get_menu_level(void) {
-    switch (configMenuLevel) {
-        case 0:  return LEVEL_CASTLE_GROUNDS;
-        case 1:  return LEVEL_BOB;
-        case 2:  return LEVEL_WF;
-        case 3:  return LEVEL_WMOTR;
-        case 4:  return LEVEL_JRB;
-        case 5:  return LEVEL_SSL;
-        case 6:  return LEVEL_TTM;
-        case 7:  return LEVEL_SL;
-        case 8:  return LEVEL_BBH;
-        case 9:  return LEVEL_LLL;
-        case 10: return LEVEL_THI;
-        case 11: return LEVEL_HMC;
-        case 12: return LEVEL_CCM;
-        case 13: return LEVEL_RR;
-        case 14: return LEVEL_BITDW;
-        case 15: return LEVEL_PSS;
-        case 16: return LEVEL_TTC;
-        case 17: return LEVEL_WDW;
+    static enum LevelNum sMenuLevels[] = {
+        LEVEL_CASTLE_GROUNDS,
+        LEVEL_BOB,
+        LEVEL_WF,
+        LEVEL_WMOTR,
+        LEVEL_JRB,
+        LEVEL_SSL,
+        LEVEL_TTM,
+        LEVEL_SL,
+        LEVEL_BBH,
+        LEVEL_LLL,
+        LEVEL_THI,
+        LEVEL_HMC,
+        LEVEL_CCM,
+        LEVEL_RR,
+        LEVEL_BITDW,
+        LEVEL_PSS,
+        LEVEL_TTC,
+        LEVEL_WDW,
+    };
+    if (configMenuLevel < ARRAY_COUNT(sMenuLevels)) {
+        return sMenuLevels[configMenuLevel];
     }
     return LEVEL_CASTLE_GROUNDS;
 }

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -1541,7 +1541,7 @@ s32 update_current_play_mode() {
     return changeLevel;
 }
 
-s16 get_menu_level() {
+s16 get_menu_level(void) {
     switch (configMenuLevel) {
         case 0:  return LEVEL_CASTLE_GROUNDS;
         case 1:  return LEVEL_BOB;

--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -1541,30 +1541,33 @@ s32 update_current_play_mode() {
     return changeLevel;
 }
 
+s16 get_menu_level() {
+    switch (configMenuLevel) {
+        case 0:  return LEVEL_CASTLE_GROUNDS;
+        case 1:  return LEVEL_BOB;
+        case 2:  return LEVEL_WF;
+        case 3:  return LEVEL_WMOTR;
+        case 4:  return LEVEL_JRB;
+        case 5:  return LEVEL_SSL;
+        case 6:  return LEVEL_TTM;
+        case 7:  return LEVEL_SL;
+        case 8:  return LEVEL_BBH;
+        case 9:  return LEVEL_LLL;
+        case 10: return LEVEL_THI;
+        case 11: return LEVEL_HMC;
+        case 12: return LEVEL_CCM;
+        case 13: return LEVEL_RR;
+        case 14: return LEVEL_BITDW;
+        case 15: return LEVEL_PSS;
+        case 16: return LEVEL_TTC;
+        case 17: return LEVEL_WDW;
+    }
+    return LEVEL_CASTLE_GROUNDS;
+}
+
 void update_menu_level(void) {
     // figure out level
-    s32 curLevel = 0;
-    switch (configMenuLevel) {
-        case 0:  curLevel = LEVEL_CASTLE_GROUNDS; break;
-        case 1:  curLevel = LEVEL_BOB;            break;
-        case 2:  curLevel = LEVEL_WF;             break;
-        case 3:  curLevel = LEVEL_WMOTR;          break;
-        case 4:  curLevel = LEVEL_JRB;            break;
-        case 5:  curLevel = LEVEL_SSL;            break;
-        case 6:  curLevel = LEVEL_TTM;            break;
-        case 7:  curLevel = LEVEL_SL;             break;
-        case 8:  curLevel = LEVEL_BBH;            break;
-        case 9:  curLevel = LEVEL_LLL;            break;
-        case 10: curLevel = LEVEL_THI;            break;
-        case 11: curLevel = LEVEL_HMC;            break;
-        case 12: curLevel = LEVEL_CCM;            break;
-        case 13: curLevel = LEVEL_RR;             break;
-        case 14: curLevel = LEVEL_BITDW;          break;
-        case 15: curLevel = LEVEL_PSS;            break;
-        case 16: curLevel = LEVEL_TTC;            break;
-        case 17: curLevel = LEVEL_WDW;            break;
-        default: curLevel = LEVEL_CASTLE_GROUNDS; break;
-    }
+    s16 curLevel = get_menu_level();
 
     // figure out music
     stop_cap_music();

--- a/src/game/level_update.h
+++ b/src/game/level_update.h
@@ -215,6 +215,7 @@ s32 lvl_exiting_credits(UNUSED s16 arg0, UNUSED s32 arg1);
 void fake_lvl_init_from_save_file(void);
 void lvl_skip_credits(void);
 
+s16 get_menu_level(void);
 void update_menu_level(void);
 void stop_demo(UNUSED struct DjuiBase* caller);
 

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -739,6 +739,9 @@ void network_shutdown(bool sendLeaving, bool exiting, bool popup, bool reconnect
     smlua_shutdown();
     extern s16 gChangeLevel;
     gChangeLevel = LEVEL_CASTLE_GROUNDS;
+    void force_level_script_change(const void *script);
+    s16 get_menu_level();
+    force_level_script_change(dynos_level_get_vanilla_script(get_menu_level()));
     network_player_init();
     gMarioStates[0].cap = 0;
     gMarioStates[0].input = 0;

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -738,10 +738,8 @@ void network_shutdown(bool sendLeaving, bool exiting, bool popup, bool reconnect
     mods_clear(&gRemoteMods);
     smlua_shutdown();
     extern s16 gChangeLevel;
-    gChangeLevel = LEVEL_CASTLE_GROUNDS;
-    void force_level_script_change(const void *script);
-    s16 get_menu_level();
-    force_level_script_change(dynos_level_get_vanilla_script(get_menu_level()));
+    s16 menuLevel = get_menu_level();
+    gChangeLevel = menuLevel;
     network_player_init();
     gMarioStates[0].cap = 0;
     gMarioStates[0].input = 0;


### PR DESCRIPTION
this fixes the giant memory leak that happens due to not freeing custom level data when closing a lobby.
`DynOS_Lvl_ModShutdown` was not freeing the data nodes for the level data, it was only freeing the surface data.
To fix this, I have made it use `DynOS_Gfx_Free` to free the `GfxData` correctly. I found that the level script VM will still be trying to warp from the custom level after `DynOS_Lvl_ModShutdown` is executed, so I added a schedule to simply free it the next frame.
I've made it force the level script to change to a vanilla level during mod shutdown. This is critical to ensure the VM doesn't continue to read from a freed level script.

Removed the explicit deletion of data nodes in `DynOS_MovtexQC_ModShutdown` because `DynOS_Gfx_Free` already frees that, and it's actually data owned by the data node, so it's more appropriate in `DynOS_Gfx_Free`