### PR TITLE
Subdirectories for Mod Textures/Sounds

### DIFF
--- a/src/pc/mods/mod.c
+++ b/src/pc/mods/mod.c
@@ -382,7 +382,7 @@ static bool mod_load_files(struct Mod* mod, char* fullPath) {
     // deal with textures directory
     {
         const char* fileTypes[] = { ".tex", NULL };
-        if (!mod_load_files_dir(mod, fullPath, "textures", fileTypes, false)) { return false; }
+        if (!mod_load_files_dir(mod, fullPath, "textures", fileTypes, true)) { return false; }
     }
 
     // deal with levels directory

--- a/src/pc/mods/mod.c
+++ b/src/pc/mods/mod.c
@@ -394,7 +394,7 @@ static bool mod_load_files(struct Mod* mod, char* fullPath) {
     // deal with sound directory
     {
         const char* fileTypes[] = { ".m64", ".mp3", ".aiff", ".ogg", NULL };
-        if (!mod_load_files_dir(mod, fullPath, "sound", fileTypes, false)) { return false; }
+        if (!mod_load_files_dir(mod, fullPath, "sound", fileTypes, true)) { return false; }
     }
 
     return true;


### PR DESCRIPTION
(A single line/parameter change, wow!)
Like the title says, it simply allows for subdirectories in the sound folder of a mod.

This is mainly for organization, seeing how large character packs can end up with hundreds of sound files in a single folder, which gets messy fast. Best example is Extra Characters Plus with a total of 538 sounds all in one place.
Allowing this would also be helpful for separating things like music, sfx and anything else in general.

Update:
Allowed subdirs for textures, mostly for the same reasons of organization