### PR TITLE
Add djui_console_is_open

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -3917,6 +3917,12 @@ function djui_console_toggle()
     -- ...
 end
 
+--- @return boolean
+--- Toggles the visibility of the DJUI console
+function djui_console_is_open()
+    -- ...
+end
+
 --- @return integer
 --- Gets the current DJUI HUD resolution
 function djui_hud_get_resolution()

--- a/docs/lua/functions-3.md
+++ b/docs/lua/functions-3.md
@@ -2844,7 +2844,7 @@ Creates a `message` in the game's chat box
 ## [djui_console_toggle](#djui_console_toggle)
 
 ### Description
-Toggles the visibility of the DJUI console
+Returns whether the DJUI console is currently open or not
 
 ### Lua Example
 `djui_console_toggle()`

--- a/docs/lua/functions-3.md
+++ b/docs/lua/functions-3.md
@@ -2862,6 +2862,27 @@ Toggles the visibility of the DJUI console
 
 <br />
 
+## [djui_console_is_open](#djui_console_is_open)
+
+### Description
+Toggles the visibility of the DJUI console
+
+### Lua Example
+`local booleanValue = djui_console_is_open()`
+
+### Parameters
+- None
+
+### Returns
+- `boolean`
+
+### C Prototype
+`bool djui_console_is_open(void);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ---
 # functions from djui_hud_utils.h
 

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -751,6 +751,7 @@
 
 - djui_console.h
    - [djui_console_toggle](functions-3.md#djui_console_toggle)
+   - [djui_console_is_open](functions-3.md#djui_console_is_open)
 
 <br />
 

--- a/src/pc/djui/djui_console.c
+++ b/src/pc/djui/djui_console.c
@@ -86,6 +86,10 @@ void djui_console_toggle(void) {
     }
 }
 
+bool djui_console_is_open(void) {
+    return gDjuiConsoleFocus;
+}
+
 static void djui_console_on_scroll(UNUSED struct DjuiBase *base, UNUSED float x, float y) {
     if (gDjuiConsole == NULL) { return; }
 

--- a/src/pc/djui/djui_console.h
+++ b/src/pc/djui/djui_console.h
@@ -23,6 +23,6 @@ void djui_console_message_dequeue(void);
 void djui_console_message_create(const char* message, enum ConsoleMessageLevel level);
 /* |description|Toggles the visibility of the DJUI console|descriptionEnd| */
 void djui_console_toggle(void);
-/* |description|Toggles the visibility of the DJUI console|descriptionEnd| */
+/* |description|Returns whether the DJUI console is currently open or not|descriptionEnd| */
 bool djui_console_is_open(void);
 struct DjuiConsole* djui_console_create(void);

--- a/src/pc/djui/djui_console.h
+++ b/src/pc/djui/djui_console.h
@@ -23,4 +23,6 @@ void djui_console_message_dequeue(void);
 void djui_console_message_create(const char* message, enum ConsoleMessageLevel level);
 /* |description|Toggles the visibility of the DJUI console|descriptionEnd| */
 void djui_console_toggle(void);
+/* |description|Toggles the visibility of the DJUI console|descriptionEnd| */
+bool djui_console_is_open(void);
 struct DjuiConsole* djui_console_create(void);

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -12197,6 +12197,21 @@ int smlua_func_djui_console_toggle(lua_State* L) {
     return 1;
 }
 
+int smlua_func_djui_console_is_open(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 0) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "djui_console_is_open", 0, top);
+        return 0;
+    }
+
+
+    lua_pushboolean(L, djui_console_is_open());
+
+    return 1;
+}
+
   //////////////////////
  // djui_hud_utils.h //
 //////////////////////
@@ -37929,6 +37944,7 @@ void smlua_bind_functions_autogen(void) {
 
     // djui_console.h
     smlua_bind_function(L, "djui_console_toggle", smlua_func_djui_console_toggle);
+    smlua_bind_function(L, "djui_console_is_open", smlua_func_djui_console_is_open);
 
     // djui_hud_utils.h
     smlua_bind_function(L, "djui_hud_get_resolution", smlua_func_djui_hud_get_resolution);


### PR DESCRIPTION
Adds a lua function that returns if the djui console is open or not. Useful with the existing function djui_console_toggle() for disabling the djui console (mainly to prevent reading chat messages, as opposed to the only other solution which is to fill the console with spam). It doesn't affect the console used with the --console launch parameter in case debugging is necessary.

This mod was used for testing:
```lua
DISABLE_CONSOLE = false

function on_hud_render()
    djui_hud_set_font(FONT_HUD)
    djui_hud_set_color(255, 255, 255, 255)

    if DISABLE_CONSOLE and djui_console_is_open() then
        djui_console_toggle()
    end

    local x = 32
    local y = djui_hud_get_screen_height() - 32
    djui_hud_print_text("Console "..tostring(djui_console_is_open()), x, y, 1)
end
hook_event(HOOK_ON_HUD_RENDER, on_hud_render)

hook_chat_command("disableConsole", "- Toggle the ability to use the console", function()
    DISABLE_CONSOLE = not DISABLE_CONSOLE
    return true
end)
```

<img width="1360" height="768" alt="Function returns false" src="https://github.com/user-attachments/assets/844052d7-ac70-4ab9-a4bd-ffeec8e8f597" />

<img width="1360" height="768" alt="Function returns true" src="https://github.com/user-attachments/assets/5c2d44c4-629a-4c39-b3d2-969cc9a34842" />
