### PR TITLE
Small SDL Audio Tweaks

### DIFF
--- a/src/pc/audio/audio_sdl.c
+++ b/src/pc/audio/audio_sdl.c
@@ -7,8 +7,8 @@
 static SDL_AudioDeviceID dev;
 
 static bool audio_sdl_init(void) {
-    if (SDL_Init(SDL_INIT_AUDIO) != 0) {
-        fprintf(stderr, "SDL init error: %s\n", SDL_GetError());
+    if (SDL_InitSubSystem(SDL_INIT_AUDIO) != 0) {
+        fprintf(stderr, "SDL_InitSubSystem error: %s\n", SDL_GetError());
         return false;
     }
 
@@ -17,13 +17,15 @@ static bool audio_sdl_init(void) {
     want.freq = 32000;
     want.format = AUDIO_S16SYS;
     want.channels = 2;
-    want.samples = 512;
+    want.samples = 1024;
     want.callback = NULL;
+
     dev = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
     if (dev == 0) {
-        fprintf(stderr, "SDL_OpenAudio error: %s\n", SDL_GetError());
+        fprintf(stderr, "SDL_OpenAudioDevice error: %s\n", SDL_GetError());
         return false;
     }
+
     SDL_PauseAudioDevice(dev, 0);
     return true;
 }
@@ -37,16 +39,14 @@ static int audio_sdl_get_desired_buffered(void) {
 }
 
 static void audio_sdl_play(const uint8_t *buf, size_t len) {
-    if (audio_sdl_buffered() < 6000) {
-        // Don't fill the audio buffer too much in case this happens
-        SDL_QueueAudio(dev, buf, len);
-    }
+    SDL_QueueAudio(dev, buf, len);
 }
 
-static void audio_sdl_shutdown(void)
-{
+static void audio_sdl_shutdown(void) {
     if (SDL_WasInit(SDL_INIT_AUDIO)) {
         if (dev != 0) {
+            SDL_PauseAudioDevice(dev, 1);
+            SDL_ClearQueuedAudio(dev);
             SDL_CloseAudioDevice(dev);
             dev = 0;
         }

--- a/src/pc/audio/audio_sdl.c
+++ b/src/pc/audio/audio_sdl.c
@@ -23,6 +23,7 @@ static bool audio_sdl_init(void) {
     dev = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
     if (dev == 0) {
         fprintf(stderr, "SDL_OpenAudioDevice error: %s\n", SDL_GetError());
+        SDL_QuitSubSystem(SDL_INIT_AUDIO);
         return false;
     }
 

--- a/src/pc/pc_main.h
+++ b/src/pc/pc_main.h
@@ -40,7 +40,6 @@ extern u8 gLuaVolumeLevel;
 extern u8 gLuaVolumeSfx;
 extern u8 gLuaVolumeEnv;
 
-extern struct GfxWindowManagerAPI* wm_api;
 void produce_one_dummy_frame(void (*callback)(), u8 clearColorR, u8 clearColorG, u8 clearColorB);
 void game_deinit(void);
 void game_exit(void);


### PR DESCRIPTION
Changes:
- Replace SDL_Init with SDL_InitSubSystem -> Minor improvement, gets rid of an extra call
- Double Samples -> Reduces (rare) playback glitches
- Remove frame fill guard -> SDL handles it internally
- Pause and Clear device Queue before closing -> Mostly to make sure no extra audio is left on shutdown
- (Not part of any Audio Tweaks) Removed left-over WM struct