### PR TITLE
Add get_current_play_mode() and get_delayed_warp_op()

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -11859,6 +11859,18 @@ function is_transition_playing()
     -- ...
 end
 
+--- @return integer
+--- Gets the current play mode (`PLAY_MODE_*`)
+function get_current_play_mode()
+    -- ...
+end
+
+--- @return integer
+--- Gets the delayed warp operation type (`WARP_OP_*`)
+function get_delayed_warp_op()
+    -- ...
+end
+
 --- @param actFlags integer
 --- @return integer
 --- Allocates an action ID with bitwise flags

--- a/docs/lua/functions-7.md
+++ b/docs/lua/functions-7.md
@@ -2558,6 +2558,48 @@ Checks if a screen transition is playing
 
 <br />
 
+## [get_current_play_mode](#get_current_play_mode)
+
+### Description
+Gets the current play mode (`PLAY_MODE_*`)
+
+### Lua Example
+`local integerValue = get_current_play_mode()`
+
+### Parameters
+- None
+
+### Returns
+- `integer`
+
+### C Prototype
+`s16 get_current_play_mode(void);`
+
+[:arrow_up_small:](#)
+
+<br />
+
+## [get_delayed_warp_op](#get_delayed_warp_op)
+
+### Description
+Gets the delayed warp operation type (`WARP_OP_*`)
+
+### Lua Example
+`local integerValue = get_delayed_warp_op()`
+
+### Parameters
+- None
+
+### Returns
+- `integer`
+
+### C Prototype
+`s16 get_delayed_warp_op(void);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ## [allocate_mario_action](#allocate_mario_action)
 
 ### Description

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -2058,6 +2058,8 @@
    - [game_pause](functions-7.md#game_pause)
    - [game_unpause](functions-7.md#game_unpause)
    - [is_transition_playing](functions-7.md#is_transition_playing)
+   - [get_current_play_mode](functions-7.md#get_current_play_mode)
+   - [get_delayed_warp_op](functions-7.md#get_delayed_warp_op)
    - [allocate_mario_action](functions-7.md#allocate_mario_action)
    - [get_hand_foot_pos_x](functions-7.md#get_hand_foot_pos_x)
    - [get_hand_foot_pos_y](functions-7.md#get_hand_foot_pos_y)

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -34077,6 +34077,36 @@ int smlua_func_is_transition_playing(UNUSED lua_State* L) {
     return 1;
 }
 
+int smlua_func_get_current_play_mode(UNUSED lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 0) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "get_current_play_mode", 0, top);
+        return 0;
+    }
+
+
+    lua_pushinteger(L, get_current_play_mode());
+
+    return 1;
+}
+
+int smlua_func_get_delayed_warp_op(UNUSED lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 0) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "get_delayed_warp_op", 0, top);
+        return 0;
+    }
+
+
+    lua_pushinteger(L, get_delayed_warp_op());
+
+    return 1;
+}
+
 int smlua_func_allocate_mario_action(lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -39102,6 +39132,8 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "game_pause", smlua_func_game_pause);
     smlua_bind_function(L, "game_unpause", smlua_func_game_unpause);
     smlua_bind_function(L, "is_transition_playing", smlua_func_is_transition_playing);
+    smlua_bind_function(L, "get_current_play_mode", smlua_func_get_current_play_mode);
+    smlua_bind_function(L, "get_delayed_warp_op", smlua_func_get_delayed_warp_op);
     smlua_bind_function(L, "allocate_mario_action", smlua_func_allocate_mario_action);
     smlua_bind_function(L, "get_hand_foot_pos_x", smlua_func_get_hand_foot_pos_x);
     smlua_bind_function(L, "get_hand_foot_pos_y", smlua_func_get_hand_foot_pos_y);

--- a/src/pc/lua/utils/smlua_misc_utils.c
+++ b/src/pc/lua/utils/smlua_misc_utils.c
@@ -327,7 +327,17 @@ void game_unpause(void) {
 ///
 
 bool is_transition_playing(void) {
-    return sTransitionUpdate != NULL || gWarpTransition.isActive;
+    return gWarpTransition.isActive;
+}
+
+///
+
+s16 get_current_play_mode(void) {
+    return sCurrPlayMode;
+}
+
+s16 get_delayed_warp_op(void) {
+    return sDelayedWarpOp;
 }
 
 ///

--- a/src/pc/lua/utils/smlua_misc_utils.h
+++ b/src/pc/lua/utils/smlua_misc_utils.h
@@ -150,6 +150,11 @@ void game_unpause(void);
 /* |description|Checks if a screen transition is playing|descriptionEnd| */
 bool is_transition_playing(void);
 
+/* |description|Gets the current play mode (`PLAY_MODE_*`)|descriptionEnd| */
+s16 get_current_play_mode(void);
+/* |description|Gets the delayed warp operation type (`WARP_OP_*`)|descriptionEnd| */
+s16 get_delayed_warp_op(void);
+
 /* |description|Allocates an action ID with bitwise flags|descriptionEnd| */
 u32 allocate_mario_action(u32 actFlags);
 


### PR DESCRIPTION
I also set `is_transition_playing` to check `gWarpTransition.isActive` specifically. I tested with printing the result in the console and its the same to the version of the function with that extra check.
It's unnecessary and isActive is the way it should be checked, sTransitionUpdate is only specific instances that isActive all covers anyway lol