### PR TITLE
Fix Mario knockback

### DIFF
--- a/mods/arena/arena-player.lua
+++ b/mods/arena/arena-player.lua
@@ -141,7 +141,7 @@ function mario_local_hammer_check(m)
                 vec3f_normalize(vel)
                 vec3f_mul(vel, 80 + 10 * (1 - mario_health_float(cmvictim)))
 
-                set_mario_action(m, ACT_BACKWARD_AIR_KB, 0)
+                set_mario_action(m, ACT_BACKWARD_AIR_KB, PVP_ATTACK_KNOCKBACK_ACTION_ARG)
                 m.invincTimer = 20
                 m.knockbackTimer = 10
                 m.vel.x = vel.x

--- a/mods/arena/arena-proj-bobomb.lua
+++ b/mods/arena/arena-proj-bobomb.lua
@@ -73,7 +73,7 @@ function bhv_arena_bobomb_expode(obj, directHitLocal)
         vec3f_normalize(vel)
         vec3f_mul(vel, 40)
 
-        set_mario_action(m, ACT_BACKWARD_AIR_KB, 0)
+        set_mario_action(m, ACT_BACKWARD_AIR_KB, PVP_ATTACK_KNOCKBACK_ACTION_ARG)
         m.invincTimer = 10
         m.knockbackTimer = 10
         m.vel.x = vel.x

--- a/src/game/mario.c
+++ b/src/game/mario.c
@@ -1043,29 +1043,6 @@ static u32 set_mario_action_airborne(struct MarioState *m, u32 action, u32 actio
         case ACT_JUMP_KICK:
             m->vel[1] = 20.0f;
             break;
-
-        // Set forward vel to a predefined value for non-player knockbacks
-        case ACT_BACKWARD_AIR_KB:
-        case ACT_HARD_BACKWARD_AIR_KB:
-            if (!(actionArg & PVP_ATTACK_KNOCKBACK_ACTION_ARG)) {
-                mario_set_forward_vel(m, -16.0f);
-            }
-            break;
-
-        case ACT_FORWARD_AIR_KB:
-        case ACT_HARD_FORWARD_AIR_KB:
-            if (!(actionArg & PVP_ATTACK_KNOCKBACK_ACTION_ARG)) {
-                mario_set_forward_vel(m, 16.0f);
-            }
-            break;
-
-        case ACT_THROWN_BACKWARD:
-        case ACT_THROWN_FORWARD:
-        case ACT_SOFT_BONK:
-            if (!(actionArg & PVP_ATTACK_KNOCKBACK_ACTION_ARG)) {
-                mario_set_forward_vel(m, m->forwardVel); // needed to update velocities
-            }
-            break;
     }
 
     m->peakHeight = m->pos[1];

--- a/src/game/mario_actions_airborne.c
+++ b/src/game/mario_actions_airborne.c
@@ -1236,6 +1236,11 @@ u32 common_air_knockback_step(struct MarioState *m, u32 landAction, u32 hardFall
     if (!m) { return 0; }
     u32 stepResult;
 
+    // Update velocity only if it's not a PVP attack
+    if (!(m->actionArg & PVP_ATTACK_KNOCKBACK_ACTION_ARG)) {
+        mario_set_forward_vel(m, speed);
+    }
+
     // Refresh knockbackTimer
     if (m->knockbackTimer > 0) {
         m->knockbackTimer = PVP_ATTACK_KNOCKBACK_TIMER_DEFAULT;


### PR DESCRIPTION
- Restore Mario's "doh" knockback sound on high speeds
- Fix incorrect knockback speed with Heave-ho and Chuckya

As far as I know, only Arena uses custom knockbacks, so enforcing `PVP_ATTACK_KNOCKBACK_ACTION_ARG` shouldn't be an issue with other mods
