### PR TITLE
fix dx11 compilation issues in levels with noise or alpha dithering

### DIFF
--- a/src/pc/gfx/gfx_direct3d_common.cpp
+++ b/src/pc/gfx/gfx_direct3d_common.cpp
@@ -153,7 +153,7 @@ void gfx_direct3d_common_build_shader(char buf[4096], size_t& len, size_t& num_f
         }
     }
     if ((cc.cm.use_alpha && cc.cm.use_dither) || ccf.do_noise) {
-        append_line(buf, &len, "    float4 screenPos : TEXCOORD1;");
+        append_line(buf, &len, "    float4 screenPos : SCREENPOS;");
     }
     if (cc.cm.use_fog) {
         append_line(buf, &len, "    float4 fog : FOG;");


### PR DESCRIPTION
Fix was quite simple, TEXCOORD1 was defined multiple times so changed the name to SCREENPOS. The reason we don't need to change the input element description is because `TEXCOORD1` wasn't actually set there anyways, so it can just be it's own thing. It has always been set here:

```cpp
append_line(buf, &len, ") {");
append_line(buf, &len, "    PSInput result;");
append_line(buf, &len, "    result.position = position;");
if ((cc.cm.use_alpha && cc.cm.use_dither) || ccf.do_noise) {
    append_line(buf, &len, "    result.screenPos = position;");
}
```

Tested by entering VCUTM, which would crash before but now works as intended