### PR TITLE
Add "Reset Binds" button to N64 and Extra controls menus and allow quick unbind

### DIFF
--- a/lang/Czech.ini
+++ b/lang/Czech.ini
@@ -65,6 +65,7 @@ CANCEL = "Zrušit"
 NO = "Ne"
 YES = "Ano"
 SEARCH = "Hledat..."
+RESET_BINDS = "Resetovat ovládání"
 
 [CAMERA]
 CAMERA = "KAMERA"

--- a/lang/Dutch.ini
+++ b/lang/Dutch.ini
@@ -65,6 +65,7 @@ CANCEL = "Stop"
 NO = "Nee"
 YES = "Ja"
 SEARCH = "Zoek..."
+RESET_BINDS = "Toetsen resetten"
 
 [CAMERA]
 CAMERA = "CAMERA"

--- a/lang/English.ini
+++ b/lang/English.ini
@@ -65,6 +65,7 @@ CANCEL = "Cancel"
 NO = "No"
 YES = "Yes"
 SEARCH = "Search..."
+RESET_BINDS = "Reset Binds"
 
 [CAMERA]
 CAMERA = "CAMERA"

--- a/lang/French.ini
+++ b/lang/French.ini
@@ -65,6 +65,7 @@ CANCEL = "Annuler"
 NO = "Non"
 YES = "Oui"
 SEARCH = "Rechercher..."
+RESET_BINDS = "Réinitialiser les touches"
 
 [CAMERA]
 CAMERA = "CAMÉRA"

--- a/lang/German.ini
+++ b/lang/German.ini
@@ -65,6 +65,7 @@ CANCEL = "Abbrechen"
 NO = "Nein"
 YES = "Ja"
 SEARCH = "Suche..."
+RESET_BINDS = "Tasten zurücksetzen"
 
 [CAMERA]
 CAMERA = "KAMERA"

--- a/lang/Italian.ini
+++ b/lang/Italian.ini
@@ -65,6 +65,7 @@ CANCEL = "Annulla"
 NO = "No"
 YES = "Si"
 SEARCH = "Cerca..."
+RESET_BINDS = "Reimposta i tasti"
 
 [CAMERA]
 CAMERA = "TELECAMERA"

--- a/lang/Japanese.ini
+++ b/lang/Japanese.ini
@@ -65,6 +65,7 @@ CANCEL = "キャンセル"
 NO = "いいえ"
 YES = "はい"
 SEARCH = "検索…"
+RESET_BINDS = "キー割り当てをリセット"
 
 [CAMERA]
 CAMERA = "CAMERA"

--- a/lang/Polish.ini
+++ b/lang/Polish.ini
@@ -65,6 +65,7 @@ CANCEL = "Anuluj"
 NO = "Nie"
 YES = "Tak"
 SEARCH = "Szukaj..."
+RESET_BINDS = "Resetuj przyciski"
 
 [CAMERA]
 CAMERA = "KAMERA"

--- a/lang/Portuguese.ini
+++ b/lang/Portuguese.ini
@@ -65,6 +65,7 @@ CANCEL = "Cancelar"
 NO = "Não"
 YES = "Sim"
 SEARCH = "Pesquisar..."
+RESET_BINDS = "Redefinir teclas"
 
 [CAMERA]
 CAMERA = "CÂMERA"

--- a/lang/Russian.ini
+++ b/lang/Russian.ini
@@ -65,6 +65,7 @@ CANCEL = "Отмена"
 NO = "Нет"
 YES = "Да"
 SEARCH = "Поиск..."
+RESET_BINDS = "Сбросить клавиши"
 
 [CAMERA]
 CAMERA = "CAMERA"

--- a/lang/Spanish.ini
+++ b/lang/Spanish.ini
@@ -65,6 +65,7 @@ CANCEL = "Cancelar"
 NO = "No"
 YES = "Sí"
 SEARCH = "Buscar..."
+RESET_BINDS = "Restablecer teclas"
 
 [CAMERA]
 CAMERA = "CÁMARA"

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -99,6 +99,33 @@ bool         configFadeoutDistantSounds           = false;
 bool         configMuteFocusLoss                  = false;
 unsigned int configSoundOutput                    = 0; // 0 = Stereo, 1 = Mono, 2 = Headset
 // control binds
