### PR TITLE
Add default values for mod_storage_load functions

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -8079,30 +8079,34 @@ function mod_storage_save_bool(key, value)
 end
 
 --- @param key string
+--- @param defaultValue? string
 --- @return string
---- Loads a string `value` from a `key` in mod storage
-function mod_storage_load(key)
+--- Loads a string `value` from a `key` in mod storage. If the `key` is not found, returns `defaultValue` or `nil`
+function mod_storage_load(key, defaultValue)
     -- ...
 end
 
 --- @param key string
+--- @param defaultValue? integer
 --- @return integer
---- Loads an integer `value` from a `key` in mod storage
-function mod_storage_load_integer(key)
+--- Loads an integer `value` from a `key` in mod storage. If the `key` is not found, returns `defaultValue` or `0`
+function mod_storage_load_integer(key, defaultValue)
     -- ...
 end
 
 --- @param key string
+--- @param defaultValue? number
 --- @return number
---- Loads a number `value` from a `key` in mod storage
-function mod_storage_load_number(key)
+--- Loads a number `value` from a `key` in mod storage. If the `key` is not found, returns `defaultValue` or `0`
+function mod_storage_load_number(key, defaultValue)
     -- ...
 end
 
 --- @param key string
+--- @param defaultValue? boolean
 --- @return boolean
---- Loads a bool `value` from a `key` in mod storage
-function mod_storage_load_bool(key)
+--- Loads a bool `value` from a `key` in mod storage. If the `key` is not found, returns `defaultValue` or `false`
+function mod_storage_load_bool(key, defaultValue)
     -- ...
 end
 

--- a/docs/lua/functions-5.md
+++ b/docs/lua/functions-5.md
@@ -2295,21 +2295,22 @@ Saves a `key` corresponding to a bool `value` to mod storage
 ## [mod_storage_load](#mod_storage_load)
 
 ### Description
-Loads a string `value` from a `key` in mod storage
+Loads a string `value` from a `key` in mod storage. If the `key` is not found, returns `defaultValue` or `nil`
 
 ### Lua Example
-`local stringValue = mod_storage_load(key)`
+`local stringValue = mod_storage_load(key, defaultValue)`
 
 ### Parameters
 | Field | Type |
 | ----- | ---- |
 | key | `string` |
+| defaultValue | `string` |
 
 ### Returns
 - `string`
 
 ### C Prototype
-`const char *mod_storage_load(const char* key);`
+`const char *mod_storage_load(const char* key, OPTIONAL const char* defaultValue);`
 
 [:arrow_up_small:](#)
 
@@ -2318,21 +2319,22 @@ Loads a string `value` from a `key` in mod storage
 ## [mod_storage_load_integer](#mod_storage_load_integer)
 
 ### Description
-Loads an integer `value` from a `key` in mod storage
+Loads an integer `value` from a `key` in mod storage. If the `key` is not found, returns `defaultValue` or `0`
 
 ### Lua Example
-`local integerValue = mod_storage_load_integer(key)`
+`local integerValue = mod_storage_load_integer(key, defaultValue)`
 
 ### Parameters
 | Field | Type |
 | ----- | ---- |
 | key | `string` |
+| defaultValue | `integer` |
 
 ### Returns
 - `integer`
 
 ### C Prototype
-`lua_Integer mod_storage_load_integer(const char* key);`
+`lua_Integer mod_storage_load_integer(const char* key, OPTIONAL lua_Integer defaultValue);`
 
 [:arrow_up_small:](#)
 
@@ -2341,21 +2343,22 @@ Loads an integer `value` from a `key` in mod storage
 ## [mod_storage_load_number](#mod_storage_load_number)
 
 ### Description
-Loads a number `value` from a `key` in mod storage
+Loads a number `value` from a `key` in mod storage. If the `key` is not found, returns `defaultValue` or `0`
 
 ### Lua Example
-`local numberValue = mod_storage_load_number(key)`
+`local numberValue = mod_storage_load_number(key, defaultValue)`
 
 ### Parameters
 | Field | Type |
 | ----- | ---- |
 | key | `string` |
+| defaultValue | `number` |
 
 ### Returns
 - `number`
 
 ### C Prototype
-`lua_Number mod_storage_load_number(const char* key);`
+`lua_Number mod_storage_load_number(const char* key, OPTIONAL lua_Number defaultValue);`
 
 [:arrow_up_small:](#)
 
@@ -2364,21 +2367,22 @@ Loads a number `value` from a `key` in mod storage
 ## [mod_storage_load_bool](#mod_storage_load_bool)
 
 ### Description
-Loads a bool `value` from a `key` in mod storage
+Loads a bool `value` from a `key` in mod storage. If the `key` is not found, returns `defaultValue` or `false`
 
 ### Lua Example
-`local booleanValue = mod_storage_load_bool(key)`
+`local booleanValue = mod_storage_load_bool(key, defaultValue)`
 
 ### Parameters
 | Field | Type |
 | ----- | ---- |
 | key | `string` |
+| defaultValue | `boolean` |
 
 ### Returns
 - `boolean`
 
 ### C Prototype
-`bool mod_storage_load_bool(const char* key);`
+`bool mod_storage_load_bool(const char* key, OPTIONAL bool defaultValue);`
 
 [:arrow_up_small:](#)
 

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -23201,15 +23201,20 @@ int smlua_func_mod_storage_load(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
-    if (top != 1) {
-        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "mod_storage_load", 1, top);
+    if (top < 1 || top > 2) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "mod_storage_load", 1, 2, top);
         return 0;
     }
 
     const char* key = smlua_to_string(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "mod_storage_load"); return 0; }
+    const char* defaultValue = (const char*) NULL;
+    if (top >= 2) {
+        defaultValue = smlua_to_string(L, 2);
+        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "mod_storage_load"); return 0; }
+    }
 
