### PR TITLE
Resolve a minor issue with a 2 frame freeze when not necessary

### DIFF
--- a/src/game/level_update.c
+++ b/src/game/level_update.c
@@ -319,6 +319,9 @@ void load_level_init_text(u32 arg) {
     if (!gotAchievement) {
         //level_set_transition(-1, NULL);
         create_dialog_box(dialogID);
+        // since coop doesn't use timefreeze, freeze mario to preserve no input when there
+        // is a dialog on screen when loading a new level
+        gMarioState->freeze = 2;
     }
 }
 

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -1271,7 +1271,6 @@ s32 act_spawn_spin_airborne(struct MarioState *m) {
         if (m == &gMarioStates[0]) {
             load_level_init_text(0);
         }
-        m->freeze = 2;
         return set_water_plunge_action(m);
     }
 
@@ -1304,7 +1303,6 @@ s32 act_spawn_spin_landing(struct MarioState *m) {
         if (m == &gMarioStates[0]) {
             load_level_init_text(0);
         }
-        m->freeze = 2;
         set_mario_action(m, ACT_IDLE, 0);
     }
     return FALSE;
@@ -1557,7 +1555,6 @@ s32 act_spawn_no_spin_landing(struct MarioState *m) {
         if (m == &gMarioStates[0]) {
             load_level_init_text(0);
         }
-        m->freeze = 2;
         set_mario_action(m, ACT_IDLE, 0);
     }
     return FALSE;


### PR DESCRIPTION
Original issue introduced in https://github.com/coop-deluxe/sm64coopdx/pull/1109

Previously in an attempt to resolve an issue where Mario could move for one frame, I had set Mario to be frozen for 2 frames. The reason I picked 2 is because one frame later that is what Mario's freeze state is set to anyways. The issue with this was that Mario would freeze for 2 frames even if there was not a dialog. This is resolved by moving this section of code to where the dialog box is created