### PR TITLE
Undo more "fixes" introduced in yoshi pr

### DIFF
--- a/src/game/behaviors/spawn_star.inc.c
+++ b/src/game/behaviors/spawn_star.inc.c
@@ -91,7 +91,7 @@ void bhv_star_spawn_init(void) {
     o->oForwardVel = o->oStarSpawnDisFromHome / 30.0f;
     o->oStarSpawnUnkFC = o->oPosY;
 
-    if (o->oStarSpawnExtCutsceneFlags) {
+    if (o->oStarSpawnExtCutsceneFlags && ((gMarioStates[0].action & ACT_GROUP_MASK) != ACT_GROUP_CUTSCENE)) {
         if (o->oBehParams2ndByte == 0 || gCurrCourseNum == COURSE_BBH)
             cutscene_object(CUTSCENE_STAR_SPAWN, o);
         else

--- a/src/pc/network/packets/packet_level.c
+++ b/src/pc/network/packets/packet_level.c
@@ -80,9 +80,7 @@ void network_receive_level(struct Packet* p) {
     packet_read(p, &gMarioStates[0].numCoins, sizeof(s16));
     packet_read(p, &gPssSlideStarted,         sizeof(u8));
     packet_read(p, &gTTCSpeedSetting,         sizeof(s16));
-    if (gCurrCourseNum != COURSE_NONE) {
-        gHudDisplay.coins = gMarioStates[0].numCoins;
-    }
+    gHudDisplay.coins = gMarioStates[0].numCoins;
 
     // fix TTC objects by reinitializing values pertaining to speed
     if (levelNum == LEVEL_TTC) {


### PR DESCRIPTION
Fixes constant coin count increase in castle lobbies and resolves an issue with camera cutscenes that was introduced. While this undoes the "fixes" these changes were meant to implement, the "fixes" were meant to fix very old bugs, so they'll just stick around for longer.