+static const unsigned int defaultConfigKeyA[MAX_BINDS]          = { 0x0026,     0x1000,     0x1103     };
+static const unsigned int defaultConfigKeyB[MAX_BINDS]          = { 0x0033,     0x1001,     0x1101     };
+static const unsigned int defaultConfigKeyX[MAX_BINDS]          = { 0x0017,     0x1002,     VK_INVALID };
+static const unsigned int defaultConfigKeyY[MAX_BINDS]          = { 0x0032,     0x1003,     VK_INVALID };
+static const unsigned int defaultConfigKeyStart[MAX_BINDS]      = { 0x0039,     0x1006,     VK_INVALID };
+static const unsigned int defaultConfigKeyL[MAX_BINDS]          = { 0x002A,     0x1009,     0x1104     };
+static const unsigned int defaultConfigKeyR[MAX_BINDS]          = { 0x0036,     0x100A,     0x101B     };
+static const unsigned int defaultConfigKeyZ[MAX_BINDS]          = { 0x0025,     0x1007,     0x101A     };
+static const unsigned int defaultConfigKeyCUp[MAX_BINDS]        = { 0x0148,     VK_INVALID, VK_INVALID };
+static const unsigned int defaultConfigKeyCDown[MAX_BINDS]      = { 0x0150,     VK_INVALID, VK_INVALID };
+static const unsigned int defaultConfigKeyCLeft[MAX_BINDS]      = { 0x014B,     VK_INVALID, VK_INVALID };
+static const unsigned int defaultConfigKeyCRight[MAX_BINDS]     = { 0x014D,     VK_INVALID, VK_INVALID };
+static const unsigned int defaultConfigKeyStickUp[MAX_BINDS]    = { 0x0011,     VK_INVALID, VK_INVALID };
+static const unsigned int defaultConfigKeyStickDown[MAX_BINDS]  = { 0x001F,     VK_INVALID, VK_INVALID };
+static const unsigned int defaultConfigKeyStickLeft[MAX_BINDS]  = { 0x001E,     VK_INVALID, VK_INVALID };
+static const unsigned int defaultConfigKeyStickRight[MAX_BINDS] = { 0x0020,     VK_INVALID, VK_INVALID };
+static const unsigned int defaultConfigKeyChat[MAX_BINDS]       = { 0x001C,     VK_INVALID, VK_INVALID };
+static const unsigned int defaultConfigKeyPlayerList[MAX_BINDS] = { 0x000F,     0x1004,     VK_INVALID };
+static const unsigned int defaultConfigKeyDUp[MAX_BINDS]        = { 0x0147,     0x100b,     VK_INVALID };
+static const unsigned int defaultConfigKeyDDown[MAX_BINDS]      = { 0x014f,     0x100c,     VK_INVALID };
+static const unsigned int defaultConfigKeyDLeft[MAX_BINDS]      = { 0x0153,     0x100d,     VK_INVALID };
+static const unsigned int defaultConfigKeyDRight[MAX_BINDS]     = { 0x0151,     0x100e,     VK_INVALID };
+static const unsigned int defaultConfigKeyConsole[MAX_BINDS]    = { 0x0029,     0x003B,     VK_INVALID };
+static const unsigned int defaultConfigKeyPrevPage[MAX_BINDS]   = { 0x0016,     VK_INVALID, VK_INVALID };
+static const unsigned int defaultConfigKeyNextPage[MAX_BINDS]   = { 0x0018,     VK_INVALID, VK_INVALID };
+static const unsigned int defaultConfigKeyDisconnect[MAX_BINDS] = { VK_INVALID, VK_INVALID, VK_INVALID };
+
 unsigned int configKeyA[MAX_BINDS]                = { 0x0026,     0x1000,     0x1103     };
 unsigned int configKeyB[MAX_BINDS]                = { 0x0033,     0x1001,     0x1101     };
 unsigned int configKeyX[MAX_BINDS]                = { 0x0017,     0x1002,     VK_INVALID };
