### PR TITLE
[v1.6] Fix UNUSED keyword usage in smlua function autogen

### DIFF
--- a/autogen/convert_functions.py
+++ b/autogen/convert_functions.py
@@ -973,10 +973,7 @@ def build_function(function, do_extern):
 
     fparams, freturns = split_function_parameters_and_returns(function)
 
-    if len(function['params']) <= 0:
-        s += 'int smlua_func_%s(UNUSED lua_State* L) {\n' % function['identifier']
-    else:
-        s += 'int smlua_func_%s(lua_State* L) {\n' % function['identifier']
+    s += 'int smlua_func_%s(lua_State* L) {\n' % function['identifier']
 
     # make sure the bhv functions have a current object
     fname = function['filename']

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -479,7 +479,7 @@ int smlua_func_area_get_warp_node(lua_State* L) {
     return 1;
 }
 
-int smlua_func_area_get_any_warp_node(UNUSED lua_State* L) {
+int smlua_func_area_get_any_warp_node(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -633,7 +633,7 @@ int smlua_func_spawn_triangle_break_particles(lua_State* L) {
     return 1;
 }
 
-int smlua_func_spawn_mist_from_global(UNUSED lua_State* L) {
+int smlua_func_spawn_mist_from_global(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -815,7 +815,7 @@ int smlua_func_cur_obj_spawn_strong_wind_particles(lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_star_door_loop_2(UNUSED lua_State* L) {
+int smlua_func_bhv_star_door_loop_2(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -831,7 +831,7 @@ int smlua_func_bhv_star_door_loop_2(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_cap_switch_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_cap_switch_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -847,7 +847,7 @@ int smlua_func_bhv_cap_switch_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tiny_star_particles_init(UNUSED lua_State* L) {
+int smlua_func_bhv_tiny_star_particles_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -863,7 +863,7 @@ int smlua_func_bhv_tiny_star_particles_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_grindel_thwomp_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_grindel_thwomp_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -879,7 +879,7 @@ int smlua_func_bhv_grindel_thwomp_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_koopa_shell_underwater_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_koopa_shell_underwater_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -895,7 +895,7 @@ int smlua_func_bhv_koopa_shell_underwater_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_door_init(UNUSED lua_State* L) {
+int smlua_func_bhv_door_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -911,7 +911,7 @@ int smlua_func_bhv_door_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_door_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_door_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -927,7 +927,7 @@ int smlua_func_bhv_door_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_star_door_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_star_door_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -943,7 +943,7 @@ int smlua_func_bhv_star_door_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_mr_i_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_mr_i_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -959,7 +959,7 @@ int smlua_func_bhv_mr_i_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_mr_i_body_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_mr_i_body_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -975,7 +975,7 @@ int smlua_func_bhv_mr_i_body_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_mr_i_particle_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_mr_i_particle_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -991,7 +991,7 @@ int smlua_func_bhv_mr_i_particle_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_piranha_particle_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_piranha_particle_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1007,7 +1007,7 @@ int smlua_func_bhv_piranha_particle_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_giant_pole_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_giant_pole_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1023,7 +1023,7 @@ int smlua_func_bhv_giant_pole_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pole_init(UNUSED lua_State* L) {
+int smlua_func_bhv_pole_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1039,7 +1039,7 @@ int smlua_func_bhv_pole_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pole_base_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_pole_base_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1055,7 +1055,7 @@ int smlua_func_bhv_pole_base_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_thi_huge_island_top_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_thi_huge_island_top_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1071,7 +1071,7 @@ int smlua_func_bhv_thi_huge_island_top_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_thi_tiny_island_top_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_thi_tiny_island_top_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1087,7 +1087,7 @@ int smlua_func_bhv_thi_tiny_island_top_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_king_bobomb_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_king_bobomb_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1103,7 +1103,7 @@ int smlua_func_bhv_king_bobomb_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bobomb_anchor_mario_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bobomb_anchor_mario_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1119,7 +1119,7 @@ int smlua_func_bhv_bobomb_anchor_mario_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_beta_chest_bottom_init(UNUSED lua_State* L) {
+int smlua_func_bhv_beta_chest_bottom_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1135,7 +1135,7 @@ int smlua_func_bhv_beta_chest_bottom_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_beta_chest_bottom_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_beta_chest_bottom_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1151,7 +1151,7 @@ int smlua_func_bhv_beta_chest_bottom_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_beta_chest_lid_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_beta_chest_lid_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1167,7 +1167,7 @@ int smlua_func_bhv_beta_chest_lid_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bubble_wave_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bubble_wave_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1183,7 +1183,7 @@ int smlua_func_bhv_bubble_wave_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bubble_maybe_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bubble_maybe_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1199,7 +1199,7 @@ int smlua_func_bhv_bubble_maybe_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bubble_player_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bubble_player_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1215,7 +1215,7 @@ int smlua_func_bhv_bubble_player_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_air_bubble_init(UNUSED lua_State* L) {
+int smlua_func_bhv_water_air_bubble_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1231,7 +1231,7 @@ int smlua_func_bhv_water_air_bubble_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_air_bubble_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_water_air_bubble_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1247,7 +1247,7 @@ int smlua_func_bhv_water_air_bubble_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_particle_init(UNUSED lua_State* L) {
+int smlua_func_bhv_particle_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1263,7 +1263,7 @@ int smlua_func_bhv_particle_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_particle_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_particle_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1279,7 +1279,7 @@ int smlua_func_bhv_particle_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_waves_init(UNUSED lua_State* L) {
+int smlua_func_bhv_water_waves_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1295,7 +1295,7 @@ int smlua_func_bhv_water_waves_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_small_bubbles_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_small_bubbles_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1311,7 +1311,7 @@ int smlua_func_bhv_small_bubbles_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_fish_group_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_fish_group_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1327,7 +1327,7 @@ int smlua_func_bhv_fish_group_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_cannon_base_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_cannon_base_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1343,7 +1343,7 @@ int smlua_func_bhv_cannon_base_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_cannon_barrel_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_cannon_barrel_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1359,7 +1359,7 @@ int smlua_func_bhv_cannon_barrel_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_cannon_base_unused_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_cannon_base_unused_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1396,7 +1396,7 @@ int smlua_func_common_anchor_mario_behavior(lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_chuckya_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_chuckya_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1412,7 +1412,7 @@ int smlua_func_bhv_chuckya_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_chuckya_anchor_mario_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_chuckya_anchor_mario_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1428,7 +1428,7 @@ int smlua_func_bhv_chuckya_anchor_mario_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_rotating_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_rotating_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1444,7 +1444,7 @@ int smlua_func_bhv_rotating_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wf_breakable_wall_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_wf_breakable_wall_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1460,7 +1460,7 @@ int smlua_func_bhv_wf_breakable_wall_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_kickable_board_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_kickable_board_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1476,7 +1476,7 @@ int smlua_func_bhv_kickable_board_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tower_door_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_tower_door_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1492,7 +1492,7 @@ int smlua_func_bhv_tower_door_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wf_rotating_wooden_platform_init(UNUSED lua_State* L) {
+int smlua_func_bhv_wf_rotating_wooden_platform_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1508,7 +1508,7 @@ int smlua_func_bhv_wf_rotating_wooden_platform_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wf_rotating_wooden_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_wf_rotating_wooden_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1524,7 +1524,7 @@ int smlua_func_bhv_wf_rotating_wooden_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_fading_warp_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_fading_warp_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1540,7 +1540,7 @@ int smlua_func_bhv_fading_warp_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_warp_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_warp_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1556,7 +1556,7 @@ int smlua_func_bhv_warp_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_white_puff_exploding_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_white_puff_exploding_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1572,7 +1572,7 @@ int smlua_func_bhv_white_puff_exploding_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_spawned_star_init(UNUSED lua_State* L) {
+int smlua_func_bhv_spawned_star_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1588,7 +1588,7 @@ int smlua_func_bhv_spawned_star_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_spawned_star_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_spawned_star_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1604,7 +1604,7 @@ int smlua_func_bhv_spawned_star_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_coin_init(UNUSED lua_State* L) {
+int smlua_func_bhv_coin_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1620,7 +1620,7 @@ int smlua_func_bhv_coin_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_coin_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_coin_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1636,7 +1636,7 @@ int smlua_func_bhv_coin_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_coin_inside_boo_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_coin_inside_boo_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1652,7 +1652,7 @@ int smlua_func_bhv_coin_inside_boo_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_coin_formation_init(UNUSED lua_State* L) {
+int smlua_func_bhv_coin_formation_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1668,7 +1668,7 @@ int smlua_func_bhv_coin_formation_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_coin_formation_spawn_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_coin_formation_spawn_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1684,7 +1684,7 @@ int smlua_func_bhv_coin_formation_spawn_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_coin_formation_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_coin_formation_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1700,7 +1700,7 @@ int smlua_func_bhv_coin_formation_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_temp_coin_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_temp_coin_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1716,7 +1716,7 @@ int smlua_func_bhv_temp_coin_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_coin_sparkles_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_coin_sparkles_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1732,7 +1732,7 @@ int smlua_func_bhv_coin_sparkles_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_golden_coin_sparkles_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_golden_coin_sparkles_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1748,7 +1748,7 @@ int smlua_func_bhv_golden_coin_sparkles_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wall_tiny_star_particle_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_wall_tiny_star_particle_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1764,7 +1764,7 @@ int smlua_func_bhv_wall_tiny_star_particle_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pound_tiny_star_particle_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_pound_tiny_star_particle_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1780,7 +1780,7 @@ int smlua_func_bhv_pound_tiny_star_particle_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pound_tiny_star_particle_init(UNUSED lua_State* L) {
+int smlua_func_bhv_pound_tiny_star_particle_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1796,7 +1796,7 @@ int smlua_func_bhv_pound_tiny_star_particle_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_punch_tiny_triangle_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_punch_tiny_triangle_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1812,7 +1812,7 @@ int smlua_func_bhv_punch_tiny_triangle_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_punch_tiny_triangle_init(UNUSED lua_State* L) {
+int smlua_func_bhv_punch_tiny_triangle_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1828,7 +1828,7 @@ int smlua_func_bhv_punch_tiny_triangle_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tumbling_bridge_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_tumbling_bridge_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1844,7 +1844,7 @@ int smlua_func_bhv_tumbling_bridge_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tumbling_bridge_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_tumbling_bridge_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1860,7 +1860,7 @@ int smlua_func_bhv_tumbling_bridge_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_elevator_init(UNUSED lua_State* L) {
+int smlua_func_bhv_elevator_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1876,7 +1876,7 @@ int smlua_func_bhv_elevator_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_elevator_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_elevator_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1892,7 +1892,7 @@ int smlua_func_bhv_elevator_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_mist_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_water_mist_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1908,7 +1908,7 @@ int smlua_func_bhv_water_mist_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_mist_spawn_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_water_mist_spawn_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1924,7 +1924,7 @@ int smlua_func_bhv_water_mist_spawn_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_mist_2_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_water_mist_2_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1940,7 +1940,7 @@ int smlua_func_bhv_water_mist_2_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pound_white_puffs_init(UNUSED lua_State* L) {
+int smlua_func_bhv_pound_white_puffs_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1956,7 +1956,7 @@ int smlua_func_bhv_pound_white_puffs_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ground_sand_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ground_sand_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1972,7 +1972,7 @@ int smlua_func_bhv_ground_sand_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ground_snow_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ground_snow_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -1988,7 +1988,7 @@ int smlua_func_bhv_ground_snow_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wind_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_wind_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2004,7 +2004,7 @@ int smlua_func_bhv_wind_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_unused_particle_spawn_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_unused_particle_spawn_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2020,7 +2020,7 @@ int smlua_func_bhv_unused_particle_spawn_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ukiki_cage_star_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_ukiki_cage_star_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2036,7 +2036,7 @@ int smlua_func_bhv_ukiki_cage_star_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ukiki_cage_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_ukiki_cage_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2052,7 +2052,7 @@ int smlua_func_bhv_ukiki_cage_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bitfs_sinking_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bitfs_sinking_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2068,7 +2068,7 @@ int smlua_func_bhv_bitfs_sinking_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bitfs_sinking_cage_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bitfs_sinking_cage_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2084,7 +2084,7 @@ int smlua_func_bhv_bitfs_sinking_cage_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ddd_moving_pole_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_ddd_moving_pole_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2100,7 +2100,7 @@ int smlua_func_bhv_ddd_moving_pole_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_platform_normals_init(UNUSED lua_State* L) {
+int smlua_func_bhv_platform_normals_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2116,7 +2116,7 @@ int smlua_func_bhv_platform_normals_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tilting_inverted_pyramid_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_tilting_inverted_pyramid_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2132,7 +2132,7 @@ int smlua_func_bhv_tilting_inverted_pyramid_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_squishable_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_squishable_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2148,7 +2148,7 @@ int smlua_func_bhv_squishable_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_beta_moving_flames_spawn_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_beta_moving_flames_spawn_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2164,7 +2164,7 @@ int smlua_func_bhv_beta_moving_flames_spawn_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_beta_moving_flames_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_beta_moving_flames_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2180,7 +2180,7 @@ int smlua_func_bhv_beta_moving_flames_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_rr_rotating_bridge_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_rr_rotating_bridge_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2196,7 +2196,7 @@ int smlua_func_bhv_rr_rotating_bridge_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_flamethrower_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_flamethrower_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2212,7 +2212,7 @@ int smlua_func_bhv_flamethrower_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_flamethrower_flame_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_flamethrower_flame_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2228,7 +2228,7 @@ int smlua_func_bhv_flamethrower_flame_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bouncing_fireball_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bouncing_fireball_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2244,7 +2244,7 @@ int smlua_func_bhv_bouncing_fireball_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bouncing_fireball_flame_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bouncing_fireball_flame_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2260,7 +2260,7 @@ int smlua_func_bhv_bouncing_fireball_flame_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_shock_wave_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_shock_wave_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2276,7 +2276,7 @@ int smlua_func_bhv_bowser_shock_wave_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_flame_mario_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_flame_mario_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2292,7 +2292,7 @@ int smlua_func_bhv_flame_mario_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_black_smoke_mario_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_black_smoke_mario_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2308,7 +2308,7 @@ int smlua_func_bhv_black_smoke_mario_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_black_smoke_bowser_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_black_smoke_bowser_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2324,7 +2324,7 @@ int smlua_func_bhv_black_smoke_bowser_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_black_smoke_upward_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_black_smoke_upward_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2340,7 +2340,7 @@ int smlua_func_bhv_black_smoke_upward_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_beta_fish_splash_spawner_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_beta_fish_splash_spawner_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2356,7 +2356,7 @@ int smlua_func_bhv_beta_fish_splash_spawner_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_spindrift_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_spindrift_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2372,7 +2372,7 @@ int smlua_func_bhv_spindrift_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tower_platform_group_init(UNUSED lua_State* L) {
+int smlua_func_bhv_tower_platform_group_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2388,7 +2388,7 @@ int smlua_func_bhv_tower_platform_group_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tower_platform_group_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_tower_platform_group_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2404,7 +2404,7 @@ int smlua_func_bhv_tower_platform_group_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wf_sliding_tower_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_wf_sliding_tower_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2420,7 +2420,7 @@ int smlua_func_bhv_wf_sliding_tower_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wf_elevator_tower_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_wf_elevator_tower_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2436,7 +2436,7 @@ int smlua_func_bhv_wf_elevator_tower_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wf_solid_tower_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_wf_solid_tower_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2452,7 +2452,7 @@ int smlua_func_bhv_wf_solid_tower_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_snow_leaf_particle_spawn_init(UNUSED lua_State* L) {
+int smlua_func_bhv_snow_leaf_particle_spawn_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2468,7 +2468,7 @@ int smlua_func_bhv_snow_leaf_particle_spawn_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tree_snow_or_leaf_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_tree_snow_or_leaf_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2484,7 +2484,7 @@ int smlua_func_bhv_tree_snow_or_leaf_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_piranha_plant_bubble_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_piranha_plant_bubble_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2500,7 +2500,7 @@ int smlua_func_bhv_piranha_plant_bubble_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_piranha_plant_waking_bubbles_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_piranha_plant_waking_bubbles_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2516,7 +2516,7 @@ int smlua_func_bhv_piranha_plant_waking_bubbles_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_purple_switch_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_purple_switch_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2532,7 +2532,7 @@ int smlua_func_bhv_purple_switch_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_hidden_object_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_hidden_object_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2548,7 +2548,7 @@ int smlua_func_bhv_hidden_object_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_breakable_box_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_breakable_box_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2564,7 +2564,7 @@ int smlua_func_bhv_breakable_box_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pushable_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_pushable_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2580,7 +2580,7 @@ int smlua_func_bhv_pushable_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_small_water_wave_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_small_water_wave_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2596,7 +2596,7 @@ int smlua_func_bhv_small_water_wave_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_yellow_coin_init(UNUSED lua_State* L) {
+int smlua_func_bhv_yellow_coin_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2612,7 +2612,7 @@ int smlua_func_bhv_yellow_coin_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_yellow_coin_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_yellow_coin_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2628,7 +2628,7 @@ int smlua_func_bhv_yellow_coin_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_squarish_path_moving_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_squarish_path_moving_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2644,7 +2644,7 @@ int smlua_func_bhv_squarish_path_moving_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_squarish_path_parent_init(UNUSED lua_State* L) {
+int smlua_func_bhv_squarish_path_parent_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2660,7 +2660,7 @@ int smlua_func_bhv_squarish_path_parent_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_squarish_path_parent_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_squarish_path_parent_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2676,7 +2676,7 @@ int smlua_func_bhv_squarish_path_parent_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_heave_ho_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_heave_ho_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2692,7 +2692,7 @@ int smlua_func_bhv_heave_ho_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_heave_ho_throw_mario_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_heave_ho_throw_mario_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2708,7 +2708,7 @@ int smlua_func_bhv_heave_ho_throw_mario_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ccm_touched_star_spawn_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_ccm_touched_star_spawn_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2724,7 +2724,7 @@ int smlua_func_bhv_ccm_touched_star_spawn_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_unused_poundable_platform(UNUSED lua_State* L) {
+int smlua_func_bhv_unused_poundable_platform(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2740,7 +2740,7 @@ int smlua_func_bhv_unused_poundable_platform(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_beta_trampoline_top_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_beta_trampoline_top_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2756,7 +2756,7 @@ int smlua_func_bhv_beta_trampoline_top_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_beta_trampoline_spring_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_beta_trampoline_spring_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2772,7 +2772,7 @@ int smlua_func_bhv_beta_trampoline_spring_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_jumping_box_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_jumping_box_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2788,7 +2788,7 @@ int smlua_func_bhv_jumping_box_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_boo_cage_init(UNUSED lua_State* L) {
+int smlua_func_bhv_boo_cage_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2804,7 +2804,7 @@ int smlua_func_bhv_boo_cage_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_boo_cage_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_boo_cage_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2820,7 +2820,7 @@ int smlua_func_bhv_boo_cage_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_key_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_key_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2836,7 +2836,7 @@ int smlua_func_bhv_bowser_key_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_key_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_key_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2852,7 +2852,7 @@ int smlua_func_bhv_bowser_key_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_grand_star_init(UNUSED lua_State* L) {
+int smlua_func_bhv_grand_star_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2868,7 +2868,7 @@ int smlua_func_bhv_grand_star_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_grand_star_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_grand_star_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2884,7 +2884,7 @@ int smlua_func_bhv_grand_star_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_beta_boo_key_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_beta_boo_key_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2900,7 +2900,7 @@ int smlua_func_bhv_beta_boo_key_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_alpha_boo_key_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_alpha_boo_key_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2916,7 +2916,7 @@ int smlua_func_bhv_alpha_boo_key_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bullet_bill_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bullet_bill_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2932,7 +2932,7 @@ int smlua_func_bhv_bullet_bill_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bullet_bill_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bullet_bill_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2948,7 +2948,7 @@ int smlua_func_bhv_bullet_bill_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_white_puff_smoke_init(UNUSED lua_State* L) {
+int smlua_func_bhv_white_puff_smoke_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2964,7 +2964,7 @@ int smlua_func_bhv_white_puff_smoke_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_tail_anchor_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_tail_anchor_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2980,7 +2980,7 @@ int smlua_func_bhv_bowser_tail_anchor_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_tail_anchor_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_tail_anchor_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -2996,7 +2996,7 @@ int smlua_func_bhv_bowser_tail_anchor_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3012,7 +3012,7 @@ int smlua_func_bhv_bowser_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3028,7 +3028,7 @@ int smlua_func_bhv_bowser_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_body_anchor_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_body_anchor_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3044,7 +3044,7 @@ int smlua_func_bhv_bowser_body_anchor_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_body_anchor_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_body_anchor_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3060,7 +3060,7 @@ int smlua_func_bhv_bowser_body_anchor_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_flame_spawn_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_flame_spawn_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3076,7 +3076,7 @@ int smlua_func_bhv_bowser_flame_spawn_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tilting_bowser_lava_platform_init(UNUSED lua_State* L) {
+int smlua_func_bhv_tilting_bowser_lava_platform_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3092,7 +3092,7 @@ int smlua_func_bhv_tilting_bowser_lava_platform_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_falling_bowser_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_falling_bowser_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3108,7 +3108,7 @@ int smlua_func_bhv_falling_bowser_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_blue_bowser_flame_init(UNUSED lua_State* L) {
+int smlua_func_bhv_blue_bowser_flame_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3124,7 +3124,7 @@ int smlua_func_bhv_blue_bowser_flame_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_blue_bowser_flame_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_blue_bowser_flame_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3140,7 +3140,7 @@ int smlua_func_bhv_blue_bowser_flame_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_flame_floating_landing_init(UNUSED lua_State* L) {
+int smlua_func_bhv_flame_floating_landing_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3156,7 +3156,7 @@ int smlua_func_bhv_flame_floating_landing_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_flame_floating_landing_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_flame_floating_landing_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3172,7 +3172,7 @@ int smlua_func_bhv_flame_floating_landing_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_blue_flames_group_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_blue_flames_group_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3188,7 +3188,7 @@ int smlua_func_bhv_blue_flames_group_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_flame_bouncing_init(UNUSED lua_State* L) {
+int smlua_func_bhv_flame_bouncing_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3204,7 +3204,7 @@ int smlua_func_bhv_flame_bouncing_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_flame_bouncing_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_flame_bouncing_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3220,7 +3220,7 @@ int smlua_func_bhv_flame_bouncing_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_flame_moving_forward_growing_init(UNUSED lua_State* L) {
+int smlua_func_bhv_flame_moving_forward_growing_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3236,7 +3236,7 @@ int smlua_func_bhv_flame_moving_forward_growing_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_flame_moving_forward_growing_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_flame_moving_forward_growing_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3252,7 +3252,7 @@ int smlua_func_bhv_flame_moving_forward_growing_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_flame_bowser_init(UNUSED lua_State* L) {
+int smlua_func_bhv_flame_bowser_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3268,7 +3268,7 @@ int smlua_func_bhv_flame_bowser_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_flame_bowser_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_flame_bowser_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3284,7 +3284,7 @@ int smlua_func_bhv_flame_bowser_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_flame_large_burning_out_init(UNUSED lua_State* L) {
+int smlua_func_bhv_flame_large_burning_out_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3300,7 +3300,7 @@ int smlua_func_bhv_flame_large_burning_out_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_blue_fish_movement_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_blue_fish_movement_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3316,7 +3316,7 @@ int smlua_func_bhv_blue_fish_movement_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tank_fish_group_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_tank_fish_group_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3332,7 +3332,7 @@ int smlua_func_bhv_tank_fish_group_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_checkerboard_elevator_group_init(UNUSED lua_State* L) {
+int smlua_func_bhv_checkerboard_elevator_group_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3348,7 +3348,7 @@ int smlua_func_bhv_checkerboard_elevator_group_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_checkerboard_elevator_group_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_checkerboard_elevator_group_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3364,7 +3364,7 @@ int smlua_func_bhv_checkerboard_elevator_group_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_checkerboard_platform_init(UNUSED lua_State* L) {
+int smlua_func_bhv_checkerboard_platform_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3380,7 +3380,7 @@ int smlua_func_bhv_checkerboard_platform_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_checkerboard_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_checkerboard_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3396,7 +3396,7 @@ int smlua_func_bhv_checkerboard_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_key_unlock_door_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_key_unlock_door_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3412,7 +3412,7 @@ int smlua_func_bhv_bowser_key_unlock_door_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_key_course_exit_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_key_course_exit_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3428,7 +3428,7 @@ int smlua_func_bhv_bowser_key_course_exit_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_invisible_objects_under_bridge_init(UNUSED lua_State* L) {
+int smlua_func_bhv_invisible_objects_under_bridge_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3444,7 +3444,7 @@ int smlua_func_bhv_invisible_objects_under_bridge_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_invisible_objects_under_bridge_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_invisible_objects_under_bridge_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3460,7 +3460,7 @@ int smlua_func_bhv_invisible_objects_under_bridge_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_level_pillar_init(UNUSED lua_State* L) {
+int smlua_func_bhv_water_level_pillar_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3476,7 +3476,7 @@ int smlua_func_bhv_water_level_pillar_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_level_pillar_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_water_level_pillar_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3492,7 +3492,7 @@ int smlua_func_bhv_water_level_pillar_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ddd_warp_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_ddd_warp_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3508,7 +3508,7 @@ int smlua_func_bhv_ddd_warp_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_moat_grills_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_moat_grills_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3524,7 +3524,7 @@ int smlua_func_bhv_moat_grills_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_rotating_clock_arm_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_rotating_clock_arm_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3540,7 +3540,7 @@ int smlua_func_bhv_rotating_clock_arm_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ukiki_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ukiki_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3556,7 +3556,7 @@ int smlua_func_bhv_ukiki_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ukiki_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_ukiki_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3572,7 +3572,7 @@ int smlua_func_bhv_ukiki_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_sinking_rock_block_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_sinking_rock_block_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3588,7 +3588,7 @@ int smlua_func_bhv_lll_sinking_rock_block_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_moving_octagonal_mesh_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_moving_octagonal_mesh_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3604,7 +3604,7 @@ int smlua_func_bhv_lll_moving_octagonal_mesh_platform_loop(UNUSED lua_State* L) 
     return 1;
 }
 
-int smlua_func_bhv_lll_rotating_block_fire_bars_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_rotating_block_fire_bars_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3620,7 +3620,7 @@ int smlua_func_bhv_lll_rotating_block_fire_bars_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_rotating_hex_flame_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_rotating_hex_flame_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3636,7 +3636,7 @@ int smlua_func_bhv_lll_rotating_hex_flame_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_wood_piece_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_wood_piece_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3652,7 +3652,7 @@ int smlua_func_bhv_lll_wood_piece_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_floating_wood_bridge_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_floating_wood_bridge_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3668,7 +3668,7 @@ int smlua_func_bhv_lll_floating_wood_bridge_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_volcano_flames_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_volcano_flames_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3684,7 +3684,7 @@ int smlua_func_bhv_volcano_flames_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_rotating_hexagonal_ring_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_rotating_hexagonal_ring_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3700,7 +3700,7 @@ int smlua_func_bhv_lll_rotating_hexagonal_ring_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_sinking_rectangular_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_sinking_rectangular_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3716,7 +3716,7 @@ int smlua_func_bhv_lll_sinking_rectangular_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_sinking_square_platforms_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_sinking_square_platforms_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3732,7 +3732,7 @@ int smlua_func_bhv_lll_sinking_square_platforms_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_koopa_shell_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_koopa_shell_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3748,7 +3748,7 @@ int smlua_func_bhv_koopa_shell_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_koopa_shell_flame_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_koopa_shell_flame_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3764,7 +3764,7 @@ int smlua_func_bhv_koopa_shell_flame_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tox_box_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_tox_box_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3780,7 +3780,7 @@ int smlua_func_bhv_tox_box_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_mario_moving_fast_enough_to_make_piranha_plant_bite(UNUSED lua_State* L) {
+int smlua_func_mario_moving_fast_enough_to_make_piranha_plant_bite(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -3795,7 +3795,7 @@ int smlua_func_mario_moving_fast_enough_to_make_piranha_plant_bite(UNUSED lua_St
     return 1;
 }
 
-int smlua_func_bhv_piranha_plant_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_piranha_plant_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3811,7 +3811,7 @@ int smlua_func_bhv_piranha_plant_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_bowser_puzzle_piece_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_bowser_puzzle_piece_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3827,7 +3827,7 @@ int smlua_func_bhv_lll_bowser_puzzle_piece_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_bowser_puzzle_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_bowser_puzzle_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3843,7 +3843,7 @@ int smlua_func_bhv_lll_bowser_puzzle_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tuxies_mother_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_tuxies_mother_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3859,7 +3859,7 @@ int smlua_func_bhv_tuxies_mother_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_small_penguin_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_small_penguin_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3875,7 +3875,7 @@ int smlua_func_bhv_small_penguin_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_fish_spawner_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_fish_spawner_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3891,7 +3891,7 @@ int smlua_func_bhv_fish_spawner_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_fish_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_fish_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3907,7 +3907,7 @@ int smlua_func_bhv_fish_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wdw_express_elevator_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_wdw_express_elevator_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3923,7 +3923,7 @@ int smlua_func_bhv_wdw_express_elevator_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bub_spawner_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bub_spawner_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3939,7 +3939,7 @@ int smlua_func_bhv_bub_spawner_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bub_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bub_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3955,7 +3955,7 @@ int smlua_func_bhv_bub_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_exclamation_box_init(UNUSED lua_State* L) {
+int smlua_func_bhv_exclamation_box_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3971,7 +3971,7 @@ int smlua_func_bhv_exclamation_box_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_exclamation_box_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_exclamation_box_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -3987,7 +3987,7 @@ int smlua_func_bhv_exclamation_box_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_rotating_exclamation_box_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_rotating_exclamation_box_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4003,7 +4003,7 @@ int smlua_func_bhv_rotating_exclamation_box_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_sound_spawner_init(UNUSED lua_State* L) {
+int smlua_func_bhv_sound_spawner_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4019,7 +4019,7 @@ int smlua_func_bhv_sound_spawner_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowsers_sub_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowsers_sub_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4035,7 +4035,7 @@ int smlua_func_bhv_bowsers_sub_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_sushi_shark_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_sushi_shark_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4051,7 +4051,7 @@ int smlua_func_bhv_sushi_shark_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_sushi_shark_collision_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_sushi_shark_collision_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4067,7 +4067,7 @@ int smlua_func_bhv_sushi_shark_collision_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_jrb_sliding_box_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_jrb_sliding_box_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4083,7 +4083,7 @@ int smlua_func_bhv_jrb_sliding_box_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ship_part_3_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_ship_part_3_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4099,7 +4099,7 @@ int smlua_func_bhv_ship_part_3_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_sunken_ship_part_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_sunken_ship_part_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4115,7 +4115,7 @@ int smlua_func_bhv_sunken_ship_part_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_white_puff_1_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_white_puff_1_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4131,7 +4131,7 @@ int smlua_func_bhv_white_puff_1_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_white_puff_2_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_white_puff_2_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4147,7 +4147,7 @@ int smlua_func_bhv_white_puff_2_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_blue_coin_number_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_blue_coin_number_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4163,7 +4163,7 @@ int smlua_func_bhv_blue_coin_number_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_blue_coin_switch_init(UNUSED lua_State* L) {
+int smlua_func_bhv_blue_coin_switch_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4179,7 +4179,7 @@ int smlua_func_bhv_blue_coin_switch_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_blue_coin_switch_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_blue_coin_switch_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4195,7 +4195,7 @@ int smlua_func_bhv_blue_coin_switch_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_hidden_blue_coin_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_hidden_blue_coin_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4211,7 +4211,7 @@ int smlua_func_bhv_hidden_blue_coin_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_openable_cage_door_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_openable_cage_door_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4227,7 +4227,7 @@ int smlua_func_bhv_openable_cage_door_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_openable_grill_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_openable_grill_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4243,7 +4243,7 @@ int smlua_func_bhv_openable_grill_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_level_diamond_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_water_level_diamond_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4259,7 +4259,7 @@ int smlua_func_bhv_water_level_diamond_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_init_changing_water_level_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_init_changing_water_level_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4275,7 +4275,7 @@ int smlua_func_bhv_init_changing_water_level_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tweester_sand_particle_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_tweester_sand_particle_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4291,7 +4291,7 @@ int smlua_func_bhv_tweester_sand_particle_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_tweester_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_tweester_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4307,7 +4307,7 @@ int smlua_func_bhv_tweester_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_merry_go_round_boo_manager_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_merry_go_round_boo_manager_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4323,7 +4323,7 @@ int smlua_func_bhv_merry_go_round_boo_manager_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_animated_texture_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_animated_texture_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4339,7 +4339,7 @@ int smlua_func_bhv_animated_texture_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_boo_in_castle_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_boo_in_castle_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4355,7 +4355,7 @@ int smlua_func_bhv_boo_in_castle_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_boo_with_cage_init(UNUSED lua_State* L) {
+int smlua_func_bhv_boo_with_cage_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4371,7 +4371,7 @@ int smlua_func_bhv_boo_with_cage_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_boo_with_cage_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_boo_with_cage_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4387,7 +4387,7 @@ int smlua_func_bhv_boo_with_cage_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_boo_init(UNUSED lua_State* L) {
+int smlua_func_bhv_boo_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4403,7 +4403,7 @@ int smlua_func_bhv_boo_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_big_boo_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_big_boo_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4419,7 +4419,7 @@ int smlua_func_bhv_big_boo_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_courtyard_boo_triplet_init(UNUSED lua_State* L) {
+int smlua_func_bhv_courtyard_boo_triplet_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4435,7 +4435,7 @@ int smlua_func_bhv_courtyard_boo_triplet_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_obj_set_secondary_camera_focus(UNUSED lua_State* L) {
+int smlua_func_obj_set_secondary_camera_focus(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -4450,7 +4450,7 @@ int smlua_func_obj_set_secondary_camera_focus(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_boo_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_boo_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4466,7 +4466,7 @@ int smlua_func_bhv_boo_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_boo_boss_spawned_bridge_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_boo_boss_spawned_bridge_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4482,7 +4482,7 @@ int smlua_func_bhv_boo_boss_spawned_bridge_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bbh_tilting_trap_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bbh_tilting_trap_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4498,7 +4498,7 @@ int smlua_func_bhv_bbh_tilting_trap_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_haunted_bookshelf_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_haunted_bookshelf_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4514,7 +4514,7 @@ int smlua_func_bhv_haunted_bookshelf_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_merry_go_round_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_merry_go_round_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4531,7 +4531,7 @@ int smlua_func_bhv_merry_go_round_loop(UNUSED lua_State* L) {
 }
 
 #ifndef VERSION_JP
-int smlua_func_bhv_play_music_track_when_touched_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_play_music_track_when_touched_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4548,7 +4548,7 @@ int smlua_func_bhv_play_music_track_when_touched_loop(UNUSED lua_State* L) {
 }
 #endif
 
-int smlua_func_bhv_beta_bowser_anchor_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_beta_bowser_anchor_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4564,7 +4564,7 @@ int smlua_func_bhv_beta_bowser_anchor_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_static_checkered_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_static_checkered_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4580,7 +4580,7 @@ int smlua_func_bhv_static_checkered_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_castle_floor_trap_init(UNUSED lua_State* L) {
+int smlua_func_bhv_castle_floor_trap_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4596,7 +4596,7 @@ int smlua_func_bhv_castle_floor_trap_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_castle_floor_trap_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_castle_floor_trap_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4612,7 +4612,7 @@ int smlua_func_bhv_castle_floor_trap_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_floor_trap_in_castle_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_floor_trap_in_castle_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4628,7 +4628,7 @@ int smlua_func_bhv_floor_trap_in_castle_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_sparkle_spawn_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_sparkle_spawn_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4644,7 +4644,7 @@ int smlua_func_bhv_sparkle_spawn_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_scuttlebug_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_scuttlebug_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4660,7 +4660,7 @@ int smlua_func_bhv_scuttlebug_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_scuttlebug_spawn_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_scuttlebug_spawn_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4676,7 +4676,7 @@ int smlua_func_bhv_scuttlebug_spawn_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_whomp_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_whomp_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4692,7 +4692,7 @@ int smlua_func_bhv_whomp_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_splash_spawn_droplets(UNUSED lua_State* L) {
+int smlua_func_bhv_water_splash_spawn_droplets(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4708,7 +4708,7 @@ int smlua_func_bhv_water_splash_spawn_droplets(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_droplet_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_water_droplet_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4724,7 +4724,7 @@ int smlua_func_bhv_water_droplet_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_droplet_splash_init(UNUSED lua_State* L) {
+int smlua_func_bhv_water_droplet_splash_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4740,7 +4740,7 @@ int smlua_func_bhv_water_droplet_splash_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bubble_splash_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bubble_splash_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4756,7 +4756,7 @@ int smlua_func_bhv_bubble_splash_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_idle_water_wave_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_idle_water_wave_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4772,7 +4772,7 @@ int smlua_func_bhv_idle_water_wave_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_shallow_water_splash_init(UNUSED lua_State* L) {
+int smlua_func_bhv_shallow_water_splash_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4788,7 +4788,7 @@ int smlua_func_bhv_shallow_water_splash_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wave_trail_shrink(UNUSED lua_State* L) {
+int smlua_func_bhv_wave_trail_shrink(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4804,7 +4804,7 @@ int smlua_func_bhv_wave_trail_shrink(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_strong_wind_particle_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_strong_wind_particle_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4820,7 +4820,7 @@ int smlua_func_bhv_strong_wind_particle_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_sl_snowman_wind_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_sl_snowman_wind_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4836,7 +4836,7 @@ int smlua_func_bhv_sl_snowman_wind_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_sl_walking_penguin_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_sl_walking_penguin_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4852,7 +4852,7 @@ int smlua_func_bhv_sl_walking_penguin_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_menu_button_init(UNUSED lua_State* L) {
+int smlua_func_bhv_menu_button_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4868,7 +4868,7 @@ int smlua_func_bhv_menu_button_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_menu_button_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_menu_button_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4884,7 +4884,7 @@ int smlua_func_bhv_menu_button_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_menu_button_manager_init(UNUSED lua_State* L) {
+int smlua_func_bhv_menu_button_manager_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4900,7 +4900,7 @@ int smlua_func_bhv_menu_button_manager_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_menu_button_manager_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_menu_button_manager_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4916,7 +4916,7 @@ int smlua_func_bhv_menu_button_manager_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_act_selector_star_type_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_act_selector_star_type_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4932,7 +4932,7 @@ int smlua_func_bhv_act_selector_star_type_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_act_selector_init(UNUSED lua_State* L) {
+int smlua_func_bhv_act_selector_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4948,7 +4948,7 @@ int smlua_func_bhv_act_selector_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_act_selector_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_act_selector_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4964,7 +4964,7 @@ int smlua_func_bhv_act_selector_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_moving_yellow_coin_init(UNUSED lua_State* L) {
+int smlua_func_bhv_moving_yellow_coin_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4980,7 +4980,7 @@ int smlua_func_bhv_moving_yellow_coin_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_moving_yellow_coin_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_moving_yellow_coin_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -4996,7 +4996,7 @@ int smlua_func_bhv_moving_yellow_coin_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_moving_blue_coin_init(UNUSED lua_State* L) {
+int smlua_func_bhv_moving_blue_coin_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5012,7 +5012,7 @@ int smlua_func_bhv_moving_blue_coin_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_moving_blue_coin_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_moving_blue_coin_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5028,7 +5028,7 @@ int smlua_func_bhv_moving_blue_coin_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_blue_coin_sliding_jumping_init(UNUSED lua_State* L) {
+int smlua_func_bhv_blue_coin_sliding_jumping_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5044,7 +5044,7 @@ int smlua_func_bhv_blue_coin_sliding_jumping_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_blue_coin_sliding_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_blue_coin_sliding_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5060,7 +5060,7 @@ int smlua_func_bhv_blue_coin_sliding_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_blue_coin_jumping_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_blue_coin_jumping_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5076,7 +5076,7 @@ int smlua_func_bhv_blue_coin_jumping_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_seaweed_init(UNUSED lua_State* L) {
+int smlua_func_bhv_seaweed_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5092,7 +5092,7 @@ int smlua_func_bhv_seaweed_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_seaweed_bundle_init(UNUSED lua_State* L) {
+int smlua_func_bhv_seaweed_bundle_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5108,7 +5108,7 @@ int smlua_func_bhv_seaweed_bundle_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bobomb_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bobomb_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5124,7 +5124,7 @@ int smlua_func_bhv_bobomb_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bobomb_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bobomb_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5140,7 +5140,7 @@ int smlua_func_bhv_bobomb_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bobomb_fuse_smoke_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bobomb_fuse_smoke_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5156,7 +5156,7 @@ int smlua_func_bhv_bobomb_fuse_smoke_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bobomb_buddy_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bobomb_buddy_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5172,7 +5172,7 @@ int smlua_func_bhv_bobomb_buddy_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bobomb_buddy_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bobomb_buddy_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5188,7 +5188,7 @@ int smlua_func_bhv_bobomb_buddy_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_cannon_closed_init(UNUSED lua_State* L) {
+int smlua_func_bhv_cannon_closed_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5204,7 +5204,7 @@ int smlua_func_bhv_cannon_closed_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_cannon_closed_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_cannon_closed_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5220,7 +5220,7 @@ int smlua_func_bhv_cannon_closed_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_whirlpool_init(UNUSED lua_State* L) {
+int smlua_func_bhv_whirlpool_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5236,7 +5236,7 @@ int smlua_func_bhv_whirlpool_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_whirlpool_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_whirlpool_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5252,7 +5252,7 @@ int smlua_func_bhv_whirlpool_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_jet_stream_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_jet_stream_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5268,7 +5268,7 @@ int smlua_func_bhv_jet_stream_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_homing_amp_init(UNUSED lua_State* L) {
+int smlua_func_bhv_homing_amp_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5284,7 +5284,7 @@ int smlua_func_bhv_homing_amp_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_homing_amp_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_homing_amp_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5300,7 +5300,7 @@ int smlua_func_bhv_homing_amp_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_circling_amp_init(UNUSED lua_State* L) {
+int smlua_func_bhv_circling_amp_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5316,7 +5316,7 @@ int smlua_func_bhv_circling_amp_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_circling_amp_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_circling_amp_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5332,7 +5332,7 @@ int smlua_func_bhv_circling_amp_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_butterfly_init(UNUSED lua_State* L) {
+int smlua_func_bhv_butterfly_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5348,7 +5348,7 @@ int smlua_func_bhv_butterfly_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_butterfly_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_butterfly_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5364,7 +5364,7 @@ int smlua_func_bhv_butterfly_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_hoot_init(UNUSED lua_State* L) {
+int smlua_func_bhv_hoot_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5380,7 +5380,7 @@ int smlua_func_bhv_hoot_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_hoot_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_hoot_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5396,7 +5396,7 @@ int smlua_func_bhv_hoot_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_beta_holdable_object_init(UNUSED lua_State* L) {
+int smlua_func_bhv_beta_holdable_object_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5412,7 +5412,7 @@ int smlua_func_bhv_beta_holdable_object_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_beta_holdable_object_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_beta_holdable_object_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5428,7 +5428,7 @@ int smlua_func_bhv_beta_holdable_object_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_object_bubble_init(UNUSED lua_State* L) {
+int smlua_func_bhv_object_bubble_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5444,7 +5444,7 @@ int smlua_func_bhv_object_bubble_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_object_bubble_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_object_bubble_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5460,7 +5460,7 @@ int smlua_func_bhv_object_bubble_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_object_water_wave_init(UNUSED lua_State* L) {
+int smlua_func_bhv_object_water_wave_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5476,7 +5476,7 @@ int smlua_func_bhv_object_water_wave_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_object_water_wave_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_object_water_wave_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5492,7 +5492,7 @@ int smlua_func_bhv_object_water_wave_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_explosion_init(UNUSED lua_State* L) {
+int smlua_func_bhv_explosion_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5508,7 +5508,7 @@ int smlua_func_bhv_explosion_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_explosion_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_explosion_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5524,7 +5524,7 @@ int smlua_func_bhv_explosion_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bobomb_bully_death_smoke_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bobomb_bully_death_smoke_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5540,7 +5540,7 @@ int smlua_func_bhv_bobomb_bully_death_smoke_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bobomb_explosion_bubble_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bobomb_explosion_bubble_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5556,7 +5556,7 @@ int smlua_func_bhv_bobomb_explosion_bubble_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bobomb_explosion_bubble_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bobomb_explosion_bubble_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5572,7 +5572,7 @@ int smlua_func_bhv_bobomb_explosion_bubble_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_respawner_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_respawner_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5588,7 +5588,7 @@ int smlua_func_bhv_respawner_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_small_bully_init(UNUSED lua_State* L) {
+int smlua_func_bhv_small_bully_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5604,7 +5604,7 @@ int smlua_func_bhv_small_bully_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bully_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bully_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5620,7 +5620,7 @@ int smlua_func_bhv_bully_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_big_bully_init(UNUSED lua_State* L) {
+int smlua_func_bhv_big_bully_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5636,7 +5636,7 @@ int smlua_func_bhv_big_bully_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_big_bully_with_minions_init(UNUSED lua_State* L) {
+int smlua_func_bhv_big_bully_with_minions_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5652,7 +5652,7 @@ int smlua_func_bhv_big_bully_with_minions_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_big_bully_with_minions_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_big_bully_with_minions_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5668,7 +5668,7 @@ int smlua_func_bhv_big_bully_with_minions_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_jet_stream_ring_spawner_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_jet_stream_ring_spawner_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5684,7 +5684,7 @@ int smlua_func_bhv_jet_stream_ring_spawner_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_jet_stream_water_ring_init(UNUSED lua_State* L) {
+int smlua_func_bhv_jet_stream_water_ring_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5700,7 +5700,7 @@ int smlua_func_bhv_jet_stream_water_ring_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_jet_stream_water_ring_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_jet_stream_water_ring_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5716,7 +5716,7 @@ int smlua_func_bhv_jet_stream_water_ring_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_manta_ray_water_ring_init(UNUSED lua_State* L) {
+int smlua_func_bhv_manta_ray_water_ring_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5732,7 +5732,7 @@ int smlua_func_bhv_manta_ray_water_ring_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_manta_ray_water_ring_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_manta_ray_water_ring_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5748,7 +5748,7 @@ int smlua_func_bhv_manta_ray_water_ring_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_bomb_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_bomb_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5764,7 +5764,7 @@ int smlua_func_bhv_bowser_bomb_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_bomb_explosion_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_bomb_explosion_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5780,7 +5780,7 @@ int smlua_func_bhv_bowser_bomb_explosion_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_bomb_smoke_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_bomb_smoke_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5796,7 +5796,7 @@ int smlua_func_bhv_bowser_bomb_smoke_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_celebration_star_init(UNUSED lua_State* L) {
+int smlua_func_bhv_celebration_star_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5812,7 +5812,7 @@ int smlua_func_bhv_celebration_star_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_celebration_star_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_celebration_star_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5828,7 +5828,7 @@ int smlua_func_bhv_celebration_star_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_celebration_star_sparkle_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_celebration_star_sparkle_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5844,7 +5844,7 @@ int smlua_func_bhv_celebration_star_sparkle_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_star_key_collection_puff_spawner_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_star_key_collection_puff_spawner_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5860,7 +5860,7 @@ int smlua_func_bhv_star_key_collection_puff_spawner_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_drawbridge_spawner_init(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_drawbridge_spawner_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5876,7 +5876,7 @@ int smlua_func_bhv_lll_drawbridge_spawner_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_drawbridge_spawner_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_drawbridge_spawner_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5892,7 +5892,7 @@ int smlua_func_bhv_lll_drawbridge_spawner_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_drawbridge_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_drawbridge_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5908,7 +5908,7 @@ int smlua_func_bhv_lll_drawbridge_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_small_bomp_init(UNUSED lua_State* L) {
+int smlua_func_bhv_small_bomp_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5924,7 +5924,7 @@ int smlua_func_bhv_small_bomp_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_small_bomp_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_small_bomp_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5940,7 +5940,7 @@ int smlua_func_bhv_small_bomp_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_large_bomp_init(UNUSED lua_State* L) {
+int smlua_func_bhv_large_bomp_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5956,7 +5956,7 @@ int smlua_func_bhv_large_bomp_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_large_bomp_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_large_bomp_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5972,7 +5972,7 @@ int smlua_func_bhv_large_bomp_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wf_sliding_platform_init(UNUSED lua_State* L) {
+int smlua_func_bhv_wf_sliding_platform_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -5988,7 +5988,7 @@ int smlua_func_bhv_wf_sliding_platform_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wf_sliding_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_wf_sliding_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6004,7 +6004,7 @@ int smlua_func_bhv_wf_sliding_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_moneybag_init(UNUSED lua_State* L) {
+int smlua_func_bhv_moneybag_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6020,7 +6020,7 @@ int smlua_func_bhv_moneybag_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_moneybag_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_moneybag_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6036,7 +6036,7 @@ int smlua_func_bhv_moneybag_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_moneybag_hidden_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_moneybag_hidden_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6052,7 +6052,7 @@ int smlua_func_bhv_moneybag_hidden_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bob_pit_bowling_ball_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bob_pit_bowling_ball_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6068,7 +6068,7 @@ int smlua_func_bhv_bob_pit_bowling_ball_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bob_pit_bowling_ball_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bob_pit_bowling_ball_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6084,7 +6084,7 @@ int smlua_func_bhv_bob_pit_bowling_ball_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_free_bowling_ball_init(UNUSED lua_State* L) {
+int smlua_func_bhv_free_bowling_ball_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6100,7 +6100,7 @@ int smlua_func_bhv_free_bowling_ball_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_free_bowling_ball_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_free_bowling_ball_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6116,7 +6116,7 @@ int smlua_func_bhv_free_bowling_ball_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowling_ball_init(UNUSED lua_State* L) {
+int smlua_func_bhv_bowling_ball_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6132,7 +6132,7 @@ int smlua_func_bhv_bowling_ball_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowling_ball_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowling_ball_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6148,7 +6148,7 @@ int smlua_func_bhv_bowling_ball_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_generic_bowling_ball_spawner_init(UNUSED lua_State* L) {
+int smlua_func_bhv_generic_bowling_ball_spawner_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6164,7 +6164,7 @@ int smlua_func_bhv_generic_bowling_ball_spawner_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_generic_bowling_ball_spawner_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_generic_bowling_ball_spawner_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6180,7 +6180,7 @@ int smlua_func_bhv_generic_bowling_ball_spawner_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_thi_bowling_ball_spawner_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_thi_bowling_ball_spawner_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6196,7 +6196,7 @@ int smlua_func_bhv_thi_bowling_ball_spawner_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_rr_cruiser_wing_init(UNUSED lua_State* L) {
+int smlua_func_bhv_rr_cruiser_wing_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6212,7 +6212,7 @@ int smlua_func_bhv_rr_cruiser_wing_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_rr_cruiser_wing_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_rr_cruiser_wing_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6228,7 +6228,7 @@ int smlua_func_bhv_rr_cruiser_wing_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_spindel_init(UNUSED lua_State* L) {
+int smlua_func_bhv_spindel_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6244,7 +6244,7 @@ int smlua_func_bhv_spindel_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_spindel_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_spindel_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6260,7 +6260,7 @@ int smlua_func_bhv_spindel_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ssl_moving_pyramid_wall_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ssl_moving_pyramid_wall_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6276,7 +6276,7 @@ int smlua_func_bhv_ssl_moving_pyramid_wall_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ssl_moving_pyramid_wall_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_ssl_moving_pyramid_wall_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6292,7 +6292,7 @@ int smlua_func_bhv_ssl_moving_pyramid_wall_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pyramid_elevator_init(UNUSED lua_State* L) {
+int smlua_func_bhv_pyramid_elevator_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6308,7 +6308,7 @@ int smlua_func_bhv_pyramid_elevator_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pyramid_elevator_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_pyramid_elevator_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6324,7 +6324,7 @@ int smlua_func_bhv_pyramid_elevator_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pyramid_elevator_trajectory_marker_ball_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_pyramid_elevator_trajectory_marker_ball_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6340,7 +6340,7 @@ int smlua_func_bhv_pyramid_elevator_trajectory_marker_ball_loop(UNUSED lua_State
     return 1;
 }
 
-int smlua_func_bhv_pyramid_top_init(UNUSED lua_State* L) {
+int smlua_func_bhv_pyramid_top_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6356,7 +6356,7 @@ int smlua_func_bhv_pyramid_top_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pyramid_top_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_pyramid_top_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6372,7 +6372,7 @@ int smlua_func_bhv_pyramid_top_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pyramid_top_fragment_init(UNUSED lua_State* L) {
+int smlua_func_bhv_pyramid_top_fragment_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6388,7 +6388,7 @@ int smlua_func_bhv_pyramid_top_fragment_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pyramid_top_fragment_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_pyramid_top_fragment_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6404,7 +6404,7 @@ int smlua_func_bhv_pyramid_top_fragment_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pyramid_pillar_touch_detector_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_pyramid_pillar_touch_detector_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6420,7 +6420,7 @@ int smlua_func_bhv_pyramid_pillar_touch_detector_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_waterfall_sound_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_waterfall_sound_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6436,7 +6436,7 @@ int smlua_func_bhv_waterfall_sound_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_volcano_sound_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_volcano_sound_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6452,7 +6452,7 @@ int smlua_func_bhv_volcano_sound_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_castle_flag_init(UNUSED lua_State* L) {
+int smlua_func_bhv_castle_flag_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6468,7 +6468,7 @@ int smlua_func_bhv_castle_flag_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_birds_sound_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_birds_sound_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6484,7 +6484,7 @@ int smlua_func_bhv_birds_sound_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ambient_sounds_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ambient_sounds_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6500,7 +6500,7 @@ int smlua_func_bhv_ambient_sounds_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_sand_sound_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_sand_sound_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6516,7 +6516,7 @@ int smlua_func_bhv_sand_sound_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_castle_cannon_grate_init(UNUSED lua_State* L) {
+int smlua_func_bhv_castle_cannon_grate_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6532,7 +6532,7 @@ int smlua_func_bhv_castle_cannon_grate_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_snowmans_bottom_init(UNUSED lua_State* L) {
+int smlua_func_bhv_snowmans_bottom_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6548,7 +6548,7 @@ int smlua_func_bhv_snowmans_bottom_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_snowmans_bottom_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_snowmans_bottom_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6564,7 +6564,7 @@ int smlua_func_bhv_snowmans_bottom_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_snowmans_head_init(UNUSED lua_State* L) {
+int smlua_func_bhv_snowmans_head_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6580,7 +6580,7 @@ int smlua_func_bhv_snowmans_head_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_snowmans_head_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_snowmans_head_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6596,7 +6596,7 @@ int smlua_func_bhv_snowmans_head_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_snowmans_body_checkpoint_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_snowmans_body_checkpoint_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6612,7 +6612,7 @@ int smlua_func_bhv_snowmans_body_checkpoint_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_big_boulder_init(UNUSED lua_State* L) {
+int smlua_func_bhv_big_boulder_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6628,7 +6628,7 @@ int smlua_func_bhv_big_boulder_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_big_boulder_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_big_boulder_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6644,7 +6644,7 @@ int smlua_func_bhv_big_boulder_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_big_boulder_generator_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_big_boulder_generator_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6660,7 +6660,7 @@ int smlua_func_bhv_big_boulder_generator_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wing_cap_init(UNUSED lua_State* L) {
+int smlua_func_bhv_wing_cap_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6676,7 +6676,7 @@ int smlua_func_bhv_wing_cap_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wing_vanish_cap_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_wing_vanish_cap_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6692,7 +6692,7 @@ int smlua_func_bhv_wing_vanish_cap_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_metal_cap_init(UNUSED lua_State* L) {
+int smlua_func_bhv_metal_cap_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6708,7 +6708,7 @@ int smlua_func_bhv_metal_cap_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_metal_cap_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_metal_cap_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6724,7 +6724,7 @@ int smlua_func_bhv_metal_cap_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_normal_cap_init(UNUSED lua_State* L) {
+int smlua_func_bhv_normal_cap_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6740,7 +6740,7 @@ int smlua_func_bhv_normal_cap_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_normal_cap_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_normal_cap_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6756,7 +6756,7 @@ int smlua_func_bhv_normal_cap_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_vanish_cap_init(UNUSED lua_State* L) {
+int smlua_func_bhv_vanish_cap_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6772,7 +6772,7 @@ int smlua_func_bhv_vanish_cap_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_star_number_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_star_number_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6788,7 +6788,7 @@ int smlua_func_bhv_star_number_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_spawn_star_number(UNUSED lua_State* L) {
+int smlua_func_spawn_star_number(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -6803,7 +6803,7 @@ int smlua_func_spawn_star_number(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_collect_star_init(UNUSED lua_State* L) {
+int smlua_func_bhv_collect_star_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6819,7 +6819,7 @@ int smlua_func_bhv_collect_star_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_collect_star_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_collect_star_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6835,7 +6835,7 @@ int smlua_func_bhv_collect_star_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_star_spawn_init(UNUSED lua_State* L) {
+int smlua_func_bhv_star_spawn_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6851,7 +6851,7 @@ int smlua_func_bhv_star_spawn_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_star_spawn_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_star_spawn_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6867,7 +6867,7 @@ int smlua_func_bhv_star_spawn_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_hidden_red_coin_star_init(UNUSED lua_State* L) {
+int smlua_func_bhv_hidden_red_coin_star_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6883,7 +6883,7 @@ int smlua_func_bhv_hidden_red_coin_star_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_hidden_red_coin_star_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_hidden_red_coin_star_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6899,7 +6899,7 @@ int smlua_func_bhv_hidden_red_coin_star_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_red_coin_init(UNUSED lua_State* L) {
+int smlua_func_bhv_red_coin_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6915,7 +6915,7 @@ int smlua_func_bhv_red_coin_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_red_coin_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_red_coin_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6931,7 +6931,7 @@ int smlua_func_bhv_red_coin_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bowser_course_red_coin_star_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bowser_course_red_coin_star_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6947,7 +6947,7 @@ int smlua_func_bhv_bowser_course_red_coin_star_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_hidden_star_init(UNUSED lua_State* L) {
+int smlua_func_bhv_hidden_star_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6963,7 +6963,7 @@ int smlua_func_bhv_hidden_star_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_hidden_star_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_hidden_star_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6979,7 +6979,7 @@ int smlua_func_bhv_hidden_star_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_hidden_star_trigger_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_hidden_star_trigger_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -6995,7 +6995,7 @@ int smlua_func_bhv_hidden_star_trigger_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttm_rolling_log_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ttm_rolling_log_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7011,7 +7011,7 @@ int smlua_func_bhv_ttm_rolling_log_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_rolling_log_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_rolling_log_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7027,7 +7027,7 @@ int smlua_func_bhv_rolling_log_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_lll_rolling_log_init(UNUSED lua_State* L) {
+int smlua_func_bhv_lll_rolling_log_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7043,7 +7043,7 @@ int smlua_func_bhv_lll_rolling_log_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_1up_trigger_init(UNUSED lua_State* L) {
+int smlua_func_bhv_1up_trigger_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7059,7 +7059,7 @@ int smlua_func_bhv_1up_trigger_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_1up_common_init(UNUSED lua_State* L) {
+int smlua_func_bhv_1up_common_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7075,7 +7075,7 @@ int smlua_func_bhv_1up_common_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_1up_walking_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_1up_walking_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7091,7 +7091,7 @@ int smlua_func_bhv_1up_walking_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_1up_running_away_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_1up_running_away_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7107,7 +7107,7 @@ int smlua_func_bhv_1up_running_away_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_1up_sliding_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_1up_sliding_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7123,7 +7123,7 @@ int smlua_func_bhv_1up_sliding_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_1up_init(UNUSED lua_State* L) {
+int smlua_func_bhv_1up_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7139,7 +7139,7 @@ int smlua_func_bhv_1up_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_1up_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_1up_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7155,7 +7155,7 @@ int smlua_func_bhv_1up_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_1up_jump_on_approach_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_1up_jump_on_approach_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7171,7 +7171,7 @@ int smlua_func_bhv_1up_jump_on_approach_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_1up_hidden_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_1up_hidden_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7187,7 +7187,7 @@ int smlua_func_bhv_1up_hidden_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_1up_hidden_trigger_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_1up_hidden_trigger_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7203,7 +7203,7 @@ int smlua_func_bhv_1up_hidden_trigger_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_1up_hidden_in_pole_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_1up_hidden_in_pole_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7219,7 +7219,7 @@ int smlua_func_bhv_1up_hidden_in_pole_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_1up_hidden_in_pole_trigger_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_1up_hidden_in_pole_trigger_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7235,7 +7235,7 @@ int smlua_func_bhv_1up_hidden_in_pole_trigger_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_1up_hidden_in_pole_spawner_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_1up_hidden_in_pole_spawner_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7251,7 +7251,7 @@ int smlua_func_bhv_1up_hidden_in_pole_spawner_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_controllable_platform_init(UNUSED lua_State* L) {
+int smlua_func_bhv_controllable_platform_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7267,7 +7267,7 @@ int smlua_func_bhv_controllable_platform_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_controllable_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_controllable_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7283,7 +7283,7 @@ int smlua_func_bhv_controllable_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_controllable_platform_sub_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_controllable_platform_sub_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7299,7 +7299,7 @@ int smlua_func_bhv_controllable_platform_sub_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_breakable_box_small_init(UNUSED lua_State* L) {
+int smlua_func_bhv_breakable_box_small_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7315,7 +7315,7 @@ int smlua_func_bhv_breakable_box_small_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_breakable_box_small_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_breakable_box_small_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7331,7 +7331,7 @@ int smlua_func_bhv_breakable_box_small_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_sliding_snow_mound_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_sliding_snow_mound_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7347,7 +7347,7 @@ int smlua_func_bhv_sliding_snow_mound_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_snow_mound_spawn_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_snow_mound_spawn_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7363,7 +7363,7 @@ int smlua_func_bhv_snow_mound_spawn_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_floating_platform_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_floating_platform_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7379,7 +7379,7 @@ int smlua_func_bhv_floating_platform_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_arrow_lift_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_arrow_lift_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7395,7 +7395,7 @@ int smlua_func_bhv_arrow_lift_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_orange_number_init(UNUSED lua_State* L) {
+int smlua_func_bhv_orange_number_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7411,7 +7411,7 @@ int smlua_func_bhv_orange_number_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_orange_number_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_orange_number_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7427,7 +7427,7 @@ int smlua_func_bhv_orange_number_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_manta_ray_init(UNUSED lua_State* L) {
+int smlua_func_bhv_manta_ray_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7443,7 +7443,7 @@ int smlua_func_bhv_manta_ray_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_manta_ray_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_manta_ray_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7459,7 +7459,7 @@ int smlua_func_bhv_manta_ray_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_falling_pillar_init(UNUSED lua_State* L) {
+int smlua_func_bhv_falling_pillar_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7475,7 +7475,7 @@ int smlua_func_bhv_falling_pillar_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_falling_pillar_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_falling_pillar_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7491,7 +7491,7 @@ int smlua_func_bhv_falling_pillar_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_falling_pillar_hitbox_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_falling_pillar_hitbox_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7507,7 +7507,7 @@ int smlua_func_bhv_falling_pillar_hitbox_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_jrb_floating_box_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_jrb_floating_box_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7523,7 +7523,7 @@ int smlua_func_bhv_jrb_floating_box_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_decorative_pendulum_init(UNUSED lua_State* L) {
+int smlua_func_bhv_decorative_pendulum_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7539,7 +7539,7 @@ int smlua_func_bhv_decorative_pendulum_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_decorative_pendulum_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_decorative_pendulum_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7555,7 +7555,7 @@ int smlua_func_bhv_decorative_pendulum_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_treasure_chest_ship_init(UNUSED lua_State* L) {
+int smlua_func_bhv_treasure_chest_ship_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7571,7 +7571,7 @@ int smlua_func_bhv_treasure_chest_ship_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_treasure_chest_ship_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_treasure_chest_ship_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7587,7 +7587,7 @@ int smlua_func_bhv_treasure_chest_ship_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_treasure_chest_jrb_init(UNUSED lua_State* L) {
+int smlua_func_bhv_treasure_chest_jrb_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7603,7 +7603,7 @@ int smlua_func_bhv_treasure_chest_jrb_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_treasure_chest_jrb_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_treasure_chest_jrb_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7619,7 +7619,7 @@ int smlua_func_bhv_treasure_chest_jrb_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_treasure_chest_init(UNUSED lua_State* L) {
+int smlua_func_bhv_treasure_chest_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7635,7 +7635,7 @@ int smlua_func_bhv_treasure_chest_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_treasure_chest_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_treasure_chest_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7651,7 +7651,7 @@ int smlua_func_bhv_treasure_chest_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_treasure_chest_bottom_init(UNUSED lua_State* L) {
+int smlua_func_bhv_treasure_chest_bottom_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7667,7 +7667,7 @@ int smlua_func_bhv_treasure_chest_bottom_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_treasure_chest_bottom_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_treasure_chest_bottom_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7683,7 +7683,7 @@ int smlua_func_bhv_treasure_chest_bottom_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_treasure_chest_top_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_treasure_chest_top_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7699,7 +7699,7 @@ int smlua_func_bhv_treasure_chest_top_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_mips_init(UNUSED lua_State* L) {
+int smlua_func_bhv_mips_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7715,7 +7715,7 @@ int smlua_func_bhv_mips_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_mips_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_mips_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7731,7 +7731,7 @@ int smlua_func_bhv_mips_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_yoshi_init(UNUSED lua_State* L) {
+int smlua_func_bhv_yoshi_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7747,7 +7747,7 @@ int smlua_func_bhv_yoshi_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_koopa_init(UNUSED lua_State* L) {
+int smlua_func_bhv_koopa_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7763,7 +7763,7 @@ int smlua_func_bhv_koopa_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_koopa_update(UNUSED lua_State* L) {
+int smlua_func_bhv_koopa_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7779,7 +7779,7 @@ int smlua_func_bhv_koopa_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_koopa_race_endpoint_update(UNUSED lua_State* L) {
+int smlua_func_bhv_koopa_race_endpoint_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7795,7 +7795,7 @@ int smlua_func_bhv_koopa_race_endpoint_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pokey_update(UNUSED lua_State* L) {
+int smlua_func_bhv_pokey_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7811,7 +7811,7 @@ int smlua_func_bhv_pokey_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_pokey_body_part_update(UNUSED lua_State* L) {
+int smlua_func_bhv_pokey_body_part_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7827,7 +7827,7 @@ int smlua_func_bhv_pokey_body_part_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_swoop_update(UNUSED lua_State* L) {
+int smlua_func_bhv_swoop_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7843,7 +7843,7 @@ int smlua_func_bhv_swoop_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_fly_guy_update(UNUSED lua_State* L) {
+int smlua_func_bhv_fly_guy_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7859,7 +7859,7 @@ int smlua_func_bhv_fly_guy_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_goomba_init(UNUSED lua_State* L) {
+int smlua_func_bhv_goomba_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7875,7 +7875,7 @@ int smlua_func_bhv_goomba_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_goomba_update(UNUSED lua_State* L) {
+int smlua_func_bhv_goomba_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7891,7 +7891,7 @@ int smlua_func_bhv_goomba_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_goomba_triplet_spawner_update(UNUSED lua_State* L) {
+int smlua_func_bhv_goomba_triplet_spawner_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7907,7 +7907,7 @@ int smlua_func_bhv_goomba_triplet_spawner_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_chain_chomp_update(UNUSED lua_State* L) {
+int smlua_func_bhv_chain_chomp_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7923,7 +7923,7 @@ int smlua_func_bhv_chain_chomp_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_chain_chomp_chain_part_update(UNUSED lua_State* L) {
+int smlua_func_bhv_chain_chomp_chain_part_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7939,7 +7939,7 @@ int smlua_func_bhv_chain_chomp_chain_part_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wooden_post_update(UNUSED lua_State* L) {
+int smlua_func_bhv_wooden_post_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7955,7 +7955,7 @@ int smlua_func_bhv_wooden_post_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_chain_chomp_gate_init(UNUSED lua_State* L) {
+int smlua_func_bhv_chain_chomp_gate_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7971,7 +7971,7 @@ int smlua_func_bhv_chain_chomp_gate_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_chain_chomp_gate_update(UNUSED lua_State* L) {
+int smlua_func_bhv_chain_chomp_gate_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -7987,7 +7987,7 @@ int smlua_func_bhv_chain_chomp_gate_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wiggler_update(UNUSED lua_State* L) {
+int smlua_func_bhv_wiggler_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8003,7 +8003,7 @@ int smlua_func_bhv_wiggler_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_wiggler_body_part_update(UNUSED lua_State* L) {
+int smlua_func_bhv_wiggler_body_part_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8019,7 +8019,7 @@ int smlua_func_bhv_wiggler_body_part_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_enemy_lakitu_update(UNUSED lua_State* L) {
+int smlua_func_bhv_enemy_lakitu_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8035,7 +8035,7 @@ int smlua_func_bhv_enemy_lakitu_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_camera_lakitu_init(UNUSED lua_State* L) {
+int smlua_func_bhv_camera_lakitu_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8051,7 +8051,7 @@ int smlua_func_bhv_camera_lakitu_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_camera_lakitu_update(UNUSED lua_State* L) {
+int smlua_func_bhv_camera_lakitu_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8067,7 +8067,7 @@ int smlua_func_bhv_camera_lakitu_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_cloud_update(UNUSED lua_State* L) {
+int smlua_func_bhv_cloud_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8083,7 +8083,7 @@ int smlua_func_bhv_cloud_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_cloud_part_update(UNUSED lua_State* L) {
+int smlua_func_bhv_cloud_part_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8099,7 +8099,7 @@ int smlua_func_bhv_cloud_part_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_spiny_update(UNUSED lua_State* L) {
+int smlua_func_bhv_spiny_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8115,7 +8115,7 @@ int smlua_func_bhv_spiny_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_monty_mole_init(UNUSED lua_State* L) {
+int smlua_func_bhv_monty_mole_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8131,7 +8131,7 @@ int smlua_func_bhv_monty_mole_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_monty_mole_update(UNUSED lua_State* L) {
+int smlua_func_bhv_monty_mole_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8147,7 +8147,7 @@ int smlua_func_bhv_monty_mole_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_monty_mole_hole_update(UNUSED lua_State* L) {
+int smlua_func_bhv_monty_mole_hole_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8163,7 +8163,7 @@ int smlua_func_bhv_monty_mole_hole_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_monty_mole_rock_update(UNUSED lua_State* L) {
+int smlua_func_bhv_monty_mole_rock_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8179,7 +8179,7 @@ int smlua_func_bhv_monty_mole_rock_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_platform_on_track_init(UNUSED lua_State* L) {
+int smlua_func_bhv_platform_on_track_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8195,7 +8195,7 @@ int smlua_func_bhv_platform_on_track_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_platform_on_track_update(UNUSED lua_State* L) {
+int smlua_func_bhv_platform_on_track_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8211,7 +8211,7 @@ int smlua_func_bhv_platform_on_track_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_track_ball_update(UNUSED lua_State* L) {
+int smlua_func_bhv_track_ball_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8227,7 +8227,7 @@ int smlua_func_bhv_track_ball_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_seesaw_platform_init(UNUSED lua_State* L) {
+int smlua_func_bhv_seesaw_platform_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8243,7 +8243,7 @@ int smlua_func_bhv_seesaw_platform_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_seesaw_platform_update(UNUSED lua_State* L) {
+int smlua_func_bhv_seesaw_platform_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8259,7 +8259,7 @@ int smlua_func_bhv_seesaw_platform_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ferris_wheel_axle_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ferris_wheel_axle_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8275,7 +8275,7 @@ int smlua_func_bhv_ferris_wheel_axle_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ferris_wheel_platform_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ferris_wheel_platform_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8291,7 +8291,7 @@ int smlua_func_bhv_ferris_wheel_platform_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ferris_wheel_platform_update(UNUSED lua_State* L) {
+int smlua_func_bhv_ferris_wheel_platform_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8307,7 +8307,7 @@ int smlua_func_bhv_ferris_wheel_platform_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_bomb_spawner_update(UNUSED lua_State* L) {
+int smlua_func_bhv_water_bomb_spawner_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8323,7 +8323,7 @@ int smlua_func_bhv_water_bomb_spawner_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_bomb_update(UNUSED lua_State* L) {
+int smlua_func_bhv_water_bomb_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8339,7 +8339,7 @@ int smlua_func_bhv_water_bomb_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_bomb_shadow_update(UNUSED lua_State* L) {
+int smlua_func_bhv_water_bomb_shadow_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8355,7 +8355,7 @@ int smlua_func_bhv_water_bomb_shadow_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_rotating_solid_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_rotating_solid_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8371,7 +8371,7 @@ int smlua_func_bhv_ttc_rotating_solid_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_rotating_solid_update(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_rotating_solid_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8387,7 +8387,7 @@ int smlua_func_bhv_ttc_rotating_solid_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_pendulum_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_pendulum_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8403,7 +8403,7 @@ int smlua_func_bhv_ttc_pendulum_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_pendulum_update(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_pendulum_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8419,7 +8419,7 @@ int smlua_func_bhv_ttc_pendulum_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_treadmill_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_treadmill_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8435,7 +8435,7 @@ int smlua_func_bhv_ttc_treadmill_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_treadmill_update(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_treadmill_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8451,7 +8451,7 @@ int smlua_func_bhv_ttc_treadmill_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_moving_bar_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_moving_bar_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8467,7 +8467,7 @@ int smlua_func_bhv_ttc_moving_bar_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_moving_bar_update(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_moving_bar_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8483,7 +8483,7 @@ int smlua_func_bhv_ttc_moving_bar_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_cog_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_cog_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8499,7 +8499,7 @@ int smlua_func_bhv_ttc_cog_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_cog_update(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_cog_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8515,7 +8515,7 @@ int smlua_func_bhv_ttc_cog_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_pit_block_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_pit_block_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8531,7 +8531,7 @@ int smlua_func_bhv_ttc_pit_block_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_pit_block_update(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_pit_block_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8547,7 +8547,7 @@ int smlua_func_bhv_ttc_pit_block_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_elevator_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_elevator_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8563,7 +8563,7 @@ int smlua_func_bhv_ttc_elevator_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_elevator_update(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_elevator_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8579,7 +8579,7 @@ int smlua_func_bhv_ttc_elevator_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_2d_rotator_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_2d_rotator_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8595,7 +8595,7 @@ int smlua_func_bhv_ttc_2d_rotator_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_2d_rotator_update(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_2d_rotator_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8611,7 +8611,7 @@ int smlua_func_bhv_ttc_2d_rotator_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ttc_spinner_update(UNUSED lua_State* L) {
+int smlua_func_bhv_ttc_spinner_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8627,7 +8627,7 @@ int smlua_func_bhv_ttc_spinner_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_mr_blizzard_init(UNUSED lua_State* L) {
+int smlua_func_bhv_mr_blizzard_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8643,7 +8643,7 @@ int smlua_func_bhv_mr_blizzard_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_mr_blizzard_update(UNUSED lua_State* L) {
+int smlua_func_bhv_mr_blizzard_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8659,7 +8659,7 @@ int smlua_func_bhv_mr_blizzard_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_mr_blizzard_snowball(UNUSED lua_State* L) {
+int smlua_func_bhv_mr_blizzard_snowball(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8675,7 +8675,7 @@ int smlua_func_bhv_mr_blizzard_snowball(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_sliding_plat_2_init(UNUSED lua_State* L) {
+int smlua_func_bhv_sliding_plat_2_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8691,7 +8691,7 @@ int smlua_func_bhv_sliding_plat_2_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_sliding_plat_2_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_sliding_plat_2_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8707,7 +8707,7 @@ int smlua_func_bhv_sliding_plat_2_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_rotating_octagonal_plat_init(UNUSED lua_State* L) {
+int smlua_func_bhv_rotating_octagonal_plat_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8723,7 +8723,7 @@ int smlua_func_bhv_rotating_octagonal_plat_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_rotating_octagonal_plat_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_rotating_octagonal_plat_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8739,7 +8739,7 @@ int smlua_func_bhv_rotating_octagonal_plat_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_animates_on_floor_switch_press_init(UNUSED lua_State* L) {
+int smlua_func_bhv_animates_on_floor_switch_press_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8755,7 +8755,7 @@ int smlua_func_bhv_animates_on_floor_switch_press_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_animates_on_floor_switch_press_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_animates_on_floor_switch_press_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8771,7 +8771,7 @@ int smlua_func_bhv_animates_on_floor_switch_press_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_activated_back_and_forth_platform_init(UNUSED lua_State* L) {
+int smlua_func_bhv_activated_back_and_forth_platform_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8787,7 +8787,7 @@ int smlua_func_bhv_activated_back_and_forth_platform_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_activated_back_and_forth_platform_update(UNUSED lua_State* L) {
+int smlua_func_bhv_activated_back_and_forth_platform_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8803,7 +8803,7 @@ int smlua_func_bhv_activated_back_and_forth_platform_update(UNUSED lua_State* L)
     return 1;
 }
 
-int smlua_func_bhv_recovery_heart_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_recovery_heart_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8819,7 +8819,7 @@ int smlua_func_bhv_recovery_heart_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_water_bomb_cannon_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_water_bomb_cannon_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8835,7 +8835,7 @@ int smlua_func_bhv_water_bomb_cannon_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bubble_cannon_barrel_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bubble_cannon_barrel_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8851,7 +8851,7 @@ int smlua_func_bhv_bubble_cannon_barrel_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_unagi_init(UNUSED lua_State* L) {
+int smlua_func_bhv_unagi_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8867,7 +8867,7 @@ int smlua_func_bhv_unagi_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_unagi_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_unagi_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8883,7 +8883,7 @@ int smlua_func_bhv_unagi_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_unagi_subobject_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_unagi_subobject_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8899,7 +8899,7 @@ int smlua_func_bhv_unagi_subobject_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_dorrie_update(UNUSED lua_State* L) {
+int smlua_func_bhv_dorrie_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8915,7 +8915,7 @@ int smlua_func_bhv_dorrie_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_haunted_chair_init(UNUSED lua_State* L) {
+int smlua_func_bhv_haunted_chair_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8931,7 +8931,7 @@ int smlua_func_bhv_haunted_chair_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_haunted_chair_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_haunted_chair_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8947,7 +8947,7 @@ int smlua_func_bhv_haunted_chair_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_mad_piano_update(UNUSED lua_State* L) {
+int smlua_func_bhv_mad_piano_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8963,7 +8963,7 @@ int smlua_func_bhv_mad_piano_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_flying_bookend_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_flying_bookend_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8979,7 +8979,7 @@ int smlua_func_bhv_flying_bookend_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bookend_spawn_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bookend_spawn_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -8995,7 +8995,7 @@ int smlua_func_bhv_bookend_spawn_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_haunted_bookshelf_manager_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_haunted_bookshelf_manager_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9011,7 +9011,7 @@ int smlua_func_bhv_haunted_bookshelf_manager_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_book_switch_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_book_switch_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9027,7 +9027,7 @@ int smlua_func_bhv_book_switch_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_fire_piranha_plant_init(UNUSED lua_State* L) {
+int smlua_func_bhv_fire_piranha_plant_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9043,7 +9043,7 @@ int smlua_func_bhv_fire_piranha_plant_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_fire_piranha_plant_update(UNUSED lua_State* L) {
+int smlua_func_bhv_fire_piranha_plant_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9059,7 +9059,7 @@ int smlua_func_bhv_fire_piranha_plant_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_small_piranha_flame_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_small_piranha_flame_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9075,7 +9075,7 @@ int smlua_func_bhv_small_piranha_flame_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_fire_spitter_update(UNUSED lua_State* L) {
+int smlua_func_bhv_fire_spitter_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9091,7 +9091,7 @@ int smlua_func_bhv_fire_spitter_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_fly_guy_flame_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_fly_guy_flame_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9107,7 +9107,7 @@ int smlua_func_bhv_fly_guy_flame_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_snufit_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_snufit_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9123,7 +9123,7 @@ int smlua_func_bhv_snufit_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_snufit_balls_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_snufit_balls_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9139,7 +9139,7 @@ int smlua_func_bhv_snufit_balls_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_horizontal_grindel_init(UNUSED lua_State* L) {
+int smlua_func_bhv_horizontal_grindel_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9155,7 +9155,7 @@ int smlua_func_bhv_horizontal_grindel_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_horizontal_grindel_update(UNUSED lua_State* L) {
+int smlua_func_bhv_horizontal_grindel_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9171,7 +9171,7 @@ int smlua_func_bhv_horizontal_grindel_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_eyerok_boss_init(UNUSED lua_State* L) {
+int smlua_func_bhv_eyerok_boss_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9187,7 +9187,7 @@ int smlua_func_bhv_eyerok_boss_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_eyerok_boss_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_eyerok_boss_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9203,7 +9203,7 @@ int smlua_func_bhv_eyerok_boss_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_eyerok_hand_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_eyerok_hand_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9219,7 +9219,7 @@ int smlua_func_bhv_eyerok_hand_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_klepto_init(UNUSED lua_State* L) {
+int smlua_func_bhv_klepto_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9235,7 +9235,7 @@ int smlua_func_bhv_klepto_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_klepto_update(UNUSED lua_State* L) {
+int smlua_func_bhv_klepto_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9251,7 +9251,7 @@ int smlua_func_bhv_klepto_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bird_update(UNUSED lua_State* L) {
+int smlua_func_bhv_bird_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9267,7 +9267,7 @@ int smlua_func_bhv_bird_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_racing_penguin_init(UNUSED lua_State* L) {
+int smlua_func_bhv_racing_penguin_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9283,7 +9283,7 @@ int smlua_func_bhv_racing_penguin_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_racing_penguin_update(UNUSED lua_State* L) {
+int smlua_func_bhv_racing_penguin_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9299,7 +9299,7 @@ int smlua_func_bhv_racing_penguin_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_penguin_race_finish_line_update(UNUSED lua_State* L) {
+int smlua_func_bhv_penguin_race_finish_line_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9315,7 +9315,7 @@ int smlua_func_bhv_penguin_race_finish_line_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_penguin_race_shortcut_check_update(UNUSED lua_State* L) {
+int smlua_func_bhv_penguin_race_shortcut_check_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9331,7 +9331,7 @@ int smlua_func_bhv_penguin_race_shortcut_check_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_coffin_spawner_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_coffin_spawner_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9347,7 +9347,7 @@ int smlua_func_bhv_coffin_spawner_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_coffin_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_coffin_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9363,7 +9363,7 @@ int smlua_func_bhv_coffin_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_clam_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_clam_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9379,7 +9379,7 @@ int smlua_func_bhv_clam_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_skeeter_update(UNUSED lua_State* L) {
+int smlua_func_bhv_skeeter_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9395,7 +9395,7 @@ int smlua_func_bhv_skeeter_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_skeeter_wave_update(UNUSED lua_State* L) {
+int smlua_func_bhv_skeeter_wave_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9411,7 +9411,7 @@ int smlua_func_bhv_skeeter_wave_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_swing_platform_init(UNUSED lua_State* L) {
+int smlua_func_bhv_swing_platform_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9427,7 +9427,7 @@ int smlua_func_bhv_swing_platform_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_swing_platform_update(UNUSED lua_State* L) {
+int smlua_func_bhv_swing_platform_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9443,7 +9443,7 @@ int smlua_func_bhv_swing_platform_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_donut_platform_spawner_update(UNUSED lua_State* L) {
+int smlua_func_bhv_donut_platform_spawner_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9459,7 +9459,7 @@ int smlua_func_bhv_donut_platform_spawner_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_donut_platform_update(UNUSED lua_State* L) {
+int smlua_func_bhv_donut_platform_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9475,7 +9475,7 @@ int smlua_func_bhv_donut_platform_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ddd_pole_init(UNUSED lua_State* L) {
+int smlua_func_bhv_ddd_pole_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9491,7 +9491,7 @@ int smlua_func_bhv_ddd_pole_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ddd_pole_update(UNUSED lua_State* L) {
+int smlua_func_bhv_ddd_pole_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9507,7 +9507,7 @@ int smlua_func_bhv_ddd_pole_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_red_coin_star_marker_init(UNUSED lua_State* L) {
+int smlua_func_bhv_red_coin_star_marker_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9523,7 +9523,7 @@ int smlua_func_bhv_red_coin_star_marker_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_triplet_butterfly_update(UNUSED lua_State* L) {
+int smlua_func_bhv_triplet_butterfly_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9539,7 +9539,7 @@ int smlua_func_bhv_triplet_butterfly_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_bubba_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_bubba_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9555,7 +9555,7 @@ int smlua_func_bhv_bubba_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_intro_lakitu_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_intro_lakitu_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9571,7 +9571,7 @@ int smlua_func_bhv_intro_lakitu_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_intro_peach_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_intro_peach_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9587,7 +9587,7 @@ int smlua_func_bhv_intro_peach_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_end_birds_1_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_end_birds_1_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9603,7 +9603,7 @@ int smlua_func_bhv_end_birds_1_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_end_birds_2_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_end_birds_2_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9619,7 +9619,7 @@ int smlua_func_bhv_end_birds_2_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_intro_scene_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_intro_scene_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9635,7 +9635,7 @@ int smlua_func_bhv_intro_scene_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_yoshi_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_yoshi_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9651,7 +9651,7 @@ int smlua_func_bhv_yoshi_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_volcano_trap_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_volcano_trap_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9667,7 +9667,7 @@ int smlua_func_bhv_volcano_trap_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_uv_update_scroll(UNUSED lua_State* L) {
+int smlua_func_uv_update_scroll(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -9682,7 +9682,7 @@ int smlua_func_uv_update_scroll(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_ambient_light_update(UNUSED lua_State* L) {
+int smlua_func_bhv_ambient_light_update(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9698,7 +9698,7 @@ int smlua_func_bhv_ambient_light_update(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_point_light_init(UNUSED lua_State* L) {
+int smlua_func_bhv_point_light_init(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9714,7 +9714,7 @@ int smlua_func_bhv_point_light_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_point_light_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_point_light_loop(lua_State* L) {
     if (!gCurrentObject) { return 0; }
     if (L == NULL) { return 0; }
 
@@ -9797,7 +9797,7 @@ int smlua_func_spawn_no_exit_star(lua_State* L) {
  // behavior_script.h //
 ///////////////////////
 
-int smlua_func_random_u16(UNUSED lua_State* L) {
+int smlua_func_random_u16(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -9812,7 +9812,7 @@ int smlua_func_random_u16(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_random_float(UNUSED lua_State* L) {
+int smlua_func_random_float(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -9827,7 +9827,7 @@ int smlua_func_random_float(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_random_sign(UNUSED lua_State* L) {
+int smlua_func_random_sign(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -9859,7 +9859,7 @@ int smlua_func_obj_update_gfx_pos_and_angle(lua_State* L) {
     return 1;
 }
 
-int smlua_func_position_based_random_u16(UNUSED lua_State* L) {
+int smlua_func_position_based_random_u16(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -9874,7 +9874,7 @@ int smlua_func_position_based_random_u16(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_position_based_random_float_position(UNUSED lua_State* L) {
+int smlua_func_position_based_random_float_position(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -9889,7 +9889,7 @@ int smlua_func_position_based_random_float_position(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_draw_distance_scalar_is_infinite(UNUSED lua_State* L) {
+int smlua_func_draw_distance_scalar_is_infinite(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -9904,7 +9904,7 @@ int smlua_func_draw_distance_scalar_is_infinite(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_draw_distance_scalar(UNUSED lua_State* L) {
+int smlua_func_draw_distance_scalar(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -10029,7 +10029,7 @@ int smlua_func_get_id_from_behavior_name(lua_State* L) {
  // camera.h //
 //////////////
 
-int smlua_func_skip_camera_interpolation(UNUSED lua_State* L) {
+int smlua_func_skip_camera_interpolation(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -10192,7 +10192,7 @@ int smlua_func_reset_camera(lua_State* L) {
     return 1;
 }
 
-int smlua_func_select_mario_cam_mode(UNUSED lua_State* L) {
+int smlua_func_select_mario_cam_mode(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -11256,7 +11256,7 @@ int smlua_func_offset_yaw_outward_radial(lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_camera_buzz_if_cdown(UNUSED lua_State* L) {
+int smlua_func_play_camera_buzz_if_cdown(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -11271,7 +11271,7 @@ int smlua_func_play_camera_buzz_if_cdown(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_camera_buzz_if_cbutton(UNUSED lua_State* L) {
+int smlua_func_play_camera_buzz_if_cbutton(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -11286,7 +11286,7 @@ int smlua_func_play_camera_buzz_if_cbutton(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_camera_buzz_if_c_sideways(UNUSED lua_State* L) {
+int smlua_func_play_camera_buzz_if_c_sideways(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -11301,7 +11301,7 @@ int smlua_func_play_camera_buzz_if_c_sideways(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_sound_cbutton_up(UNUSED lua_State* L) {
+int smlua_func_play_sound_cbutton_up(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -11316,7 +11316,7 @@ int smlua_func_play_sound_cbutton_up(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_sound_cbutton_down(UNUSED lua_State* L) {
+int smlua_func_play_sound_cbutton_down(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -11331,7 +11331,7 @@ int smlua_func_play_sound_cbutton_down(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_sound_cbutton_side(UNUSED lua_State* L) {
+int smlua_func_play_sound_cbutton_side(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -11346,7 +11346,7 @@ int smlua_func_play_sound_cbutton_side(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_sound_button_change_blocked(UNUSED lua_State* L) {
+int smlua_func_play_sound_button_change_blocked(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -11361,7 +11361,7 @@ int smlua_func_play_sound_button_change_blocked(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_sound_rbutton_changed(UNUSED lua_State* L) {
+int smlua_func_play_sound_rbutton_changed(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -11376,7 +11376,7 @@ int smlua_func_play_sound_rbutton_changed(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_sound_if_cam_switched_to_lakitu_or_mario(UNUSED lua_State* L) {
+int smlua_func_play_sound_if_cam_switched_to_lakitu_or_mario(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12007,7 +12007,7 @@ int smlua_func_camera_set_use_course_specific_settings(lua_State* L) {
     return 1;
 }
 
-int smlua_func_center_rom_hack_camera(UNUSED lua_State* L) {
+int smlua_func_center_rom_hack_camera(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12182,7 +12182,7 @@ int smlua_func_djui_chat_message_create(lua_State* L) {
  // djui_console.h //
 ////////////////////
 
-int smlua_func_djui_console_toggle(UNUSED lua_State* L) {
+int smlua_func_djui_console_toggle(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12201,7 +12201,7 @@ int smlua_func_djui_console_toggle(UNUSED lua_State* L) {
  // djui_hud_utils.h //
 //////////////////////
 
-int smlua_func_djui_hud_get_resolution(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_resolution(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12233,7 +12233,7 @@ int smlua_func_djui_hud_set_resolution(lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_filter(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_filter(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12265,7 +12265,7 @@ int smlua_func_djui_hud_set_filter(lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_font(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_font(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12297,7 +12297,7 @@ int smlua_func_djui_hud_set_font(lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_color(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_color(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12335,7 +12335,7 @@ int smlua_func_djui_hud_set_color(lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_reset_color(UNUSED lua_State* L) {
+int smlua_func_djui_hud_reset_color(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12350,7 +12350,7 @@ int smlua_func_djui_hud_reset_color(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_text_color(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_text_color(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12388,7 +12388,7 @@ int smlua_func_djui_hud_set_text_color(lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_reset_text_color(UNUSED lua_State* L) {
+int smlua_func_djui_hud_reset_text_color(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12537,7 +12537,7 @@ int smlua_func_djui_hud_set_text_alignment_interpolated(lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_screen_width(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_screen_width(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12552,7 +12552,7 @@ int smlua_func_djui_hud_get_screen_width(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_screen_height(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_screen_height(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12567,7 +12567,7 @@ int smlua_func_djui_hud_get_screen_height(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_mouse_x(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_mouse_x(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12582,7 +12582,7 @@ int smlua_func_djui_hud_get_mouse_x(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_mouse_y(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_mouse_y(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12597,7 +12597,7 @@ int smlua_func_djui_hud_get_mouse_y(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_raw_mouse_x(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_raw_mouse_x(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12612,7 +12612,7 @@ int smlua_func_djui_hud_get_raw_mouse_x(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_raw_mouse_y(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_raw_mouse_y(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12627,7 +12627,7 @@ int smlua_func_djui_hud_get_raw_mouse_y(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_is_mouse_locked(UNUSED lua_State* L) {
+int smlua_func_djui_hud_is_mouse_locked(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12659,7 +12659,7 @@ int smlua_func_djui_hud_set_mouse_locked(lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_mouse_buttons_down(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_mouse_buttons_down(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12674,7 +12674,7 @@ int smlua_func_djui_hud_get_mouse_buttons_down(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_mouse_buttons_pressed(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_mouse_buttons_pressed(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12689,7 +12689,7 @@ int smlua_func_djui_hud_get_mouse_buttons_pressed(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_mouse_buttons_released(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_mouse_buttons_released(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12704,7 +12704,7 @@ int smlua_func_djui_hud_get_mouse_buttons_released(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_mouse_scroll_x(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_mouse_scroll_x(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12719,7 +12719,7 @@ int smlua_func_djui_hud_get_mouse_scroll_x(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_mouse_scroll_y(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_mouse_scroll_y(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12757,7 +12757,7 @@ int smlua_func_djui_hud_set_viewport(lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_reset_viewport(UNUSED lua_State* L) {
+int smlua_func_djui_hud_reset_viewport(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -12795,7 +12795,7 @@ int smlua_func_djui_hud_set_scissor(lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_reset_scissor(UNUSED lua_State* L) {
+int smlua_func_djui_hud_reset_scissor(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13044,7 +13044,7 @@ int smlua_func_djui_hud_render_line(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_current_fov(UNUSED lua_State* L) {
+int smlua_func_get_current_fov(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13059,7 +13059,7 @@ int smlua_func_get_current_fov(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_get_fov_coeff(UNUSED lua_State* L) {
+int smlua_func_djui_hud_get_fov_coeff(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13099,7 +13099,7 @@ int smlua_func_djui_hud_world_pos_to_screen_pos(lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_hud_is_pause_menu_created(UNUSED lua_State* L) {
+int smlua_func_djui_hud_is_pause_menu_created(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13114,7 +13114,7 @@ int smlua_func_djui_hud_is_pause_menu_created(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_open_pause_menu(UNUSED lua_State* L) {
+int smlua_func_djui_open_pause_menu(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13381,7 +13381,7 @@ int smlua_func_stop_sounds_from_source(lua_State* L) {
     return 1;
 }
 
-int smlua_func_stop_sounds_in_continuous_banks(UNUSED lua_State* L) {
+int smlua_func_stop_sounds_in_continuous_banks(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13527,7 +13527,7 @@ int smlua_func_fadeout_background_music(lua_State* L) {
     return 1;
 }
 
-int smlua_func_drop_queued_background_music(UNUSED lua_State* L) {
+int smlua_func_drop_queued_background_music(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13542,7 +13542,7 @@ int smlua_func_drop_queued_background_music(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_current_background_music(UNUSED lua_State* L) {
+int smlua_func_get_current_background_music(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13557,7 +13557,7 @@ int smlua_func_get_current_background_music(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_current_background_music_default_volume(UNUSED lua_State* L) {
+int smlua_func_get_current_background_music_default_volume(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13572,7 +13572,7 @@ int smlua_func_get_current_background_music_default_volume(UNUSED lua_State* L) 
     return 1;
 }
 
-int smlua_func_get_current_background_music_target_volume(UNUSED lua_State* L) {
+int smlua_func_get_current_background_music_target_volume(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13587,7 +13587,7 @@ int smlua_func_get_current_background_music_target_volume(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_current_background_music_max_target_volume(UNUSED lua_State* L) {
+int smlua_func_get_current_background_music_max_target_volume(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13602,7 +13602,7 @@ int smlua_func_get_current_background_music_max_target_volume(UNUSED lua_State* 
     return 1;
 }
 
-int smlua_func_is_current_background_music_volume_lowered(UNUSED lua_State* L) {
+int smlua_func_is_current_background_music_volume_lowered(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13674,7 +13674,7 @@ int smlua_func_set_audio_fadeout(lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_course_clear(UNUSED lua_State* L) {
+int smlua_func_play_course_clear(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13689,7 +13689,7 @@ int smlua_func_play_course_clear(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_peachs_jingle(UNUSED lua_State* L) {
+int smlua_func_play_peachs_jingle(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13704,7 +13704,7 @@ int smlua_func_play_peachs_jingle(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_puzzle_jingle(UNUSED lua_State* L) {
+int smlua_func_play_puzzle_jingle(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13719,7 +13719,7 @@ int smlua_func_play_puzzle_jingle(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_star_fanfare(UNUSED lua_State* L) {
+int smlua_func_play_star_fanfare(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13751,7 +13751,7 @@ int smlua_func_play_power_star_jingle(lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_race_fanfare(UNUSED lua_State* L) {
+int smlua_func_play_race_fanfare(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13766,7 +13766,7 @@ int smlua_func_play_race_fanfare(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_toads_jingle(UNUSED lua_State* L) {
+int smlua_func_play_toads_jingle(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13874,7 +13874,7 @@ int smlua_func_first_person_check_cancels(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_first_person_enabled(UNUSED lua_State* L) {
+int smlua_func_get_first_person_enabled(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13906,7 +13906,7 @@ int smlua_func_set_first_person_enabled(lua_State* L) {
     return 1;
 }
 
-int smlua_func_first_person_reset(UNUSED lua_State* L) {
+int smlua_func_first_person_reset(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -13995,7 +13995,7 @@ int smlua_func_create_dialog_box_with_response(lua_State* L) {
     return 1;
 }
 
-int smlua_func_reset_dialog_render_state(UNUSED lua_State* L) {
+int smlua_func_reset_dialog_render_state(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -14080,7 +14080,7 @@ int smlua_func_set_dialog_override_pos(lua_State* L) {
     return 1;
 }
 
-int smlua_func_reset_dialog_override_pos(UNUSED lua_State* L) {
+int smlua_func_reset_dialog_override_pos(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -14126,7 +14126,7 @@ int smlua_func_set_dialog_override_color(lua_State* L) {
     return 1;
 }
 
-int smlua_func_reset_dialog_override_color(UNUSED lua_State* L) {
+int smlua_func_reset_dialog_override_color(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -15105,7 +15105,7 @@ int smlua_func_determine_interaction(lua_State* L) {
  // lag_compensation.h //
 ////////////////////////
 
-int smlua_func_lag_compensation_store(UNUSED lua_State* L) {
+int smlua_func_lag_compensation_store(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -15137,7 +15137,7 @@ int smlua_func_lag_compensation_get_local_state(lua_State* L) {
     return 1;
 }
 
-int smlua_func_lag_compensation_get_local_state_ready(UNUSED lua_State* L) {
+int smlua_func_lag_compensation_get_local_state_ready(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -15152,7 +15152,7 @@ int smlua_func_lag_compensation_get_local_state_ready(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_lag_compensation_get_local_state_index(UNUSED lua_State* L) {
+int smlua_func_lag_compensation_get_local_state_index(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -15334,7 +15334,7 @@ int smlua_func_area_create_warp_node(lua_State* L) {
  // level_update.h //
 ////////////////////
 
-int smlua_func_level_control_timer_running(UNUSED lua_State* L) {
+int smlua_func_level_control_timer_running(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -15349,7 +15349,7 @@ int smlua_func_level_control_timer_running(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_pressed_pause(UNUSED lua_State* L) {
+int smlua_func_pressed_pause(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -15400,7 +15400,7 @@ int smlua_func_get_instant_warp(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_painting_warp_node(UNUSED lua_State* L) {
+int smlua_func_get_painting_warp_node(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -15514,7 +15514,7 @@ int smlua_func_lvl_set_current_level(lua_State* L) {
  // lighting_engine.h //
 ///////////////////////
 
-int smlua_func_le_is_enabled(UNUSED lua_State* L) {
+int smlua_func_le_is_enabled(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -15546,7 +15546,7 @@ int smlua_func_le_set_mode(lua_State* L) {
     return 1;
 }
 
-int smlua_func_le_get_mode(UNUSED lua_State* L) {
+int smlua_func_le_get_mode(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -15785,7 +15785,7 @@ int smlua_func_le_remove_light(lua_State* L) {
     return 1;
 }
 
-int smlua_func_le_get_light_count(UNUSED lua_State* L) {
+int smlua_func_le_get_light_count(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -17778,7 +17778,7 @@ int smlua_func_get_credits_str_width(lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_end_peach_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_end_peach_loop(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -17794,7 +17794,7 @@ int smlua_func_bhv_end_peach_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_end_toad_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_end_toad_loop(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -19190,7 +19190,7 @@ int smlua_func_mario_execute_submerged_action(lua_State* L) {
  // mario_misc.h //
 //////////////////
 
-int smlua_func_bhv_toad_message_init(UNUSED lua_State* L) {
+int smlua_func_bhv_toad_message_init(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -19205,7 +19205,7 @@ int smlua_func_bhv_toad_message_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_toad_message_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_toad_message_loop(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -19220,7 +19220,7 @@ int smlua_func_bhv_toad_message_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_unlock_door_star_init(UNUSED lua_State* L) {
+int smlua_func_bhv_unlock_door_star_init(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -19235,7 +19235,7 @@ int smlua_func_bhv_unlock_door_star_init(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_unlock_door_star_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_unlock_door_star_loop(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -19250,7 +19250,7 @@ int smlua_func_bhv_unlock_door_star_loop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_geo_get_mario_state(UNUSED lua_State* L) {
+int smlua_func_geo_get_mario_state(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -19265,7 +19265,7 @@ int smlua_func_geo_get_mario_state(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_geo_get_body_state(UNUSED lua_State* L) {
+int smlua_func_geo_get_body_state(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -19284,7 +19284,7 @@ int smlua_func_geo_get_body_state(UNUSED lua_State* L) {
  // mario_step.h //
 //////////////////
 
-int smlua_func_get_additive_y_vel_for_jumps(UNUSED lua_State* L) {
+int smlua_func_get_additive_y_vel_for_jumps(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -22251,7 +22251,7 @@ int smlua_func_smooth_step(lua_State* L) {
     return 1;
 }
 
-int smlua_func_update_all_mario_stars(UNUSED lua_State* L) {
+int smlua_func_update_all_mario_stars(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -22266,7 +22266,7 @@ int smlua_func_update_all_mario_stars(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_clock_elapsed(UNUSED lua_State* L) {
+int smlua_func_clock_elapsed(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -22281,7 +22281,7 @@ int smlua_func_clock_elapsed(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_clock_elapsed_f64(UNUSED lua_State* L) {
+int smlua_func_clock_elapsed_f64(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -22296,7 +22296,7 @@ int smlua_func_clock_elapsed_f64(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_clock_elapsed_ticks(UNUSED lua_State* L) {
+int smlua_func_clock_elapsed_ticks(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -22498,7 +22498,7 @@ int smlua_func_mod_fs_reload(lua_State* L) {
     return 1;
 }
 
-int smlua_func_mod_fs_create(UNUSED lua_State* L) {
+int smlua_func_mod_fs_create(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -23102,7 +23102,7 @@ int smlua_func_mod_fs_hide_errors(lua_State* L) {
     return 1;
 }
 
-int smlua_func_mod_fs_get_last_error(UNUSED lua_State* L) {
+int smlua_func_mod_fs_get_last_error(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -23265,7 +23265,7 @@ int smlua_func_mod_storage_load_bool(lua_State* L) {
     return 1;
 }
 
-int smlua_func_mod_storage_load_all(UNUSED lua_State* L) {
+int smlua_func_mod_storage_load_all(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -23314,7 +23314,7 @@ int smlua_func_mod_storage_remove(lua_State* L) {
     return 1;
 }
 
-int smlua_func_mod_storage_clear(UNUSED lua_State* L) {
+int smlua_func_mod_storage_clear(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -23333,7 +23333,7 @@ int smlua_func_mod_storage_clear(UNUSED lua_State* L) {
  // network_player.h //
 //////////////////////
 
-int smlua_func_network_player_connected_count(UNUSED lua_State* L) {
+int smlua_func_network_player_connected_count(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -23455,7 +23455,7 @@ int smlua_func_get_network_player_from_area(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_network_player_smallest_global(UNUSED lua_State* L) {
+int smlua_func_get_network_player_smallest_global(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -23607,7 +23607,7 @@ int smlua_func_network_local_index_from_global(lua_State* L) {
     return 1;
 }
 
-int smlua_func_network_is_server(UNUSED lua_State* L) {
+int smlua_func_network_is_server(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -23622,7 +23622,7 @@ int smlua_func_network_is_server(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_network_is_moderator(UNUSED lua_State* L) {
+int smlua_func_network_is_moderator(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -23654,7 +23654,7 @@ int smlua_func_network_get_player_text_color_string(lua_State* L) {
     return 1;
 }
 
-int smlua_func_network_check_singleplayer_pause(UNUSED lua_State* L) {
+int smlua_func_network_check_singleplayer_pause(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -23690,7 +23690,7 @@ int smlua_func_network_discord_id_from_local_index(lua_State* L) {
  // obj_behaviors.c //
 /////////////////////
 
-int smlua_func_set_yoshi_as_not_dead(UNUSED lua_State* L) {
+int smlua_func_set_yoshi_as_not_dead(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -23870,7 +23870,7 @@ int smlua_func_calc_new_obj_vel_and_pos_y_underwater(lua_State* L) {
     return 1;
 }
 
-int smlua_func_obj_update_pos_vel_xz(UNUSED lua_State* L) {
+int smlua_func_obj_update_pos_vel_xz(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -23906,7 +23906,7 @@ int smlua_func_obj_splash(lua_State* L) {
     return 1;
 }
 
-int smlua_func_object_step(UNUSED lua_State* L) {
+int smlua_func_object_step(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -23922,7 +23922,7 @@ int smlua_func_object_step(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_object_step_without_floor_orient(UNUSED lua_State* L) {
+int smlua_func_object_step_without_floor_orient(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -24022,7 +24022,7 @@ int smlua_func_is_player_active(lua_State* L) {
     return 1;
 }
 
-int smlua_func_is_other_player_active(UNUSED lua_State* L) {
+int smlua_func_is_other_player_active(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -24414,7 +24414,7 @@ int smlua_func_obj_check_floor_death(lua_State* L) {
     return 1;
 }
 
-int smlua_func_obj_lava_death(UNUSED lua_State* L) {
+int smlua_func_obj_lava_death(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -24458,7 +24458,7 @@ int smlua_func_spawn_orange_number(lua_State* L) {
  // obj_behaviors_2.c //
 ///////////////////////
 
-int smlua_func_obj_is_rendering_enabled(UNUSED lua_State* L) {
+int smlua_func_obj_is_rendering_enabled(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -24474,7 +24474,7 @@ int smlua_func_obj_is_rendering_enabled(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_obj_get_pitch_from_vel(UNUSED lua_State* L) {
+int smlua_func_obj_get_pitch_from_vel(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -25153,7 +25153,7 @@ int smlua_func_obj_resolve_collisions_and_turn(lua_State* L) {
     return 1;
 }
 
-int smlua_func_obj_die_if_health_non_positive(UNUSED lua_State* L) {
+int smlua_func_obj_die_if_health_non_positive(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -25169,7 +25169,7 @@ int smlua_func_obj_die_if_health_non_positive(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_obj_unused_die(UNUSED lua_State* L) {
+int smlua_func_obj_unused_die(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -25203,7 +25203,7 @@ int smlua_func_obj_set_knockback_action(lua_State* L) {
     return 1;
 }
 
-int smlua_func_obj_set_squished_action(UNUSED lua_State* L) {
+int smlua_func_obj_set_squished_action(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -25219,7 +25219,7 @@ int smlua_func_obj_set_squished_action(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_obj_die_if_above_lava_and_health_non_positive(UNUSED lua_State* L) {
+int smlua_func_obj_die_if_above_lava_and_health_non_positive(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26039,7 +26039,7 @@ int smlua_func_obj_build_relative_transform(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_move_using_vel(UNUSED lua_State* L) {
+int smlua_func_cur_obj_move_using_vel(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26453,7 +26453,7 @@ int smlua_func_cur_obj_enable_rendering_and_become_tangible(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_enable_rendering(UNUSED lua_State* L) {
+int smlua_func_cur_obj_enable_rendering(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26487,7 +26487,7 @@ int smlua_func_cur_obj_disable_rendering_and_become_intangible(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_disable_rendering(UNUSED lua_State* L) {
+int smlua_func_cur_obj_disable_rendering(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26503,7 +26503,7 @@ int smlua_func_cur_obj_disable_rendering(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_unhide(UNUSED lua_State* L) {
+int smlua_func_cur_obj_unhide(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26519,7 +26519,7 @@ int smlua_func_cur_obj_unhide(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_hide(UNUSED lua_State* L) {
+int smlua_func_cur_obj_hide(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26581,7 +26581,7 @@ int smlua_func_cur_obj_set_pos_relative_to_parent(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_enable_rendering_2(UNUSED lua_State* L) {
+int smlua_func_cur_obj_enable_rendering_2(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26597,7 +26597,7 @@ int smlua_func_cur_obj_enable_rendering_2(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_unused_init_on_floor(UNUSED lua_State* L) {
+int smlua_func_cur_obj_unused_init_on_floor(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26685,7 +26685,7 @@ int smlua_func_cur_obj_dist_to_nearest_object_with_behavior(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_find_nearest_pole(UNUSED lua_State* L) {
+int smlua_func_cur_obj_find_nearest_pole(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26743,7 +26743,7 @@ int smlua_func_cur_obj_count_objects_with_behavior(lua_State* L) {
     return 1;
 }
 
-int smlua_func_find_unimportant_object(UNUSED lua_State* L) {
+int smlua_func_find_unimportant_object(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26759,7 +26759,7 @@ int smlua_func_find_unimportant_object(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_count_unimportant_objects(UNUSED lua_State* L) {
+int smlua_func_count_unimportant_objects(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26831,7 +26831,7 @@ int smlua_func_cur_obj_find_nearby_held_actor(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_reset_timer_and_subaction(UNUSED lua_State* L) {
+int smlua_func_cur_obj_reset_timer_and_subaction(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26887,7 +26887,7 @@ int smlua_func_cur_obj_set_vel_from_mario_vel(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_reverse_animation(UNUSED lua_State* L) {
+int smlua_func_cur_obj_reverse_animation(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26903,7 +26903,7 @@ int smlua_func_cur_obj_reverse_animation(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_extend_animation_if_at_end(UNUSED lua_State* L) {
+int smlua_func_cur_obj_extend_animation_if_at_end(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26919,7 +26919,7 @@ int smlua_func_cur_obj_extend_animation_if_at_end(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_check_if_near_animation_end(UNUSED lua_State* L) {
+int smlua_func_cur_obj_check_if_near_animation_end(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -26935,7 +26935,7 @@ int smlua_func_cur_obj_check_if_near_animation_end(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_check_if_at_animation_end(UNUSED lua_State* L) {
+int smlua_func_cur_obj_check_if_at_animation_end(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27107,7 +27107,7 @@ int smlua_func_cur_obj_get_thrown_or_placed(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_get_dropped(UNUSED lua_State* L) {
+int smlua_func_cur_obj_get_dropped(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27177,7 +27177,7 @@ int smlua_func_obj_mark_for_deletion(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_disable(UNUSED lua_State* L) {
+int smlua_func_cur_obj_disable(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27193,7 +27193,7 @@ int smlua_func_cur_obj_disable(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_become_intangible(UNUSED lua_State* L) {
+int smlua_func_cur_obj_become_intangible(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27209,7 +27209,7 @@ int smlua_func_cur_obj_become_intangible(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_become_tangible(UNUSED lua_State* L) {
+int smlua_func_cur_obj_become_tangible(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27243,7 +27243,7 @@ int smlua_func_obj_become_tangible(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_update_floor_height(UNUSED lua_State* L) {
+int smlua_func_cur_obj_update_floor_height(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27259,7 +27259,7 @@ int smlua_func_cur_obj_update_floor_height(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_update_floor_height_and_get_floor(UNUSED lua_State* L) {
+int smlua_func_cur_obj_update_floor_height_and_get_floor(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27336,7 +27336,7 @@ int smlua_func_cur_obj_move_xz(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_move_update_underwater_flags(UNUSED lua_State* L) {
+int smlua_func_cur_obj_move_update_underwater_flags(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27454,7 +27454,7 @@ int smlua_func_abs_angle_diff(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_move_xz_using_fvel_and_yaw(UNUSED lua_State* L) {
+int smlua_func_cur_obj_move_xz_using_fvel_and_yaw(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27470,7 +27470,7 @@ int smlua_func_cur_obj_move_xz_using_fvel_and_yaw(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_move_y_with_terminal_vel(UNUSED lua_State* L) {
+int smlua_func_cur_obj_move_y_with_terminal_vel(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27486,7 +27486,7 @@ int smlua_func_cur_obj_move_y_with_terminal_vel(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_compute_vel_xz(UNUSED lua_State* L) {
+int smlua_func_cur_obj_compute_vel_xz(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27640,7 +27640,7 @@ int smlua_func_cur_obj_lateral_dist_from_obj_to_home(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_lateral_dist_from_mario_to_home(UNUSED lua_State* L) {
+int smlua_func_cur_obj_lateral_dist_from_mario_to_home(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27656,7 +27656,7 @@ int smlua_func_cur_obj_lateral_dist_from_mario_to_home(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_lateral_dist_to_home(UNUSED lua_State* L) {
+int smlua_func_cur_obj_lateral_dist_to_home(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27714,7 +27714,7 @@ int smlua_func_cur_obj_outside_home_rectangle(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_set_pos_to_home(UNUSED lua_State* L) {
+int smlua_func_cur_obj_set_pos_to_home(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27730,7 +27730,7 @@ int smlua_func_cur_obj_set_pos_to_home(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_set_pos_to_home_and_stop(UNUSED lua_State* L) {
+int smlua_func_cur_obj_set_pos_to_home_and_stop(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -27842,7 +27842,7 @@ int smlua_func_obj_set_cylboard(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_set_billboard_if_vanilla_cam(UNUSED lua_State* L) {
+int smlua_func_cur_obj_set_billboard_if_vanilla_cam(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28034,7 +28034,7 @@ int smlua_func_cur_obj_spawn_loot_coin_at_mario_pos(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_abs_y_dist_to_home(UNUSED lua_State* L) {
+int smlua_func_cur_obj_abs_y_dist_to_home(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28050,7 +28050,7 @@ int smlua_func_cur_obj_abs_y_dist_to_home(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_advance_looping_anim(UNUSED lua_State* L) {
+int smlua_func_cur_obj_advance_looping_anim(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28084,7 +28084,7 @@ int smlua_func_cur_obj_detect_steep_floor(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_resolve_wall_collisions(UNUSED lua_State* L) {
+int smlua_func_cur_obj_resolve_wall_collisions(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28100,7 +28100,7 @@ int smlua_func_cur_obj_resolve_wall_collisions(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_update_floor(UNUSED lua_State* L) {
+int smlua_func_cur_obj_update_floor(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28134,7 +28134,7 @@ int smlua_func_cur_obj_update_floor_and_resolve_wall_collisions(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_update_floor_and_walls(UNUSED lua_State* L) {
+int smlua_func_cur_obj_update_floor_and_walls(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28168,7 +28168,7 @@ int smlua_func_cur_obj_move_standard(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_within_12k_bounds(UNUSED lua_State* L) {
+int smlua_func_cur_obj_within_12k_bounds(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28184,7 +28184,7 @@ int smlua_func_cur_obj_within_12k_bounds(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_move_using_vel_and_gravity(UNUSED lua_State* L) {
+int smlua_func_cur_obj_move_using_vel_and_gravity(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28200,7 +28200,7 @@ int smlua_func_cur_obj_move_using_vel_and_gravity(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_move_using_fvel_and_gravity(UNUSED lua_State* L) {
+int smlua_func_cur_obj_move_using_fvel_and_gravity(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28242,7 +28242,7 @@ int smlua_func_obj_set_pos_relative(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_angle_to_home(UNUSED lua_State* L) {
+int smlua_func_cur_obj_angle_to_home(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28376,7 +28376,7 @@ int smlua_func_obj_create_transform_from_self(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_rotate_move_angle_using_vel(UNUSED lua_State* L) {
+int smlua_func_cur_obj_rotate_move_angle_using_vel(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28392,7 +28392,7 @@ int smlua_func_cur_obj_rotate_move_angle_using_vel(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_rotate_face_angle_using_vel(UNUSED lua_State* L) {
+int smlua_func_cur_obj_rotate_face_angle_using_vel(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28408,7 +28408,7 @@ int smlua_func_cur_obj_rotate_face_angle_using_vel(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_set_face_angle_to_move_angle(UNUSED lua_State* L) {
+int smlua_func_cur_obj_set_face_angle_to_move_angle(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28558,7 +28558,7 @@ int smlua_func_obj_build_vel_from_transform(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_set_pos_via_transform(UNUSED lua_State* L) {
+int smlua_func_cur_obj_set_pos_via_transform(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28574,7 +28574,7 @@ int smlua_func_cur_obj_set_pos_via_transform(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_reflect_move_angle_off_wall(UNUSED lua_State* L) {
+int smlua_func_cur_obj_reflect_move_angle_off_wall(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28666,7 +28666,7 @@ int smlua_func_cur_obj_wait_then_blink(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_is_mario_ground_pounding_platform(UNUSED lua_State* L) {
+int smlua_func_cur_obj_is_mario_ground_pounding_platform(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28702,7 +28702,7 @@ int smlua_func_obj_is_mario_ground_pounding_platform(lua_State* L) {
     return 1;
 }
 
-int smlua_func_spawn_mist_particles(UNUSED lua_State* L) {
+int smlua_func_spawn_mist_particles(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28774,7 +28774,7 @@ int smlua_func_cur_obj_push_mario_away_from_cylinder(lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_dust_smoke_loop(UNUSED lua_State* L) {
+int smlua_func_bhv_dust_smoke_loop(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28834,7 +28834,7 @@ int smlua_func_cur_obj_scale_over_time(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_set_pos_to_home_with_debug(UNUSED lua_State* L) {
+int smlua_func_cur_obj_set_pos_to_home_with_debug(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28850,7 +28850,7 @@ int smlua_func_cur_obj_set_pos_to_home_with_debug(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_stub_obj_helpers_4(UNUSED lua_State* L) {
+int smlua_func_stub_obj_helpers_4(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28866,7 +28866,7 @@ int smlua_func_stub_obj_helpers_4(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_is_mario_on_platform(UNUSED lua_State* L) {
+int smlua_func_cur_obj_is_mario_on_platform(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28882,7 +28882,7 @@ int smlua_func_cur_obj_is_mario_on_platform(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_is_any_player_on_platform(UNUSED lua_State* L) {
+int smlua_func_cur_obj_is_any_player_on_platform(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28956,7 +28956,7 @@ int smlua_func_spawn_star_with_no_lvl_exit(lua_State* L) {
     return 1;
 }
 
-int smlua_func_spawn_base_star_with_no_lvl_exit(UNUSED lua_State* L) {
+int smlua_func_spawn_base_star_with_no_lvl_exit(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -28990,7 +28990,7 @@ int smlua_func_bit_shift_left(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_mario_far_away(UNUSED lua_State* L) {
+int smlua_func_cur_obj_mario_far_away(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29044,7 +29044,7 @@ int smlua_func_is_item_in_array(lua_State* L) {
     return 1;
 }
 
-int smlua_func_bhv_init_room(UNUSED lua_State* L) {
+int smlua_func_bhv_init_room(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29060,7 +29060,7 @@ int smlua_func_bhv_init_room(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_enable_rendering_if_mario_in_room(UNUSED lua_State* L) {
+int smlua_func_cur_obj_enable_rendering_if_mario_in_room(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29140,7 +29140,7 @@ int smlua_func_obj_set_collision_data(lua_State* L) {
 }
 */
 
-int smlua_func_cur_obj_if_hit_wall_bounce_away(UNUSED lua_State* L) {
+int smlua_func_cur_obj_if_hit_wall_bounce_away(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29192,7 +29192,7 @@ int smlua_func_obj_is_hidden(lua_State* L) {
     return 1;
 }
 
-int smlua_func_enable_time_stop(UNUSED lua_State* L) {
+int smlua_func_enable_time_stop(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29208,7 +29208,7 @@ int smlua_func_enable_time_stop(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_enable_time_stop_if_alone(UNUSED lua_State* L) {
+int smlua_func_enable_time_stop_if_alone(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29224,7 +29224,7 @@ int smlua_func_enable_time_stop_if_alone(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_disable_time_stop(UNUSED lua_State* L) {
+int smlua_func_disable_time_stop(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29380,7 +29380,7 @@ int smlua_func_cur_obj_has_model(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_align_gfx_with_floor(UNUSED lua_State* L) {
+int smlua_func_cur_obj_align_gfx_with_floor(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29456,7 +29456,7 @@ int smlua_func_obj_attack_collided_from_other_object(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_was_attacked_or_ground_pounded(UNUSED lua_State* L) {
+int smlua_func_cur_obj_was_attacked_or_ground_pounded(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29548,7 +29548,7 @@ int smlua_func_cur_obj_init_animation_and_extend_if_at_end(lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_check_grabbed_mario(UNUSED lua_State* L) {
+int smlua_func_cur_obj_check_grabbed_mario(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29564,7 +29564,7 @@ int smlua_func_cur_obj_check_grabbed_mario(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_player_performed_grab_escape_action(UNUSED lua_State* L) {
+int smlua_func_player_performed_grab_escape_action(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29602,7 +29602,7 @@ int smlua_func_cur_obj_unused_play_footstep_sound(lua_State* L) {
     return 1;
 }
 
-int smlua_func_enable_time_stop_including_mario(UNUSED lua_State* L) {
+int smlua_func_enable_time_stop_including_mario(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29618,7 +29618,7 @@ int smlua_func_enable_time_stop_including_mario(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_disable_time_stop_including_mario(UNUSED lua_State* L) {
+int smlua_func_disable_time_stop_including_mario(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29634,7 +29634,7 @@ int smlua_func_disable_time_stop_including_mario(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_check_interacted(UNUSED lua_State* L) {
+int smlua_func_cur_obj_check_interacted(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29650,7 +29650,7 @@ int smlua_func_cur_obj_check_interacted(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_cur_obj_spawn_loot_blue_coin(UNUSED lua_State* L) {
+int smlua_func_cur_obj_spawn_loot_blue_coin(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29692,7 +29692,7 @@ int smlua_func_cur_obj_spawn_star_at_y_offset(lua_State* L) {
 }
 #endif
 
-int smlua_func_cur_obj_set_home_once(UNUSED lua_State* L) {
+int smlua_func_cur_obj_set_home_once(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -29966,7 +29966,7 @@ int smlua_func_save_file_erase(lua_State* L) {
     return 1;
 }
 
-int smlua_func_save_file_erase_current_backup_save(UNUSED lua_State* L) {
+int smlua_func_save_file_erase_current_backup_save(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -30089,7 +30089,7 @@ int smlua_func_save_file_clear_flags(lua_State* L) {
     return 1;
 }
 
-int smlua_func_save_file_get_flags(UNUSED lua_State* L) {
+int smlua_func_save_file_get_flags(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -30224,7 +30224,7 @@ int smlua_func_save_file_is_cannon_unlocked(lua_State* L) {
     return 1;
 }
 
-int smlua_func_save_file_set_cannon_unlocked(UNUSED lua_State* L) {
+int smlua_func_save_file_set_cannon_unlocked(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -30260,7 +30260,7 @@ int smlua_func_save_file_get_cap_pos(lua_State* L) {
     return 1;
 }
 
-int smlua_func_save_file_get_sound_mode(UNUSED lua_State* L) {
+int smlua_func_save_file_get_sound_mode(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -30499,7 +30499,7 @@ int smlua_func_smlua_anim_util_get_current_animation_name(lua_State* L) {
  // smlua_audio_utils.h //
 /////////////////////////
 
-int smlua_func_smlua_audio_utils_reset_all(UNUSED lua_State* L) {
+int smlua_func_smlua_audio_utils_reset_all(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -30537,7 +30537,7 @@ int smlua_func_smlua_audio_utils_replace_sequence(lua_State* L) {
     return 1;
 }
 
-int smlua_func_smlua_audio_utils_allocate_sequence(UNUSED lua_State* L) {
+int smlua_func_smlua_audio_utils_allocate_sequence(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -30920,7 +30920,7 @@ int smlua_func_audio_sample_play(lua_State* L) {
  // smlua_camera_utils.h //
 //////////////////////////
 
-int smlua_func_camera_reset_overrides(UNUSED lua_State* L) {
+int smlua_func_camera_reset_overrides(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -30935,7 +30935,7 @@ int smlua_func_camera_reset_overrides(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_freeze(UNUSED lua_State* L) {
+int smlua_func_camera_freeze(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -30950,7 +30950,7 @@ int smlua_func_camera_freeze(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_unfreeze(UNUSED lua_State* L) {
+int smlua_func_camera_unfreeze(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -30965,7 +30965,7 @@ int smlua_func_camera_unfreeze(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_is_frozen(UNUSED lua_State* L) {
+int smlua_func_camera_is_frozen(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31150,7 +31150,7 @@ int smlua_func_camera_romhack_set_zoomed_out_height(lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_romhack_get_zoomed_in_dist(UNUSED lua_State* L) {
+int smlua_func_camera_romhack_get_zoomed_in_dist(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31165,7 +31165,7 @@ int smlua_func_camera_romhack_get_zoomed_in_dist(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_romhack_get_zoomed_out_dist(UNUSED lua_State* L) {
+int smlua_func_camera_romhack_get_zoomed_out_dist(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31180,7 +31180,7 @@ int smlua_func_camera_romhack_get_zoomed_out_dist(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_romhack_get_zoomed_in_height(UNUSED lua_State* L) {
+int smlua_func_camera_romhack_get_zoomed_in_height(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31195,7 +31195,7 @@ int smlua_func_camera_romhack_get_zoomed_in_height(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_romhack_get_zoomed_out_height(UNUSED lua_State* L) {
+int smlua_func_camera_romhack_get_zoomed_out_height(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31210,7 +31210,7 @@ int smlua_func_camera_romhack_get_zoomed_out_height(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_get_romhack_override(UNUSED lua_State* L) {
+int smlua_func_camera_get_romhack_override(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31225,7 +31225,7 @@ int smlua_func_camera_get_romhack_override(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_romhack_get_allow_switchable(UNUSED lua_State* L) {
+int smlua_func_camera_romhack_get_allow_switchable(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31240,7 +31240,7 @@ int smlua_func_camera_romhack_get_allow_switchable(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_get_allow_toxic_gas_camera(UNUSED lua_State* L) {
+int smlua_func_camera_get_allow_toxic_gas_camera(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31255,7 +31255,7 @@ int smlua_func_camera_get_allow_toxic_gas_camera(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_romhack_get_allow_dpad_usage(UNUSED lua_State* L) {
+int smlua_func_camera_romhack_get_allow_dpad_usage(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31270,7 +31270,7 @@ int smlua_func_camera_romhack_get_allow_dpad_usage(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_romhack_get_collisions(UNUSED lua_State* L) {
+int smlua_func_camera_romhack_get_collisions(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31285,7 +31285,7 @@ int smlua_func_camera_romhack_get_collisions(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_config_is_free_cam_enabled(UNUSED lua_State* L) {
+int smlua_func_camera_config_is_free_cam_enabled(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31300,7 +31300,7 @@ int smlua_func_camera_config_is_free_cam_enabled(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_config_is_analog_cam_enabled(UNUSED lua_State* L) {
+int smlua_func_camera_config_is_analog_cam_enabled(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31315,7 +31315,7 @@ int smlua_func_camera_config_is_analog_cam_enabled(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_config_is_dpad_enabled(UNUSED lua_State* L) {
+int smlua_func_camera_config_is_dpad_enabled(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31330,7 +31330,7 @@ int smlua_func_camera_config_is_dpad_enabled(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_config_is_collision_enabled(UNUSED lua_State* L) {
+int smlua_func_camera_config_is_collision_enabled(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31345,7 +31345,7 @@ int smlua_func_camera_config_is_collision_enabled(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_config_is_mouse_look_enabled(UNUSED lua_State* L) {
+int smlua_func_camera_config_is_mouse_look_enabled(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31360,7 +31360,7 @@ int smlua_func_camera_config_is_mouse_look_enabled(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_config_is_x_inverted(UNUSED lua_State* L) {
+int smlua_func_camera_config_is_x_inverted(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31375,7 +31375,7 @@ int smlua_func_camera_config_is_x_inverted(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_config_is_y_inverted(UNUSED lua_State* L) {
+int smlua_func_camera_config_is_y_inverted(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31390,7 +31390,7 @@ int smlua_func_camera_config_is_y_inverted(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_config_get_x_sensitivity(UNUSED lua_State* L) {
+int smlua_func_camera_config_get_x_sensitivity(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31405,7 +31405,7 @@ int smlua_func_camera_config_get_x_sensitivity(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_config_get_y_sensitivity(UNUSED lua_State* L) {
+int smlua_func_camera_config_get_y_sensitivity(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31420,7 +31420,7 @@ int smlua_func_camera_config_get_y_sensitivity(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_config_get_aggression(UNUSED lua_State* L) {
+int smlua_func_camera_config_get_aggression(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31435,7 +31435,7 @@ int smlua_func_camera_config_get_aggression(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_config_get_pan_level(UNUSED lua_State* L) {
+int smlua_func_camera_config_get_pan_level(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31450,7 +31450,7 @@ int smlua_func_camera_config_get_pan_level(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_config_get_deceleration(UNUSED lua_State* L) {
+int smlua_func_camera_config_get_deceleration(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31465,7 +31465,7 @@ int smlua_func_camera_config_get_deceleration(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_config_get_centering(UNUSED lua_State* L) {
+int smlua_func_camera_config_get_centering(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31701,7 +31701,7 @@ int smlua_func_camera_config_set_deceleration(lua_State* L) {
     return 1;
 }
 
-int smlua_func_camera_get_checking_surfaces(UNUSED lua_State* L) {
+int smlua_func_camera_get_checking_surfaces(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31779,7 +31779,7 @@ int smlua_func_collision_find_ceil(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_water_surface_pseudo_floor(UNUSED lua_State* L) {
+int smlua_func_get_water_surface_pseudo_floor(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31811,7 +31811,7 @@ int smlua_func_smlua_collision_util_get(lua_State* L) {
     return 1;
 }
 
-int smlua_func_collision_get_temp_wall_collision_data(UNUSED lua_State* L) {
+int smlua_func_collision_get_temp_wall_collision_data(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -31845,7 +31845,7 @@ int smlua_func_get_surface_from_wcd_index(lua_State* L) {
     return 1;
 }
 
-int smlua_func_smlua_collision_util_get_current_terrain_collision(UNUSED lua_State* L) {
+int smlua_func_smlua_collision_util_get_current_terrain_collision(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -32228,7 +32228,7 @@ int smlua_func_set_shader_flag_value(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_global_shader_flags_enabled(UNUSED lua_State* L) {
+int smlua_func_get_global_shader_flags_enabled(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -32260,7 +32260,7 @@ int smlua_func_set_global_shader_flags_enabled(lua_State* L) {
     return 1;
 }
 
-int smlua_func_clear_all_shader_flags(UNUSED lua_State* L) {
+int smlua_func_clear_all_shader_flags(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -32275,7 +32275,7 @@ int smlua_func_clear_all_shader_flags(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_shading_fullbright_enabled(UNUSED lua_State* L) {
+int smlua_func_get_shading_fullbright_enabled(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -32538,7 +32538,7 @@ int smlua_func_set_fog_color(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_fog_intensity(UNUSED lua_State* L) {
+int smlua_func_get_fog_intensity(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -32570,7 +32570,7 @@ int smlua_func_set_fog_intensity(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_skybox(UNUSED lua_State* L) {
+int smlua_func_get_skybox(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -32909,7 +32909,7 @@ int smlua_func_gfx_delete(lua_State* L) {
     return 1;
 }
 
-int smlua_func_gfx_delete_all(UNUSED lua_State* L) {
+int smlua_func_gfx_delete_all(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33091,7 +33091,7 @@ int smlua_func_vtx_delete(lua_State* L) {
     return 1;
 }
 
-int smlua_func_vtx_delete_all(UNUSED lua_State* L) {
+int smlua_func_vtx_delete_all(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33270,7 +33270,7 @@ int smlua_func_warp_to_level(lua_State* L) {
     return 1;
 }
 
-int smlua_func_warp_restart_level(UNUSED lua_State* L) {
+int smlua_func_warp_restart_level(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33285,7 +33285,7 @@ int smlua_func_warp_restart_level(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_warp_to_start_level(UNUSED lua_State* L) {
+int smlua_func_warp_to_start_level(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33338,7 +33338,7 @@ int smlua_func_warp_to_castle(lua_State* L) {
  // smlua_misc_utils.h //
 ////////////////////////
 
-int smlua_func_get_network_area_timer(UNUSED lua_State* L) {
+int smlua_func_get_network_area_timer(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33353,7 +33353,7 @@ int smlua_func_get_network_area_timer(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_area_update_counter(UNUSED lua_State* L) {
+int smlua_func_get_area_update_counter(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33421,7 +33421,7 @@ int smlua_func_djui_popup_create_global(lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_is_popup_disabled(UNUSED lua_State* L) {
+int smlua_func_djui_is_popup_disabled(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33453,7 +33453,7 @@ int smlua_func_djui_set_popup_disabled_override(lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_reset_popup_disabled_override(UNUSED lua_State* L) {
+int smlua_func_djui_reset_popup_disabled_override(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33468,7 +33468,7 @@ int smlua_func_djui_reset_popup_disabled_override(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_is_playerlist_open(UNUSED lua_State* L) {
+int smlua_func_djui_is_playerlist_open(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33483,7 +33483,7 @@ int smlua_func_djui_is_playerlist_open(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_attempting_to_open_playerlist(UNUSED lua_State* L) {
+int smlua_func_djui_attempting_to_open_playerlist(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33498,7 +33498,7 @@ int smlua_func_djui_attempting_to_open_playerlist(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_get_playerlist_page_index(UNUSED lua_State* L) {
+int smlua_func_djui_get_playerlist_page_index(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33513,7 +33513,7 @@ int smlua_func_djui_get_playerlist_page_index(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_is_chatbox_open(UNUSED lua_State* L) {
+int smlua_func_djui_is_chatbox_open(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33528,7 +33528,7 @@ int smlua_func_djui_is_chatbox_open(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_menu_get_font(UNUSED lua_State* L) {
+int smlua_func_djui_menu_get_font(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33543,7 +33543,7 @@ int smlua_func_djui_menu_get_font(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_menu_get_theme(UNUSED lua_State* L) {
+int smlua_func_djui_menu_get_theme(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33558,7 +33558,7 @@ int smlua_func_djui_menu_get_theme(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_djui_is_playerlist_ping_visible(UNUSED lua_State* L) {
+int smlua_func_djui_is_playerlist_ping_visible(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33573,7 +33573,7 @@ int smlua_func_djui_is_playerlist_ping_visible(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_dialog_box_state(UNUSED lua_State* L) {
+int smlua_func_get_dialog_box_state(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33588,7 +33588,7 @@ int smlua_func_get_dialog_box_state(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_dialog_id(UNUSED lua_State* L) {
+int smlua_func_get_dialog_id(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33603,7 +33603,7 @@ int smlua_func_get_dialog_id(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_last_star_or_key(UNUSED lua_State* L) {
+int smlua_func_get_last_star_or_key(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33635,7 +33635,7 @@ int smlua_func_set_last_star_or_key(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_last_completed_course_num(UNUSED lua_State* L) {
+int smlua_func_get_last_completed_course_num(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33667,7 +33667,7 @@ int smlua_func_set_last_completed_course_num(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_last_completed_star_num(UNUSED lua_State* L) {
+int smlua_func_get_last_completed_star_num(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33699,7 +33699,7 @@ int smlua_func_set_last_completed_star_num(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_got_file_coin_hi_score(UNUSED lua_State* L) {
+int smlua_func_get_got_file_coin_hi_score(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33731,7 +33731,7 @@ int smlua_func_set_got_file_coin_hi_score(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_save_file_modified(UNUSED lua_State* L) {
+int smlua_func_get_save_file_modified(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33763,7 +33763,7 @@ int smlua_func_set_save_file_modified(lua_State* L) {
     return 1;
 }
 
-int smlua_func_hud_hide(UNUSED lua_State* L) {
+int smlua_func_hud_hide(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33778,7 +33778,7 @@ int smlua_func_hud_hide(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_hud_show(UNUSED lua_State* L) {
+int smlua_func_hud_show(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33793,7 +33793,7 @@ int smlua_func_hud_show(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_hud_is_hidden(UNUSED lua_State* L) {
+int smlua_func_hud_is_hidden(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33902,7 +33902,7 @@ int smlua_func_hud_render_power_meter_interpolated(lua_State* L) {
     return 1;
 }
 
-int smlua_func_hud_get_flash(UNUSED lua_State* L) {
+int smlua_func_hud_get_flash(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -33985,7 +33985,7 @@ int smlua_func_act_select_hud_is_hidden(lua_State* L) {
     return 1;
 }
 
-int smlua_func_is_game_paused(UNUSED lua_State* L) {
+int smlua_func_is_game_paused(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34000,7 +34000,7 @@ int smlua_func_is_game_paused(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_is_pause_menu_hidden(UNUSED lua_State* L) {
+int smlua_func_is_pause_menu_hidden(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34032,7 +34032,7 @@ int smlua_func_set_pause_menu_hidden(lua_State* L) {
     return 1;
 }
 
-int smlua_func_game_pause(UNUSED lua_State* L) {
+int smlua_func_game_pause(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34047,7 +34047,7 @@ int smlua_func_game_pause(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_game_unpause(UNUSED lua_State* L) {
+int smlua_func_game_unpause(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34062,7 +34062,7 @@ int smlua_func_game_unpause(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_is_transition_playing(UNUSED lua_State* L) {
+int smlua_func_is_transition_playing(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34201,7 +34201,7 @@ int smlua_func_get_mario_anim_part_rot(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_current_save_file_num(UNUSED lua_State* L) {
+int smlua_func_get_current_save_file_num(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34216,7 +34216,7 @@ int smlua_func_get_current_save_file_num(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_save_file_get_using_backup_slot(UNUSED lua_State* L) {
+int smlua_func_save_file_get_using_backup_slot(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34326,7 +34326,7 @@ int smlua_func_course_is_main_course(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_ttc_speed_setting(UNUSED lua_State* L) {
+int smlua_func_get_ttc_speed_setting(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34358,7 +34358,7 @@ int smlua_func_set_ttc_speed_setting(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_time(UNUSED lua_State* L) {
+int smlua_func_get_time(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34373,7 +34373,7 @@ int smlua_func_get_time(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_date_and_time(UNUSED lua_State* L) {
+int smlua_func_get_date_and_time(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34388,7 +34388,7 @@ int smlua_func_get_date_and_time(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_envfx(UNUSED lua_State* L) {
+int smlua_func_get_envfx(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34420,7 +34420,7 @@ int smlua_func_set_override_envfx(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_global_timer(UNUSED lua_State* L) {
+int smlua_func_get_global_timer(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34435,7 +34435,7 @@ int smlua_func_get_global_timer(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_dialog_response(UNUSED lua_State* L) {
+int smlua_func_get_dialog_response(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34450,7 +34450,7 @@ int smlua_func_get_dialog_response(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_time_stop_flags(UNUSED lua_State* L) {
+int smlua_func_get_time_stop_flags(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34465,7 +34465,7 @@ int smlua_func_get_time_stop_flags(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_local_discord_id(UNUSED lua_State* L) {
+int smlua_func_get_local_discord_id(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34497,7 +34497,7 @@ int smlua_func_get_coopnet_id(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_volume_master(UNUSED lua_State* L) {
+int smlua_func_get_volume_master(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34512,7 +34512,7 @@ int smlua_func_get_volume_master(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_volume_level(UNUSED lua_State* L) {
+int smlua_func_get_volume_level(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34527,7 +34527,7 @@ int smlua_func_get_volume_level(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_volume_sfx(UNUSED lua_State* L) {
+int smlua_func_get_volume_sfx(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34542,7 +34542,7 @@ int smlua_func_get_volume_sfx(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_volume_env(UNUSED lua_State* L) {
+int smlua_func_get_volume_env(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34678,7 +34678,7 @@ int smlua_func_mod_file_exists(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_active_mod(UNUSED lua_State* L) {
+int smlua_func_get_active_mod(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34732,7 +34732,7 @@ int smlua_func_set_window_title(lua_State* L) {
     return 1;
 }
 
-int smlua_func_reset_window_title(UNUSED lua_State* L) {
+int smlua_func_reset_window_title(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34747,7 +34747,7 @@ int smlua_func_reset_window_title(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_os_name(UNUSED lua_State* L) {
+int smlua_func_get_os_name(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34762,7 +34762,7 @@ int smlua_func_get_os_name(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_geo_get_current_root(UNUSED lua_State* L) {
+int smlua_func_geo_get_current_root(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34777,7 +34777,7 @@ int smlua_func_geo_get_current_root(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_geo_get_current_master_list(UNUSED lua_State* L) {
+int smlua_func_geo_get_current_master_list(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34792,7 +34792,7 @@ int smlua_func_geo_get_current_master_list(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_geo_get_current_perspective(UNUSED lua_State* L) {
+int smlua_func_geo_get_current_perspective(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34807,7 +34807,7 @@ int smlua_func_geo_get_current_perspective(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_geo_get_current_camera(UNUSED lua_State* L) {
+int smlua_func_geo_get_current_camera(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34822,7 +34822,7 @@ int smlua_func_geo_get_current_camera(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_geo_get_current_held_object(UNUSED lua_State* L) {
+int smlua_func_geo_get_current_held_object(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -35060,7 +35060,7 @@ int smlua_func_get_trajectory(lua_State* L) {
     return 1;
 }
 
-int smlua_func_geo_get_current_object(UNUSED lua_State* L) {
+int smlua_func_geo_get_current_object(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -35075,7 +35075,7 @@ int smlua_func_geo_get_current_object(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_current_object(UNUSED lua_State* L) {
+int smlua_func_get_current_object(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -35090,7 +35090,7 @@ int smlua_func_get_current_object(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_dialog_object(UNUSED lua_State* L) {
+int smlua_func_get_dialog_object(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -35105,7 +35105,7 @@ int smlua_func_get_dialog_object(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_cutscene_focus(UNUSED lua_State* L) {
+int smlua_func_get_cutscene_focus(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -35120,7 +35120,7 @@ int smlua_func_get_cutscene_focus(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_secondary_camera_focus(UNUSED lua_State* L) {
+int smlua_func_get_secondary_camera_focus(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -35576,7 +35576,7 @@ int smlua_func_obj_get_temp_water_droplet_params(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_temp_object_hitbox(UNUSED lua_State* L) {
+int smlua_func_get_temp_object_hitbox(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -35903,7 +35903,7 @@ int smlua_func_obj_anim_skip_interpolation(lua_State* L) {
  // smlua_text_utils.h //
 ////////////////////////
 
-int smlua_func_smlua_text_utils_reset_all(UNUSED lua_State* L) {
+int smlua_func_smlua_text_utils_reset_all(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -35996,7 +35996,7 @@ int smlua_func_smlua_text_utils_dialog_is_replaced(lua_State* L) {
     return 1;
 }
 
-int smlua_func_smlua_text_utils_allocate_dialog(UNUSED lua_State* L) {
+int smlua_func_smlua_text_utils_allocate_dialog(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36226,7 +36226,7 @@ int smlua_func_smlua_text_utils_castle_secret_stars_replace(lua_State* L) {
     return 1;
 }
 
-int smlua_func_smlua_text_utils_castle_secret_stars_get(UNUSED lua_State* L) {
+int smlua_func_smlua_text_utils_castle_secret_stars_get(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36241,7 +36241,7 @@ int smlua_func_smlua_text_utils_castle_secret_stars_get(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_smlua_text_utils_castle_secret_stars_mod_index(UNUSED lua_State* L) {
+int smlua_func_smlua_text_utils_castle_secret_stars_mod_index(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36256,7 +36256,7 @@ int smlua_func_smlua_text_utils_castle_secret_stars_mod_index(UNUSED lua_State* 
     return 1;
 }
 
-int smlua_func_smlua_text_utils_castle_secret_stars_reset(UNUSED lua_State* L) {
+int smlua_func_smlua_text_utils_castle_secret_stars_reset(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36341,7 +36341,7 @@ int smlua_func_smlua_text_utils_extra_text_reset(lua_State* L) {
     return 1;
 }
 
-int smlua_func_smlua_text_utils_get_language(UNUSED lua_State* L) {
+int smlua_func_smlua_text_utils_get_language(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36360,7 +36360,7 @@ int smlua_func_smlua_text_utils_get_language(UNUSED lua_State* L) {
  // sound_init.h //
 //////////////////
 
-int smlua_func_reset_volume(UNUSED lua_State* L) {
+int smlua_func_reset_volume(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36409,7 +36409,7 @@ int smlua_func_lower_background_noise(lua_State* L) {
     return 1;
 }
 
-int smlua_func_disable_background_sound(UNUSED lua_State* L) {
+int smlua_func_disable_background_sound(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36424,7 +36424,7 @@ int smlua_func_disable_background_sound(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_enable_background_sound(UNUSED lua_State* L) {
+int smlua_func_enable_background_sound(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36456,7 +36456,7 @@ int smlua_func_play_menu_sounds(lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_painting_eject_sound(UNUSED lua_State* L) {
+int smlua_func_play_painting_eject_sound(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36471,7 +36471,7 @@ int smlua_func_play_painting_eject_sound(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_infinite_stairs_music(UNUSED lua_State* L) {
+int smlua_func_play_infinite_stairs_music(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36558,7 +36558,7 @@ int smlua_func_play_cutscene_music(lua_State* L) {
     return 1;
 }
 
-int smlua_func_play_shell_music(UNUSED lua_State* L) {
+int smlua_func_play_shell_music(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36573,7 +36573,7 @@ int smlua_func_play_shell_music(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_stop_shell_music(UNUSED lua_State* L) {
+int smlua_func_stop_shell_music(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36605,7 +36605,7 @@ int smlua_func_play_cap_music(lua_State* L) {
     return 1;
 }
 
-int smlua_func_fadeout_cap_music(UNUSED lua_State* L) {
+int smlua_func_fadeout_cap_music(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36620,7 +36620,7 @@ int smlua_func_fadeout_cap_music(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_stop_cap_music(UNUSED lua_State* L) {
+int smlua_func_stop_cap_music(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -36987,7 +36987,7 @@ int smlua_func_closest_point_to_triangle(lua_State* L) {
  // surface_load.h //
 ////////////////////
 
-int smlua_func_load_object_collision_model(UNUSED lua_State* L) {
+int smlua_func_load_object_collision_model(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -37002,7 +37002,7 @@ int smlua_func_load_object_collision_model(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_load_static_object_collision(UNUSED lua_State* L) {
+int smlua_func_load_static_object_collision(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);


### PR DESCRIPTION
Some smlua autogen functions have the lua state marked as UNUSED despite the fact that it is always used. This fixes that.