-    lua_pushstring(L, mod_storage_load(key));
+    lua_pushstring(L, mod_storage_load(key, defaultValue));
 
     return 1;
 }
@@ -23218,15 +23223,20 @@ int smlua_func_mod_storage_load_integer(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
-    if (top != 1) {
-        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "mod_storage_load_integer", 1, top);
+    if (top < 1 || top > 2) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "mod_storage_load_integer", 1, 2, top);
         return 0;
     }
 
     const char* key = smlua_to_string(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "mod_storage_load_integer"); return 0; }
+    lua_Integer defaultValue = (lua_Integer) 0;
+    if (top >= 2) {
+        defaultValue = smlua_to_integer(L, 2);
+        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "mod_storage_load_integer"); return 0; }
+    }
 
-    lua_pushinteger(L, mod_storage_load_integer(key));
+    lua_pushinteger(L, mod_storage_load_integer(key, defaultValue));
 
     return 1;
 }
@@ -23235,15 +23245,20 @@ int smlua_func_mod_storage_load_number(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
-    if (top != 1) {
-        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "mod_storage_load_number", 1, top);
+    if (top < 1 || top > 2) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "mod_storage_load_number", 1, 2, top);
         return 0;
     }
 
     const char* key = smlua_to_string(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "mod_storage_load_number"); return 0; }
+    lua_Number defaultValue = (lua_Number) 0;
+    if (top >= 2) {
+        defaultValue = smlua_to_number(L, 2);
+        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "mod_storage_load_number"); return 0; }
+    }
 
-    lua_pushnumber(L, mod_storage_load_number(key));
+    lua_pushnumber(L, mod_storage_load_number(key, defaultValue));
 
     return 1;
 }
@@ -23252,15 +23267,20 @@ int smlua_func_mod_storage_load_bool(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
-    if (top != 1) {
-        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "mod_storage_load_bool", 1, top);
+    if (top < 1 || top > 2) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "mod_storage_load_bool", 1, 2, top);
         return 0;
     }
 
     const char* key = smlua_to_string(L, 1);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "mod_storage_load_bool"); return 0; }
+    bool defaultValue = (bool) 0;
+    if (top >= 2) {
+        defaultValue = smlua_to_boolean(L, 2);
+        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "mod_storage_load_bool"); return 0; }
+    }
 
-    lua_pushboolean(L, mod_storage_load_bool(key));
+    lua_pushboolean(L, mod_storage_load_bool(key, defaultValue));
 
     return 1;
 }