@@ -125,6 +152,7 @@ unsigned int configKeyConsole[MAX_BINDS]          = { 0x0029,     0x003B,     VK
 unsigned int configKeyPrevPage[MAX_BINDS]         = { 0x0016,     VK_INVALID, VK_INVALID };
 unsigned int configKeyNextPage[MAX_BINDS]         = { 0x0018,     VK_INVALID, VK_INVALID };
 unsigned int configKeyDisconnect[MAX_BINDS]       = { VK_INVALID, VK_INVALID, VK_INVALID };
+
 unsigned int configStickDeadzone                  = 16;
 unsigned int configRumbleStrength                 = 50;
 unsigned int configGamepadNumber                  = 0;
@@ -825,6 +853,38 @@ NEXT_OPTION:
 #ifndef COOPNET
     configNetworkSystem = NS_SOCKET;
 #endif
+}
+
+void configfile_reset_keybinds(bool extra) {
+    if (!extra) {
+        memcpy(configKeyA, defaultConfigKeyA, sizeof(configKeyA));
+        memcpy(configKeyB, defaultConfigKeyB, sizeof(configKeyB));
+        memcpy(configKeyX, defaultConfigKeyX, sizeof(configKeyX));
+        memcpy(configKeyY, defaultConfigKeyY, sizeof(configKeyY));
+        memcpy(configKeyStart, defaultConfigKeyStart, sizeof(configKeyStart));
+        memcpy(configKeyL, defaultConfigKeyL, sizeof(configKeyL));
+        memcpy(configKeyR, defaultConfigKeyR, sizeof(configKeyR));
+        memcpy(configKeyZ, defaultConfigKeyZ, sizeof(configKeyZ));
+        memcpy(configKeyCUp, defaultConfigKeyCUp, sizeof(configKeyCUp));
+        memcpy(configKeyCDown, defaultConfigKeyCDown, sizeof(configKeyCDown));
+        memcpy(configKeyCLeft, defaultConfigKeyCLeft, sizeof(configKeyCLeft));
+        memcpy(configKeyCRight, defaultConfigKeyCRight, sizeof(configKeyCRight));
+        memcpy(configKeyStickUp, defaultConfigKeyStickUp, sizeof(configKeyStickUp));
+        memcpy(configKeyStickDown, defaultConfigKeyStickDown, sizeof(configKeyStickDown));
+        memcpy(configKeyStickLeft, defaultConfigKeyStickLeft, sizeof(configKeyStickLeft));
+        memcpy(configKeyStickRight, defaultConfigKeyStickRight, sizeof(configKeyStickRight));
+    } else {
+        memcpy(configKeyChat, defaultConfigKeyChat, sizeof(configKeyChat));
+        memcpy(configKeyPlayerList, defaultConfigKeyPlayerList, sizeof(configKeyPlayerList));
+        memcpy(configKeyDUp, defaultConfigKeyDUp, sizeof(configKeyDUp));
+        memcpy(configKeyDDown, defaultConfigKeyDDown, sizeof(configKeyDDown));
+        memcpy(configKeyDLeft, defaultConfigKeyDLeft, sizeof(configKeyDLeft));
+        memcpy(configKeyDRight, defaultConfigKeyDRight, sizeof(configKeyDRight));
+        memcpy(configKeyConsole, defaultConfigKeyConsole, sizeof(configKeyConsole));
+        memcpy(configKeyPrevPage, defaultConfigKeyPrevPage, sizeof(configKeyPrevPage));
+        memcpy(configKeyNextPage, defaultConfigKeyNextPage, sizeof(configKeyNextPage));
+        memcpy(configKeyDisconnect, defaultConfigKeyDisconnect, sizeof(configKeyDisconnect));
+    }
 }
 
 void configfile_load(void) {

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -859,8 +859,6 @@ void configfile_reset_keybinds(bool extra) {
     if (!extra) {
         memcpy(configKeyA, defaultConfigKeyA, sizeof(configKeyA));
         memcpy(configKeyB, defaultConfigKeyB, sizeof(configKeyB));
-        memcpy(configKeyX, defaultConfigKeyX, sizeof(configKeyX));
-        memcpy(configKeyY, defaultConfigKeyY, sizeof(configKeyY));
         memcpy(configKeyStart, defaultConfigKeyStart, sizeof(configKeyStart));
         memcpy(configKeyL, defaultConfigKeyL, sizeof(configKeyL));
         memcpy(configKeyR, defaultConfigKeyR, sizeof(configKeyR));
@@ -874,6 +872,8 @@ void configfile_reset_keybinds(bool extra) {
         memcpy(configKeyStickLeft, defaultConfigKeyStickLeft, sizeof(configKeyStickLeft));
         memcpy(configKeyStickRight, defaultConfigKeyStickRight, sizeof(configKeyStickRight));
     } else {
+        memcpy(configKeyX, defaultConfigKeyX, sizeof(configKeyX));
+        memcpy(configKeyY, defaultConfigKeyY, sizeof(configKeyY));
         memcpy(configKeyChat, defaultConfigKeyChat, sizeof(configKeyChat));
         memcpy(configKeyPlayerList, defaultConfigKeyPlayerList, sizeof(configKeyPlayerList));
         memcpy(configKeyDUp, defaultConfigKeyDUp, sizeof(configKeyDUp));

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -124,7 +124,7 @@ static const unsigned int defaultConfigKeyDRight[MAX_BINDS]     = { 0x0151,     
 static const unsigned int defaultConfigKeyConsole[MAX_BINDS]    = { 0x0029,     0x003B,     VK_INVALID };
 static const unsigned int defaultConfigKeyPrevPage[MAX_BINDS]   = { 0x0016,     VK_INVALID, VK_INVALID };
 static const unsigned int defaultConfigKeyNextPage[MAX_BINDS]   = { 0x0018,     VK_INVALID, VK_INVALID };
-static const unsigned int defaultConfigKeyDisconnect[MAX_BINDS] = { VK_INVALID, VK_INVALID, VK_INVALID };
+static const unsigned int defaultConfigKeyDisconnect[MAX_BINDS] = { 0x0058,     VK_INVALID, VK_INVALID };
 
 unsigned int configKeyA[MAX_BINDS]                = { 0x0026,     0x1000,     0x1103     };
 unsigned int configKeyB[MAX_BINDS]                = { 0x0033,     0x1001,     0x1101     };
@@ -151,8 +151,7 @@ unsigned int configKeyDRight[MAX_BINDS]           = { 0x0151,     0x100e,     VK
 unsigned int configKeyConsole[MAX_BINDS]          = { 0x0029,     0x003B,     VK_INVALID };
 unsigned int configKeyPrevPage[MAX_BINDS]         = { 0x0016,     VK_INVALID, VK_INVALID };
 unsigned int configKeyNextPage[MAX_BINDS]         = { 0x0018,     VK_INVALID, VK_INVALID };
-unsigned int configKeyDisconnect[MAX_BINDS]       = { VK_INVALID, VK_INVALID, VK_INVALID };
-
+unsigned int configKeyDisconnect[MAX_BINDS]       = { 0x0058,     VK_INVALID, VK_INVALID };
 unsigned int configStickDeadzone                  = 16;
 unsigned int configRumbleStrength                 = 50;
 unsigned int configGamepadNumber                  = 0;

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -190,6 +190,7 @@ extern bool configExCoopTheme;
 
 void enable_queued_mods(void);
 void enable_queued_dynos_packs(void);
+void configfile_reset_keybinds(bool extra);
 void configfile_load(void);
 void configfile_save(const char *filename);
 const char *configfile_name(void);

--- a/src/pc/djui/djui_bind.c
+++ b/src/pc/djui/djui_bind.c
@@ -88,3 +88,37 @@ struct DjuiBind* djui_bind_create(struct DjuiBase* parent, const char* message, 
 
     return bind;
 }
+
+void djui_bind_refresh(struct DjuiBind *bind) {
+    if (!bind || !bind->configKey) { return; }
+
+    for (s32 i = 0; i < MAX_BINDS; ++i) {
+        struct DjuiButton *button = bind->buttons[i];
+        if (!button) { continue; }
+
+        u32 key = bind->configKey[i];
+        djui_text_set_text(button->text, translate_bind_to_name(key));
+    }
+}
+
+void djui_bind_unbind(struct DjuiBase* caller) {
+    if (!caller || !caller->interactable || !caller->parent || !caller->parent->parent) { return; }
+
+    struct DjuiInteractable *interactable = caller->interactable;
+    if (interactable->on_bind != djui_bind_button_on_bind) {
+        return; // not a bind
+    }
+
+    struct DjuiBind *bind = (struct DjuiBind *) caller->parent->parent;
+    for (s32 i = 0; i < MAX_BINDS; ++i) {
+        if (&bind->buttons[i]->base == caller) {
+            bind->configKey[i] = VK_INVALID;
+
+            // refresh bind
+            djui_bind_refresh(bind);
+            play_sound(SOUND_MENU_CHANGE_SELECT, gGlobalSoundSource);
+            controller_reconfigure();
+            return;
+        }
+    }
+}

--- a/src/pc/djui/djui_bind.h
+++ b/src/pc/djui/djui_bind.h
@@ -11,3 +11,5 @@ struct DjuiBind {
 };
 
 struct DjuiBind* djui_bind_create(struct DjuiBase* parent, const char* message, unsigned int configKey[]);
+void djui_bind_refresh(struct DjuiBind* bind);
+void djui_bind_unbind(struct DjuiBase* caller);

--- a/src/pc/djui/djui_cursor.c
+++ b/src/pc/djui/djui_cursor.c
@@ -155,7 +155,7 @@ static void djui_cursor_update_position(void) {
     djui_base_set_location(&sMouseCursor->base, gCursorX - 13, gCursorY - 13);
 
     // set cursor sprite
-    if ((gInteractablePad.button & PAD_BUTTON_A) || (mouse_window_buttons & MOUSE_BUTTON_1)) {
+    if ((gInteractablePad.button & PAD_BUTTON_A) || (mouse_window_buttons & L_MOUSE_BUTTON)) {
         sMouseCursor->textureInfo.texture = gd_texture_hand_closed;
     } else {
         sMouseCursor->textureInfo.texture = gd_texture_hand_open;

--- a/src/pc/djui/djui_interactable.c
+++ b/src/pc/djui/djui_interactable.c
@@ -22,6 +22,8 @@ static enum PadHoldDirection sKeyboardHoldDirection = PAD_HOLD_DIR_NONE;
 static u16 sKeyboardButtons = 0;
 
 static bool sIgnoreInteractableUntilCursorReleased = false;
+static bool sIgnoreAllInputsWhenBinding = false;
+static bool sAttemptingToToggleConsole = false;
 
 struct DjuiBase* gDjuiHovered = NULL;
 struct DjuiBase* gDjuiCursorDownOn = NULL;
@@ -198,6 +200,15 @@ bool djui_interactable_on_key_down(int scancode) {
         return true;
     }
 
+    if (!gDjuiChatBoxFocus) {
+        for (int i = 0; i < MAX_BINDS; i++) {
+            if (scancode == (int)configKeyConsole[i]) {
+                sAttemptingToToggleConsole = true;
+                break;
+            }
+        }
+    }
+
     bool keyFocused = (gInteractableFocus != NULL)
                    && (gInteractableFocus->interactable != NULL)
                    && (gInteractableFocus->interactable->on_key_down != NULL);
@@ -279,9 +290,13 @@ bool djui_interactable_on_key_down(int scancode) {
 
 void djui_interactable_on_key_up(int scancode) {
 
-    if (!gDjuiChatBoxFocus) {
+    if (!gDjuiChatBoxFocus && sAttemptingToToggleConsole) {
         for (int i = 0; i < MAX_BINDS; i++) {
-            if (scancode == (int)configKeyConsole[i]) { djui_console_toggle(); break; }
+            if (scancode == (int)configKeyConsole[i]) {
+                djui_console_toggle();
+                sAttemptingToToggleConsole = false;
+                break;
+            }
         }
     }
 
@@ -390,7 +405,7 @@ void djui_interactable_update_pad(void) {
         validPadHold = true;
     }
 
-    if (validPadHold && gInteractableFocus == NULL) {
+    if (validPadHold && gInteractableFocus == NULL && !sIgnoreAllInputsWhenBinding) {
         switch (padHoldDirection) {
             case PAD_HOLD_DIR_UP:    djui_cursor_move( 0, -1); break;
             case PAD_HOLD_DIR_DOWN:  djui_cursor_move( 0,  1); break;
@@ -408,21 +423,25 @@ void djui_interactable_update(void) {
     djui_interactable_update_pad();
 
     // prevent pressing buttons when they should be ignored
-    int mouseButtons = mouse_window_buttons;
-    u16 padButtons = gInteractablePad.button;
-    if (sIgnoreInteractableUntilCursorReleased) {
-        if ((padButtons & PAD_BUTTON_A) || (mouseButtons & MOUSE_BUTTON_1)) {
-            padButtons   &= ~PAD_BUTTON_A;
-            mouseButtons &= ~MOUSE_BUTTON_1;
-        } else {
-            sIgnoreInteractableUntilCursorReleased = false;
+    int mouseButtons = 0;
+    u16 padButtons = 0;
+    if (!sIgnoreAllInputsWhenBinding) {
+        mouseButtons = mouse_window_buttons;
+        padButtons = gInteractablePad.button;
+        if (sIgnoreInteractableUntilCursorReleased) {
+            if ((padButtons & PAD_BUTTON_A) || (mouseButtons & L_MOUSE_BUTTON)) {
+                padButtons   &= ~PAD_BUTTON_A;
+                mouseButtons &= ~L_MOUSE_BUTTON;
+            } else {
+                sIgnoreInteractableUntilCursorReleased = false;
+            }
         }
     }
 
     // update focused
     if (gInteractableFocus) {
         u16 mainButtons = PAD_BUTTON_A | PAD_BUTTON_B;
-        if ((mouseButtons & MOUSE_BUTTON_1) && !(sLastMouseButtons & MOUSE_BUTTON_1) && !djui_cursor_inside_base(gInteractableFocus)) {
+        if ((mouseButtons & L_MOUSE_BUTTON) && !(sLastMouseButtons & L_MOUSE_BUTTON) && !djui_cursor_inside_base(gInteractableFocus)) {
             // clicked outside of focus
             if (!gDjuiChatBoxFocus) {
                 djui_interactable_set_input_focus(NULL);
@@ -449,7 +468,10 @@ void djui_interactable_update(void) {
 
     if (gInteractableBinding != NULL) {
         djui_interactable_on_bind(gInteractableBinding);
-    } else if ((padButtons & PAD_BUTTON_A) || (mouseButtons & MOUSE_BUTTON_1)) {
+        // make sure to cancel all inputs when binding a key
+        sIgnoreAllInputsWhenBinding = true;
+        return;
+    } else if ((padButtons & PAD_BUTTON_A) || (mouseButtons & L_MOUSE_BUTTON)) {
         // cursor down events
         if (gDjuiHovered != NULL) {
             gInteractableMouseDown = gDjuiHovered;
@@ -457,6 +479,12 @@ void djui_interactable_update(void) {
             djui_interactable_on_cursor_down_begin(gInteractableMouseDown, !mouseButtons);
         } else {
             djui_interactable_on_cursor_down(gInteractableMouseDown);
+        }
+    } else if (((padButtons & PAD_BUTTON_Z) && !(sLastInteractablePad.button & PAD_BUTTON_Z)) ||
+               ((mouseButtons & R_MOUSE_BUTTON) && !(sLastMouseButtons & R_MOUSE_BUTTON))) {
+        // pressed unbind
+        if (gDjuiHovered != NULL) {
+            djui_bind_unbind(gDjuiHovered);
         }
     } else {
         // cursor up event
@@ -476,6 +504,13 @@ void djui_interactable_update(void) {
 
     sLastInteractablePad = gInteractablePad;
     sLastMouseButtons = mouseButtons;
+
+    // Stop ignoring inputs, but set all buttons to "pressed", so they can't reactivate during the next frame
+    if (sIgnoreAllInputsWhenBinding) {
+        sLastInteractablePad.button = ~0;
+        sLastMouseButtons = ~0;
+        sIgnoreAllInputsWhenBinding = false;
+    }
 }
 
 void djui_interactable_hook_hover(struct DjuiBase* base,

--- a/src/pc/djui/djui_interactable.c
+++ b/src/pc/djui/djui_interactable.c
@@ -23,7 +23,7 @@ static u16 sKeyboardButtons = 0;
 
 static bool sIgnoreInteractableUntilCursorReleased = false;
 static bool sIgnoreAllInputsWhenBinding = false;
-static bool sAttemptingToToggleConsole = false;
+static int sPendingConsoleToggleScancode = -1;
 
 struct DjuiBase* gDjuiHovered = NULL;
 struct DjuiBase* gDjuiCursorDownOn = NULL;
@@ -203,7 +203,7 @@ bool djui_interactable_on_key_down(int scancode) {
     if (!gDjuiChatBoxFocus) {
         for (int i = 0; i < MAX_BINDS; i++) {
             if (scancode == (int)configKeyConsole[i]) {
-                sAttemptingToToggleConsole = true;
+                sPendingConsoleToggleScancode = scancode;
                 break;
             }
         }
@@ -290,14 +290,11 @@ bool djui_interactable_on_key_down(int scancode) {
 
 void djui_interactable_on_key_up(int scancode) {
 
-    if (!gDjuiChatBoxFocus && sAttemptingToToggleConsole) {
-        for (int i = 0; i < MAX_BINDS; i++) {
-            if (scancode == (int)configKeyConsole[i]) {
-                djui_console_toggle();
-                sAttemptingToToggleConsole = false;
-                break;
-            }
+    if (sPendingConsoleToggleScancode != -1 && scancode == sPendingConsoleToggleScancode) {
+        if (!gDjuiChatBoxFocus) {
+            djui_console_toggle();
         }
+        sPendingConsoleToggleScancode = -1;
     }
 
     if (gDjuiPlayerList != NULL || gDjuiModList != NULL) {

--- a/src/pc/djui/djui_panel_controls.c
+++ b/src/pc/djui/djui_panel_controls.c
@@ -101,3 +101,14 @@ void djui_panel_controls_create(struct DjuiBase* caller) {
 
     djui_panel_add(caller, panel, NULL);
 }
+
+void djui_panel_controls_refresh_binds(struct DjuiBase *parent) {
+    if (!parent) { return; }
+
+    struct DjuiBaseChild *child = parent->child;
+    while (child) {
+        struct DjuiBind *bind = (struct DjuiBind *) child->base;
+        djui_bind_refresh(bind);
+        child = child->next;
+    }
+}

--- a/src/pc/djui/djui_panel_controls.h
+++ b/src/pc/djui/djui_panel_controls.h
@@ -2,3 +2,4 @@
 #include "djui.h"
 
 void djui_panel_controls_create(struct DjuiBase* caller);
+void djui_panel_controls_refresh_binds(struct DjuiBase* parent);

--- a/src/pc/djui/djui_panel_controls_extra.c
+++ b/src/pc/djui/djui_panel_controls_extra.c
@@ -5,27 +5,21 @@
 #include "djui_panel_pause.h"
 #include "djui_panel_options.h"
 #include "djui_panel_controls.h"
+#include "djui_panel_controls_extra.h"
+#include "pc/controller/controller_api.h"
 #include "pc/configfile.h"
+#include "audio/external.h"
 
-void djui_panel_controls_extra_create(struct DjuiBase* caller);
+static void djui_panel_controls_reset_binds_extra(struct DjuiBase* caller) {
+    configfile_reset_keybinds(true);
+    controller_reconfigure();
+    play_sound(SOUND_MENU_CHANGE_SELECT, gGlobalSoundSource);
 
-void djui_panel_controls_reset_binds_extra(UNUSED struct DjuiBase* caller) {
-    if (gDjuiInMainMenu) {
-        djui_panel_shutdown();
-        gDjuiInMainMenu = true;
-        configfile_reset_keybinds(true);
-        djui_panel_main_create(NULL);
-        djui_panel_options_create(NULL);
-        djui_panel_controls_create(NULL);
-        djui_panel_controls_extra_create(NULL);
-    } else if (gDjuiPanelPauseCreated) {
-        djui_panel_shutdown();
-        configfile_reset_keybinds(true);
-        djui_panel_pause_create(NULL);
-        djui_panel_options_create(NULL);
-        djui_panel_controls_create(NULL);
-        djui_panel_controls_extra_create(NULL);
-    }
+    struct DjuiBase *resetButtonBody = caller->parent;
+    if (!resetButtonBody || !resetButtonBody->child) { return; }
+    struct DjuiBase *bindBody = resetButtonBody->child->base;
+
+    djui_panel_controls_refresh_binds(bindBody);
 }
 
 void djui_panel_controls_extra_create(struct DjuiBase* caller) {

--- a/src/pc/djui/djui_panel_controls_extra.c
+++ b/src/pc/djui/djui_panel_controls_extra.c
@@ -1,7 +1,32 @@
 #include "djui.h"
 #include "djui_panel.h"
 #include "djui_panel_menu.h"
+#include "djui_panel_main.h"
+#include "djui_panel_pause.h"
+#include "djui_panel_options.h"
+#include "djui_panel_controls.h"
 #include "pc/configfile.h"
+
+void djui_panel_controls_extra_create(struct DjuiBase* caller);
+
+void djui_panel_controls_reset_binds_extra(UNUSED struct DjuiBase* caller) {
+    if (gDjuiInMainMenu) {
+        djui_panel_shutdown();
+        gDjuiInMainMenu = true;
+        configfile_reset_keybinds(true);
+        djui_panel_main_create(NULL);
+        djui_panel_options_create(NULL);
+        djui_panel_controls_create(NULL);
+        djui_panel_controls_extra_create(NULL);
+    } else if (gDjuiPanelPauseCreated) {
+        djui_panel_shutdown();
+        configfile_reset_keybinds(true);
+        djui_panel_pause_create(NULL);
+        djui_panel_options_create(NULL);
+        djui_panel_controls_create(NULL);
+        djui_panel_controls_extra_create(NULL);
+    }
+}
 
 void djui_panel_controls_extra_create(struct DjuiBase* caller) {
     f32 bindBodyHeight = 28 * 12 + 1 * 10;
@@ -28,7 +53,7 @@ void djui_panel_controls_extra_create(struct DjuiBase* caller) {
             djui_bind_create(&bindBody->base, DLANG(CONTROLS, NEXT),       configKeyNextPage);
             djui_bind_create(&bindBody->base, DLANG(CONTROLS, DISCONNECT), configKeyDisconnect);
         }
-
+        djui_button_create(body, DLANG(MENU, RESET_BINDS), DJUI_BUTTON_STYLE_NORMAL, djui_panel_controls_reset_binds_extra);
         djui_button_create(body, DLANG(MENU, BACK), DJUI_BUTTON_STYLE_BACK, djui_panel_menu_back);
     }
 

--- a/src/pc/djui/djui_panel_controls_n64.c
+++ b/src/pc/djui/djui_panel_controls_n64.c
@@ -1,7 +1,32 @@
 #include "djui.h"
 #include "djui_panel.h"
 #include "djui_panel_menu.h"
+#include "djui_panel_main.h"
+#include "djui_panel_pause.h"
+#include "djui_panel_options.h"
+#include "djui_panel_controls.h"
 #include "pc/configfile.h"
+
+void djui_panel_controls_n64_create(struct DjuiBase* caller);
+
+void djui_panel_controls_reset_binds_n64(UNUSED struct DjuiBase* caller) {
+    if (gDjuiInMainMenu) {
+        djui_panel_shutdown();
+        gDjuiInMainMenu = true;
+        configfile_reset_keybinds(false);
+        djui_panel_main_create(NULL);
+        djui_panel_options_create(NULL);
+        djui_panel_controls_create(NULL);
+        djui_panel_controls_n64_create(NULL);
+    } else if (gDjuiPanelPauseCreated) {
+        djui_panel_shutdown();
+        configfile_reset_keybinds(false);
+        djui_panel_pause_create(NULL);
+        djui_panel_options_create(NULL);
+        djui_panel_controls_create(NULL);
+        djui_panel_controls_n64_create(NULL);
+    }
+}
 
 void djui_panel_controls_n64_create(struct DjuiBase* caller) {
     f32 bindBodyHeight = 28 * 14 + 1 * 13;
@@ -30,7 +55,7 @@ void djui_panel_controls_n64_create(struct DjuiBase* caller) {
             djui_bind_create(&bindBody->base, DLANG(CONTROLS, C_LEFT),  configKeyCLeft);
             djui_bind_create(&bindBody->base, DLANG(CONTROLS, C_RIGHT), configKeyCRight);
         }
-
+        djui_button_create(body, DLANG(MENU, RESET_BINDS), DJUI_BUTTON_STYLE_NORMAL, djui_panel_controls_reset_binds_n64);
         djui_button_create(body, DLANG(MENU, BACK), DJUI_BUTTON_STYLE_BACK, djui_panel_menu_back);
     }
 

--- a/src/pc/djui/djui_panel_controls_n64.c
+++ b/src/pc/djui/djui_panel_controls_n64.c
@@ -5,27 +5,21 @@
 #include "djui_panel_pause.h"
 #include "djui_panel_options.h"
 #include "djui_panel_controls.h"
+#include "djui_panel_controls_n64.h"
+#include "pc/controller/controller_api.h"
 #include "pc/configfile.h"
+#include "audio/external.h"
 
-void djui_panel_controls_n64_create(struct DjuiBase* caller);
+static void djui_panel_controls_reset_binds_n64(struct DjuiBase* caller) {
+    configfile_reset_keybinds(false);
+    controller_reconfigure();
+    play_sound(SOUND_MENU_CHANGE_SELECT, gGlobalSoundSource);
 
-void djui_panel_controls_reset_binds_n64(UNUSED struct DjuiBase* caller) {
-    if (gDjuiInMainMenu) {
-        djui_panel_shutdown();
-        gDjuiInMainMenu = true;
-        configfile_reset_keybinds(false);
-        djui_panel_main_create(NULL);
-        djui_panel_options_create(NULL);
-        djui_panel_controls_create(NULL);
-        djui_panel_controls_n64_create(NULL);
-    } else if (gDjuiPanelPauseCreated) {
-        djui_panel_shutdown();
-        configfile_reset_keybinds(false);
-        djui_panel_pause_create(NULL);
-        djui_panel_options_create(NULL);
-        djui_panel_controls_create(NULL);
-        djui_panel_controls_n64_create(NULL);
-    }
+    struct DjuiBase *resetButtonBody = caller->parent;
+    if (!resetButtonBody || !resetButtonBody->child) { return; }
+    struct DjuiBase *bindBody = resetButtonBody->child->base;
+
+    djui_panel_controls_refresh_binds(bindBody);
 }
 
 void djui_panel_controls_n64_create(struct DjuiBase* caller) {


### PR DESCRIPTION
In case you wanted to revert your controls back to default (I'm not sure why you would want to do this for the horrendous default N64 controls carried over from like sm64ex) but this was a feature request and I thought it was pretty okay to add