### PR TITLE
Fixes ARM Builds and headless mode on ARM

### DIFF
--- a/src/pc/gfx/gfx_dummy.c
+++ b/src/pc/gfx/gfx_dummy.c
@@ -55,9 +55,7 @@ UNUSED static void gfx_dummy_wm_set_fullscreen(UNUSED bool enable) {
 }
 
 static void gfx_dummy_wm_main_loop(void (*run_one_game_iter)(void)) {
-    while (1) {
-        run_one_game_iter();
-    }
+    run_one_game_iter();
 }
 
 static void gfx_dummy_wm_get_dimensions(uint32_t *width, uint32_t *height) {

--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -59,7 +59,9 @@ static struct ShaderProgram shader_program_pool[CC_MAX_SHADERS];
 static uint8_t shader_program_pool_size = 0;
 static uint8_t shader_program_pool_index = 0;
 static GLuint opengl_vbo;
+#ifndef USE_GLES
 static GLuint opengl_vao;
+#endif
 
 static int tex_cache_size = 0;
 static int num_textures = 0;
@@ -835,10 +837,12 @@ static void gfx_opengl_init(void) {
 
     glBindBuffer(GL_ARRAY_BUFFER, opengl_vbo);
 
-    if (vmajor >= 3 && !is_es) {
+#ifndef USE_GLES
+    if (vmajor >= 3) {
         glGenVertexArrays(1, &opengl_vao);
         glBindVertexArray(opengl_vao);
     }
+#endif
 
     glDepthFunc(GL_LEQUAL);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/src/pc/gfx/gfx_sdl.c
+++ b/src/pc/gfx/gfx_sdl.c
@@ -36,6 +36,7 @@
 #include "../configfile.h"
 #include "../cliopts.h"
 
+#include "../platform.h"
 #include "pc/controller/controller_keyboard.h"
 #include "pc/controller/controller_sdl.h"
 #include "pc/controller/controller_bind_mapping.h"
@@ -143,7 +144,13 @@ static void gfx_sdl_init(const char *window_title) {
         xpos, ypos, configWindow.w, configWindow.h,
         SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE
     );
+    if (!wnd) {
+        sys_fatal("Failed to create SDL window: %s", SDL_GetError());
+    }
     ctx = SDL_GL_CreateContext(wnd);
+    if (!ctx) {
+        sys_fatal("Failed to create OpenGL context: %s", SDL_GetError());
+    }
 
     gfx_sdl_set_vsync(configWindow.vsync);
 

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <time.h>
 #include <unistd.h>
+#include <signal.h>
 
 #include "sm64.h"
 
@@ -96,6 +97,12 @@ static u32 sDrawnFrames = 0;
 
 bool gGameInited = false;
 bool gGfxInited = false;
+static volatile bool gQuitSignal = false;
+
+static void handle_signal(int sig) {
+    (void)sig;
+    gQuitSignal = true;
+}
 
 f32 gMasterVolume;
 
@@ -504,6 +511,13 @@ int main(int argc, char *argv[]) {
     // handle terminal arguments
     if (!parse_cli_opts(argc, argv)) { return 0; }
 
+    struct sigaction sa;
+    sa.sa_handler = handle_signal;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGINT, &sa, NULL);
+    sigaction(SIGTERM, &sa, NULL);
+
 #ifdef _WIN32
     // handle Windows console
     if (gCLIOpts.console || gCLIOpts.headless) {
@@ -542,7 +556,7 @@ int main(int argc, char *argv[]) {
 
     // render the rom setup screen
     if (!main_rom_handler()) {
-        if (!gCLIOpts.hideLoadingScreen) {
+        if (!gCLIOpts.hideLoadingScreen && !gCLIOpts.headless) {
             render_rom_setup_screen(); // holds the game load until a valid rom is provided
         } else {
             printf("ERROR: could not find valid vanilla us sm64 rom in game's user folder\n");
@@ -612,6 +626,7 @@ int main(int argc, char *argv[]) {
 
     // main loop
     while (true) {
+        if (gQuitSignal) { game_exit(); }
         debug_context_reset();
         CTX_BEGIN(CTX_TOTAL);
         gWindowApi->main_loop(produce_one_frame);


### PR DESCRIPTION
Fixes https://github.com/coop-deluxe/sm64coopdx/issues/1297 by detecting with macros whether this is an ARM build, and if so, it avoids calling `glGenVertexArrays` (which doesn't exist in OpenGL GLES, which is the library that's used when targeting Raspberry Pi and other ARM systems).

Since I am only using the binary as a makeshift dedicated server, I am offering this in hopes that it can help anyone else, and to get feedback from the community to actually do this right. I am aware of the issues with this PR. I do not want to introduce technical debt.

The handle_signal stuff I had to patch because for some reason the executable wouldn't exit anymore when sending Ctrl+C once I applied these changes. Sorry for the trouble and I appreciate your advice.