@@ -34077,7 +34097,7 @@ int smlua_func_is_transition_playing(lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_current_play_mode(UNUSED lua_State* L) {
+int smlua_func_get_current_play_mode(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
@@ -34092,7 +34112,7 @@ int smlua_func_get_current_play_mode(UNUSED lua_State* L) {
     return 1;
 }
 
-int smlua_func_get_delayed_warp_op(UNUSED lua_State* L) {
+int smlua_func_get_delayed_warp_op(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);

--- a/src/pc/mods/mod_storage.cpp
+++ b/src/pc/mods/mod_storage.cpp
@@ -117,15 +117,15 @@ static mINI::INIStructure &mod_storage_read_file(const char *filename) {
     return sModStorageFiles[filename];
 }
 
-C_FIELD const char* mod_storage_load(const char* key) {
+C_FIELD const char *mod_storage_load(const char* key, OPTIONAL const char* defaultValue) {
     char filename[SYS_MAX_PATH] = { 0 };
     if (!mod_storage_check_inputs(key, NULL, filename)) {
-        return NULL;
+        return defaultValue;
     }
 
     const mINI::INIStructure &ini = mod_storage_read_file(filename);
     std::string str = ini.get("storage").get(key);
-    if (str.empty()) { return NULL; }
+    if (str.empty()) { return defaultValue; }
 
     // Store string results in a temporary buffer
     // this assumes mod_storage_load will only ever be called by Lua
@@ -134,29 +134,29 @@ C_FIELD const char* mod_storage_load(const char* key) {
     return value;
 }
 
-C_FIELD lua_Integer mod_storage_load_integer(const char* key) {
-    const char* value = mod_storage_load(key);
-    if (value == NULL) { return 0; }
+C_FIELD lua_Integer mod_storage_load_integer(const char* key, OPTIONAL lua_Integer defaultValue) {
+    const char* value = mod_storage_load(key, NULL);
+    if (value == NULL) { return defaultValue; }
 
     return std::strtoll(value, NULL, 10);
 }
 
-C_FIELD lua_Number mod_storage_load_number(const char* key) {
-    const char* value = mod_storage_load(key);
-    if (value == NULL) { return 0.0; }
+C_FIELD lua_Number mod_storage_load_number(const char* key, OPTIONAL lua_Number defaultValue) {
+    const char* value = mod_storage_load(key, NULL);
+    if (value == NULL) { return defaultValue; }
 
     return std::strtod(value, NULL);
 }
 
-C_FIELD bool mod_storage_load_bool(const char* key) {
-    const char* value = mod_storage_load(key);
-    if (value == NULL) { return false; }
+C_FIELD bool mod_storage_load_bool(const char* key, OPTIONAL bool defaultValue) {
+    const char* value = mod_storage_load(key, NULL);
+    if (value == NULL) { return defaultValue; }
 
     return !strcmp(value, "true");
 }
 
 C_FIELD bool mod_storage_exists(const char* key) {
-    return mod_storage_load(key) != NULL;
+    return mod_storage_load(key, NULL) != NULL;
 }
 
 C_FIELD LuaTable mod_storage_load_all(void) {

--- a/src/pc/mods/mod_storage.h
+++ b/src/pc/mods/mod_storage.h
@@ -22,14 +22,14 @@ bool mod_storage_save_number(const char* key, lua_Number value);
 /* |description|Saves a `key` corresponding to a bool `value` to mod storage|descriptionEnd| */
 bool mod_storage_save_bool(const char* key, bool value);
 
-/* |description|Loads a string `value` from a `key` in mod storage|descriptionEnd| */
-const char *mod_storage_load(const char* key);
-/* |description|Loads an integer `value` from a `key` in mod storage|descriptionEnd| */
-lua_Integer mod_storage_load_integer(const char* key);
-/* |description|Loads a number `value` from a `key` in mod storage|descriptionEnd| */
-lua_Number mod_storage_load_number(const char* key);
-/* |description|Loads a bool `value` from a `key` in mod storage|descriptionEnd| */
-bool mod_storage_load_bool(const char* key);
+/* |description|Loads a string `value` from a `key` in mod storage. If the `key` is not found, returns `defaultValue` or `nil`|descriptionEnd| */
+const char *mod_storage_load(const char* key, OPTIONAL const char* defaultValue);
+/* |description|Loads an integer `value` from a `key` in mod storage. If the `key` is not found, returns `defaultValue` or `0`|descriptionEnd| */
+lua_Integer mod_storage_load_integer(const char* key, OPTIONAL lua_Integer defaultValue);
+/* |description|Loads a number `value` from a `key` in mod storage. If the `key` is not found, returns `defaultValue` or `0`|descriptionEnd| */
+lua_Number mod_storage_load_number(const char* key, OPTIONAL lua_Number defaultValue);
+/* |description|Loads a bool `value` from a `key` in mod storage. If the `key` is not found, returns `defaultValue` or `false`|descriptionEnd| */
+bool mod_storage_load_bool(const char* key, OPTIONAL bool defaultValue);
 /* |description|Loads all keys and values in mod storage as strings and returns them as a table|descriptionEnd| */
 LuaTable mod_storage_load_all(void);
 


### PR DESCRIPTION
Allow to specify default values to `mod_storage_load` functions if the key doesn't exist:
```lua
local myLevel = mod_storage_load_integer("my_level", 5) -- returns 5 if "my_level" is not found
```
