### PR TITLE
Fix Mario clones stealing bodystate from player Marios

### DIFF
--- a/autogen/convert_functions.py
+++ b/autogen/convert_functions.py
@@ -93,7 +93,7 @@ override_allowed_functions = {
     "src/pc/lua/utils/smlua_model_utils.h": [ "smlua_model_util_get_id" ],
     "src/game/object_list_processor.h":     [ "set_object_respawn_info_bits" ],
     "src/game/platform_displacement.h":     [ "apply_platform_displacement" ],
-    "src/game/mario_misc.h":                [ "bhv_toad.*", "bhv_unlock_door.*", "geo_get_.*_state" ],
+    "src/game/mario_misc.h":                [ "bhv_toad.*", "bhv_unlock_door.*", "geo_get_.*" ],
     "src/game/level_update.h":              [ "level_trigger_warp", "get_painting_warp_node", "initiate_warp", "initiate_painting_warp", "warp_special", "lvl_set_current_level", "level_control_timer_running", "pressed_pause", "fade_into_special_warp", "get_instant_warp" ],
     "src/game/area.h":                      [ "get_mario_spawn_type", "area_get_warp_node", "area_get_any_warp_node", "play_transition" ],
     "src/engine/level_script.h":            [ "area_create_warp_node" ],

--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -6749,6 +6749,12 @@ function geo_get_body_state()
     -- ...
 end
 
+--- @return Object
+--- When used in a geo function, retrieve the Mario object associated to the current processed object if it is a valid Mario or mirror Mario, return `nil` otherwise
+function geo_get_mario_object()
+    -- ...
+end
+
 --- @return number
 --- Always returns zero. May have been originally used for beta trampolines
 function get_additive_y_vel_for_jumps()

--- a/docs/lua/functions-4.md
+++ b/docs/lua/functions-4.md
@@ -4639,6 +4639,27 @@ When used in a geo function, retrieve the MarioBodyState associated to the curre
 
 <br />
 
+## [geo_get_mario_object](#geo_get_mario_object)
+
+### Description
+When used in a geo function, retrieve the Mario object associated to the current processed object if it is a valid Mario or mirror Mario, return `nil` otherwise
+
+### Lua Example
+`local objectValue = geo_get_mario_object()`
+
+### Parameters
+- None
+
+### Returns
+- [Object](structs.md#Object)
+
+### C Prototype
+`struct Object *geo_get_mario_object(void);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ---
 # functions from mario_step.h
 

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -1208,6 +1208,7 @@
    - [bhv_unlock_door_star_loop](functions-4.md#bhv_unlock_door_star_loop)
    - [geo_get_mario_state](functions-4.md#geo_get_mario_state)
    - [geo_get_body_state](functions-4.md#geo_get_body_state)
+   - [geo_get_mario_object](functions-4.md#geo_get_mario_object)
 
 <br />
 

--- a/src/game/mario_misc.c
+++ b/src/game/mario_misc.c
@@ -364,7 +364,7 @@ s8 geo_get_processing_mario_index(struct Object *obj) {
     }
 
     index = obj->oBehParams - 1;
-    return (index >= MAX_PLAYERS) ? -1 : index;
+    return (index < 0 || index >= MAX_PLAYERS) ? -1 : index;
 }
 
 struct MarioState *geo_get_mario_state(void) {
@@ -375,6 +375,27 @@ struct MarioState *geo_get_mario_state(void) {
 struct MarioBodyState *geo_get_body_state(void) {
     u8 index = geo_get_processing_object_index();
     return &gBodyStates[index];
+}
+
+struct Object *geo_get_mario_object(void) {
+    struct Object *obj = gCurGraphNodeProcessingObject;
+    if (obj == NULL) {
+        return NULL;
+    }
+
+    s8 mirrorIndex = geo_get_processing_mirror_mario_index(obj);
+    if (mirrorIndex != -1) {
+        return gMarioObjects[mirrorIndex];
+    }
+
+    if (obj->behavior == bhvMario) {
+        u8 marioLocalIndex = obj->oBehParams - 1;
+        if (marioLocalIndex < MAX_PLAYERS && obj == gMarioObjects[marioLocalIndex]) {
+            return gMarioObjects[marioLocalIndex];
+        }
+    }
+
+    return NULL;
 }
 
 /**
@@ -442,9 +463,14 @@ Gfx* geo_switch_mario_eyes(s32 callContext, struct GraphNode* node, UNUSED Mat4*
 Gfx* geo_mario_tilt_torso(s32 callContext, struct GraphNode* node, Mat4* mtx) {
     Mat4 * curTransform = mtx;
     u8 plrIdx = geo_get_processing_object_index();
+    struct Object *marioObject = geo_get_mario_object();
     struct MarioBodyState* bodyState = &gBodyStates[plrIdx];
     s32 action = bodyState->action;
-    bodyState->mirrorMario = gCurGraphNodeObject == &gMirrorMario[plrIdx];
+
+    // update mirrorMario only if it's a valid Mario
+    if (marioObject != NULL) {
+        bodyState->mirrorMario = gCurGraphNodeObject == &gMirrorMario[plrIdx];
+    }
 
     u8 charIndex = gNetworkPlayers[plrIdx].overrideModelIndex;
     if (charIndex >= CT_MAX) { charIndex = 0; }
@@ -460,9 +486,12 @@ Gfx* geo_mario_tilt_torso(s32 callContext, struct GraphNode* node, Mat4* mtx) {
         rotNode->rotation[0] = bodyState->torsoAngle[1] * character->torsoRotMult;
         rotNode->rotation[1] = bodyState->torsoAngle[2] * character->torsoRotMult;
         rotNode->rotation[2] = bodyState->torsoAngle[0] * character->torsoRotMult;
-        // update torso position in bodyState
-        get_pos_from_transform_mtx(bodyState->torsoPos, *curTransform, *gCurGraphNodeCamera->matrixPtr);
-        bodyState->updateTorsoTime = gGlobalTimer;
+
+        // update torso position in bodyState only if it's a valid Mario
+        if (marioObject != NULL) {
+            get_pos_from_transform_mtx(bodyState->torsoPos, *curTransform, *gCurGraphNodeCamera->matrixPtr);
+            bodyState->updateTorsoTime = gGlobalTimer;
+        }
     }
     return NULL;
 }
@@ -472,9 +501,14 @@ Gfx* geo_mario_tilt_torso(s32 callContext, struct GraphNode* node, Mat4* mtx) {
  */
 Gfx* geo_mario_head_rotation(s32 callContext, struct GraphNode* node, Mat4* c) {
     u8 plrIdx = geo_get_processing_object_index();
+    struct Object *marioObject = geo_get_mario_object();
     struct MarioBodyState* bodyState = &gBodyStates[plrIdx];
     s32 action = bodyState->action;
-    bodyState->mirrorMario = gCurGraphNodeObject == &gMirrorMario[plrIdx];
+
+    // update mirrorMario only if it's a valid Mario
+    if (marioObject != NULL) {
+        bodyState->mirrorMario = gCurGraphNodeObject == &gMirrorMario[plrIdx];
+    }
 
     bool marioActive = gMarioObjects[plrIdx] != NULL && gMarioObjects[plrIdx]->activeFlags != ACTIVE_FLAG_DEACTIVATED;
 
@@ -497,11 +531,11 @@ Gfx* geo_mario_head_rotation(s32 callContext, struct GraphNode* node, Mat4* c) {
             vec3s_set(rotNode->rotation, 0, 0, 0);
         }
 
-        // update head position in bodyState
-        get_pos_from_transform_mtx(bodyState->headPos,
-                                   *c,
-                                   *gCurGraphNodeCamera->matrixPtr);
-        bodyState->updateHeadPosTime = gGlobalTimer;
+        // update head position in bodyState only if it's a valid Mario
+        if (marioObject != NULL) {
+            get_pos_from_transform_mtx(bodyState->headPos, *c, *gCurGraphNodeCamera->matrixPtr);
+            bodyState->updateHeadPosTime = gGlobalTimer;
+        }
     }
     return NULL;
 }
@@ -552,7 +586,10 @@ Gfx* geo_mario_hand_foot_scaler(s32 callContext, struct GraphNode* node, UNUSED 
         scaleNode->scale = 1.0f;
         if (asGenerated->parameter == bodyState->punchState >> 6) {
             if (sMarioAttackAnimCounter[index] != gAreaUpdateCounter && (bodyState->punchState & 0x3F) > 0) {
-                bodyState->punchState -= 1;
+                // update punchState only if it's a valid Mario
+                if (geo_get_mario_object() != NULL) {
+                    bodyState->punchState -= 1;
+                }
                 sMarioAttackAnimCounter[index] = gAreaUpdateCounter;
             }
             scaleNode->scale =
@@ -820,7 +857,11 @@ Gfx* geo_mario_set_player_colors(s32 callContext, struct GraphNode* node, UNUSED
     gNetworkPlayerColors[index] = color;
 
     struct MarioBodyState* bodyState = &gBodyStates[index];
-    bodyState->mirrorMario = gCurGraphNodeObject == &gMirrorMario[index];
+
+    // update mirrorMario only if it's a valid Mario
+    if (geo_get_mario_object() != NULL) {
+        bodyState->mirrorMario = gCurGraphNodeObject == &gMirrorMario[index];
+    }
 
     if (callContext == GEO_CONTEXT_RENDER) {
         gfx = geo_mario_create_player_colors_dl(index, NULL, NULL);
@@ -842,16 +883,16 @@ Gfx* geo_mario_set_player_colors(s32 callContext, struct GraphNode* node, UNUSED
 
 Gfx* geo_mario_cap_display_list(s32 callContext, struct GraphNode* node, UNUSED Mat4* c) {
     if (callContext != GEO_CONTEXT_RENDER) { return NULL; }
-    u8 globalIndex = geo_get_processing_object_index();
+    u8 localIndex = geo_get_processing_object_index();
 
-    struct PlayerColor color = geo_mario_get_player_color(&gNetworkPlayers[globalIndex].overridePalette);
-    gNetworkPlayerColors[globalIndex] = color;
+    struct PlayerColor color = geo_mario_get_player_color(&gNetworkPlayers[localIndex].overridePalette);
+    gNetworkPlayerColors[localIndex] = color;
 
-    u8 charIndex = gNetworkPlayers[globalIndex].overrideModelIndex;
+    u8 charIndex = gNetworkPlayers[localIndex].overrideModelIndex;
     if (charIndex >= CT_MAX) { charIndex = 0; }
     struct Character* character = &gCharacters[charIndex];
 
-    Gfx *gfx = geo_mario_create_player_colors_dl(globalIndex, character->capEnemyGfx, character->capEnemyDecalGfx);
+    Gfx *gfx = geo_mario_create_player_colors_dl(localIndex, character->capEnemyGfx, character->capEnemyDecalGfx);
     struct GraphNodeGenerated* asGenerated = (struct GraphNodeGenerated*)node;
     asGenerated->fnNode.node.flags = (asGenerated->fnNode.node.flags & 0xFF) | (character->capEnemyLayer << 8);
     return gfx;
@@ -932,7 +973,7 @@ Gfx *geo_switch_character_type(s32 callContext, struct GraphNode *node, UNUSED v
         switchCase = (struct GraphNodeSwitchCase *) node;
 
         // pass in -1 to always use local mario
-        // otherwise use the mariostate asssociated with the object
+        // otherwise use the mariostate associated with the object
         struct MarioState* marioState = switchCase->parameter == -1 ? gMarioState : geo_get_mario_state();
 
         // assign the case number for execution.

--- a/src/game/mario_misc.c
+++ b/src/game/mario_misc.c
@@ -377,6 +377,8 @@ struct MarioBodyState *geo_get_body_state(void) {
     return &gBodyStates[index];
 }
 
+// Retrieve the Mario object associated to the current processed object if it is a valid Mario or mirror Mario. Return NULL otherwise.
+// When rendering mirror Mario, return the real Mario object for that player.
 struct Object *geo_get_mario_object(void) {
     struct Object *obj = gCurGraphNodeProcessingObject;
     if (obj == NULL) {

--- a/src/game/mario_misc.h
+++ b/src/game/mario_misc.h
@@ -22,6 +22,8 @@ void bhv_unlock_door_star_loop(void);
 struct MarioState *geo_get_mario_state(void);
 /* |description|When used in a geo function, retrieve the MarioBodyState associated to the current processed object|descriptionEnd| */
 struct MarioBodyState *geo_get_body_state(void);
+/* |description|When used in a geo function, retrieve the Mario object associated to the current processed object if it is a valid Mario or mirror Mario, return `nil` otherwise|descriptionEnd| */
+struct Object *geo_get_mario_object(void);
 Gfx *geo_mirror_mario_set_alpha(s32 callContext, struct GraphNode *node, UNUSED Mat4 *c);
 Gfx *geo_switch_mario_stand_run(s32 callContext, struct GraphNode *node, UNUSED Mat4 *mtx);
 Gfx *geo_switch_mario_eyes(s32 callContext, struct GraphNode *node, UNUSED Mat4 *c);

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -19295,6 +19295,21 @@ int smlua_func_geo_get_body_state(lua_State* L) {
     return 1;
 }
 
+int smlua_func_geo_get_mario_object(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 0) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "geo_get_mario_object", 0, top);
+        return 0;
+    }
+
+
+    smlua_push_object(L, LOT_OBJECT, geo_get_mario_object(), NULL);
+
+    return 1;
+}
+
   //////////////////
  // mario_step.h //
 //////////////////
@@ -38359,6 +38374,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "bhv_unlock_door_star_loop", smlua_func_bhv_unlock_door_star_loop);
     smlua_bind_function(L, "geo_get_mario_state", smlua_func_geo_get_mario_state);
     smlua_bind_function(L, "geo_get_body_state", smlua_func_geo_get_body_state);
+    smlua_bind_function(L, "geo_get_mario_object", smlua_func_geo_get_mario_object);
 
     // mario_step.h
     smlua_bind_function(L, "get_additive_y_vel_for_jumps", smlua_func_get_additive_y_vel_for_jumps);


### PR DESCRIPTION
When spawning fake Marios, these objects would steal the bodystate from valid Marios, resulting in nametags rendering in the wrong place and PvP attacks using these fake as origin.

Before:
<img width="806" height="453" alt="before" src="https://github.com/user-attachments/assets/c5f08981-01be-435d-a2a5-68cde2ea5810" />

After:
<img width="643" height="427" alt="after" src="https://github.com/user-attachments/assets/33a26625-04ce-4943-af30-8c2c7f944b32" />

Also works with mirror Marios:
<img width="853" height="401" alt="mirror" src="https://github.com/user-attachments/assets/109601ba-91d5-40a2-8095-89062105f011" />
