### PR TITLE
address some error logging in object syncing code

### DIFF
--- a/src/pc/network/packets/packet_level_macro.c
+++ b/src/pc/network/packets/packet_level_macro.c
@@ -200,7 +200,10 @@ void network_receive_level_macro(struct Packet* p) {
                     struct Object* o2 = &gObjectPool[i];
                     if (o2->parentObj != o) { continue; }
                     if (o2 == o) { continue; }
-                    if (o2->behavior != smlua_override_behavior(bhvCoinFormationSpawn) && o2->behavior != smlua_override_behavior(bhvYellowCoin)) { continue; }
+                    if (o2->behavior != smlua_override_behavior(bhvCoinFormationSpawn) &&
+                        o2->behavior != smlua_override_behavior(bhvYellowCoin)) {
+                        continue;
+                    }
                     if (o->oCoinUnkF4 & (1 << childIndex++)) {
                         obj_mark_for_deletion(o2);
                     }

--- a/src/pc/network/packets/packet_object.c
+++ b/src/pc/network/packets/packet_object.c
@@ -139,7 +139,8 @@ static struct SyncObject* packet_read_object_header(struct Packet* p, u8* fromLo
     if (behavior == NULL) {
         LOG_ERROR("unable to find behavior %04X for id %d", behaviorId, syncId);
         return NULL;
-    } if (o->behavior != behavior && o->behavior != lBehavior && !allowable_behavior_change(so, behavior)) {
+    }
+    if (o->behavior != behavior && o->behavior != lBehavior && !allowable_behavior_change(so, behavior)) {
         enum BehaviorId objBehaviorId = get_id_from_behavior(o->behavior);
         enum BehaviorId soBehaviorId = get_id_from_behavior(so->behavior);
         LOG_ERROR(

--- a/src/pc/network/packets/packet_object.c
+++ b/src/pc/network/packets/packet_object.c
@@ -145,8 +145,8 @@ static struct SyncObject* packet_read_object_header(struct Packet* p, u8* fromLo
         enum BehaviorId soBehaviorId = get_id_from_behavior(so->behavior);
         LOG_ERROR(
             "during read behavior mismatch for %d: %04X (%s) vs %04X (%s)", syncId,
-            objBehaviorId,  get_behavior_name_from_id(objBehaviorId),
-            soBehaviorId, get_behavior_name_from_id(soBehaviorId)
+            objBehaviorId, get_behavior_name_from_id(objBehaviorId),
+            soBehaviorId,  get_behavior_name_from_id(soBehaviorId)
         );
         return NULL;
     }
@@ -303,8 +303,8 @@ void network_send_object(struct Object* o) {
         enum BehaviorId soBehaviorId = get_id_from_behavior(so->behavior);
         LOG_ERROR(
             "during send behavior mismatch for %d: %04X (%s) vs %04X (%s)", o->oSyncID,
-            objBehaviorId,  get_behavior_name_from_id(objBehaviorId),
-            soBehaviorId, get_behavior_name_from_id(soBehaviorId)
+            objBehaviorId, get_behavior_name_from_id(objBehaviorId),
+            soBehaviorId,  get_behavior_name_from_id(soBehaviorId)
         );
         sync_object_forget(so->id);
         return;
@@ -343,8 +343,8 @@ void network_send_object_reliability(struct Object* o, bool reliable) {
         enum BehaviorId soBehaviorId = get_id_from_behavior(so->behavior);
         LOG_ERROR(
             "during send reliability behavior mismatch for %d: %04X (%s) vs %04X (%s)", syncId,
-            objBehaviorId,  get_behavior_name_from_id(objBehaviorId),
-            soBehaviorId, get_behavior_name_from_id(soBehaviorId)
+            objBehaviorId, get_behavior_name_from_id(objBehaviorId),
+            soBehaviorId,  get_behavior_name_from_id(soBehaviorId)
         );
         sync_object_forget(so->id);
         return;

--- a/src/pc/network/packets/packet_object.c
+++ b/src/pc/network/packets/packet_object.c
@@ -142,11 +142,11 @@ static struct SyncObject* packet_read_object_header(struct Packet* p, u8* fromLo
     }
     if (o->behavior != behavior && o->behavior != lBehavior && !allowable_behavior_change(so, behavior)) {
         enum BehaviorId objBehaviorId = get_id_from_behavior(o->behavior);
-        enum BehaviorId soBehaviorId = get_id_from_behavior(so->behavior);
+        enum BehaviorId inBehaviorId = get_id_from_behavior(behavior);
         LOG_ERROR(
             "during read behavior mismatch for %d: %04X (%s) vs %04X (%s)", syncId,
             objBehaviorId, get_behavior_name_from_id(objBehaviorId),
-            soBehaviorId,  get_behavior_name_from_id(soBehaviorId)
+            inBehaviorId,  get_behavior_name_from_id(inBehaviorId)
         );
         return NULL;
     }
@@ -491,7 +491,10 @@ void network_update_objects(void) {
 
         // check for stale sync object
         if (so->o->oSyncID != so->id) {
-            if (so->o->activeFlags != ACTIVE_FLAG_DEACTIVATED) { // check if object was just deleted
+            // check if object was deleted
+            if (so->o->activeFlags != ACTIVE_FLAG_DEACTIVATED &&
+                so->o->behavior == so->behavior // a new object may be in this slot
+            ) {
                 enum BehaviorId bhvId = get_id_from_behavior(so->o->behavior);
                 const char* bhvName = get_behavior_name_from_id(bhvId);
                 LOG_ERROR("sync id mismatch: %d vs %d (behavior %s, %d)", so->o->oSyncID, so->id, bhvName != NULL ? bhvName : "NULL", bhvId);

--- a/src/pc/network/packets/packet_object.c
+++ b/src/pc/network/packets/packet_object.c
@@ -68,10 +68,14 @@ static bool allowable_behavior_change(struct SyncObject* so, BehaviorScript* beh
     struct Object* o = so->o;
 
     // bhvPenguinBaby can be set to bhvSmallPenguin
-    bool oBehaviorPenguin = (o->behavior == segmented_to_virtual(smlua_override_behavior(bhvPenguinBaby)) || o->behavior == segmented_to_virtual(smlua_override_behavior(bhvSmallPenguin)));
-    bool inBehaviorPenguin = (behavior == segmented_to_virtual(smlua_override_behavior(bhvPenguinBaby)) || behavior == segmented_to_virtual(smlua_override_behavior(bhvSmallPenguin)));
-    bool allow = (oBehaviorPenguin && inBehaviorPenguin);
+    bool oBehaviorPenguin = (o->behavior == smlua_override_behavior(bhvPenguinBaby) || o->behavior == smlua_override_behavior(bhvSmallPenguin));
+    bool inBehaviorPenguin = (behavior == smlua_override_behavior(bhvPenguinBaby) || behavior == smlua_override_behavior(bhvSmallPenguin));
 
+    // bhvCoinFormationSpawn can be set to bhvYellowCoin
+    bool oBehaviorCoin = (o->behavior == smlua_override_behavior(bhvCoinFormationSpawn) || o->behavior == smlua_override_behavior(bhvYellowCoin));
+    bool inBehaviorCoin = (behavior == smlua_override_behavior(bhvCoinFormationSpawn) || behavior == smlua_override_behavior(bhvYellowCoin));
+
+    bool allow = (oBehaviorPenguin && inBehaviorPenguin) || (oBehaviorCoin && inBehaviorCoin);
     if (!allow) { return false; }
 
     so->behavior = behavior;
@@ -136,7 +140,13 @@ static struct SyncObject* packet_read_object_header(struct Packet* p, u8* fromLo
         LOG_ERROR("unable to find behavior %04X for id %d", behaviorId, syncId);
         return NULL;
     } if (o->behavior != behavior && o->behavior != lBehavior && !allowable_behavior_change(so, behavior)) {
-        LOG_ERROR("behavior mismatch for %d: %04X vs %04X", syncId, get_id_from_behavior(o->behavior), get_id_from_behavior(behavior));
+        enum BehaviorId objBehaviorId = get_id_from_behavior(o->behavior);
+        enum BehaviorId soBehaviorId = get_id_from_behavior(so->behavior);
+        LOG_ERROR(
+            "during read behavior mismatch for %d: %04X (%s) vs %04X (%s)", syncId,
+            objBehaviorId,  get_behavior_name_from_id(objBehaviorId),
+            soBehaviorId, get_behavior_name_from_id(soBehaviorId)
+        );
         return NULL;
     }
 
@@ -288,7 +298,13 @@ void network_send_object(struct Object* o) {
         return;
     }
     if (o->behavior != so->behavior && !allowable_behavior_change(so, so->behavior)) {
-        LOG_ERROR("behavior mismatch for %d: %04X vs %04X", o->oSyncID, get_id_from_behavior(o->behavior), get_id_from_behavior(so->behavior));
+        enum BehaviorId objBehaviorId = get_id_from_behavior(o->behavior);
+        enum BehaviorId soBehaviorId = get_id_from_behavior(so->behavior);
+        LOG_ERROR(
+            "during send behavior mismatch for %d: %04X (%s) vs %04X (%s)", o->oSyncID,
+            objBehaviorId,  get_behavior_name_from_id(objBehaviorId),
+            soBehaviorId, get_behavior_name_from_id(soBehaviorId)
+        );
         sync_object_forget(so->id);
         return;
     }
@@ -322,7 +338,13 @@ void network_send_object_reliability(struct Object* o, bool reliable) {
         return;
     }
     if (o->behavior != so->behavior && !allowable_behavior_change(so, so->behavior)) {
-        LOG_ERROR("behavior mismatch for %d: %04X vs %04X", syncId, get_id_from_behavior(o->behavior), get_id_from_behavior(so->behavior));
+        enum BehaviorId objBehaviorId = get_id_from_behavior(o->behavior);
+        enum BehaviorId soBehaviorId = get_id_from_behavior(so->behavior);
+        LOG_ERROR(
+            "during send reliability behavior mismatch for %d: %04X (%s) vs %04X (%s)", syncId,
+            objBehaviorId,  get_behavior_name_from_id(objBehaviorId),
+            soBehaviorId, get_behavior_name_from_id(soBehaviorId)
+        );
         sync_object_forget(so->id);
         return;
     }


### PR DESCRIPTION
Previously would get "behavior mismatch" errors whenever you touch a coin from a formation.
It's actually correct to allow `bhvYellowCoin` and `bhvCoinFormationSpawn` to have a behavior mismatch, as they change behaviors mid execution. 
We already checked the penguin behaviors, this is the only other two that change behaviors mid execution.
Penguin uses `obj_set_behavior`, coin uses `cur_obj_set_behavior` - not very intuitive.
Tightened up the debugging logs there a bit too to catch these bugs easier next time.

verbose example of the error I was seeing after I cleaned up the logs:
```
Mon May 25 20:19:56 2026 [00] [ERROR] packet_object.c: during send behavior mismatch for 561: 0215 (bhvYellowCoin) vs 0088 (bhvCoinFormationSpawn)
```

Also, this PR fixes a bug which caused coop to complain of a "sync id mismatch" on deleted objects.
This was because the condition for deleted objects was incomplete. Checking if `activeFlags != ACTIVE_FLAG_DEACTIVATED` is not sufficient to know an object is deleted.
Since sm64 has an object pool that reuses slots, an object may be deleted and then another object fills it's place immediately. This is rather common. The solution is to also check that the behavior is the same. 
We still want to forget the sync object since it was indeed deleted, we just don't need to log the error.
Fun fact, the old bug where player models overrode the star model on the star select screen was caused by this exact issue (and the fix was the same, so I'm confident in this one).

Example of error:
```
Mon May 25 20:44:12 2026 [00] [ERROR] packet_object.c: sync id mismatch: 0 vs 611 (behavior bhvOmmSparklyStarSparklePlayer, 32769)
```
Note that `bhvOmmSparklyStarSparklePlayer` is never spawned as a sync object, further highlighting that this error log was a bug at play here.