### PR TITLE
Make `spawn_*_object` setup function optional (and everything else)

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -12448,7 +12448,7 @@ end
 --- @param x number
 --- @param y number
 --- @param z number
---- @param objSetupFunction function
+--- @param objSetupFunction? function
 --- @return Object
 --- Spawns a synchronized object at `x`, `y`, and `z` as a child object of the local Mario with his rotation.<br>
 --- You can change the fields of the object in `objSetupFunction`
@@ -12461,7 +12461,7 @@ end
 --- @param x number
 --- @param y number
 --- @param z number
---- @param objSetupFunction function
+--- @param objSetupFunction? function
 --- @return Object
 --- Spawns a non-synchronized object at `x`, `y`, and `z` as a child object of the local Mario with his rotation.<br>
 --- You can change the fields of the object in `objSetupFunction`

--- a/docs/lua/functions-7.md
+++ b/docs/lua/functions-7.md
@@ -4104,7 +4104,7 @@ You can change the fields of the object in `objSetupFunction`
 - [Object](structs.md#Object)
 
 ### C Prototype
-`struct Object* spawn_sync_object(enum BehaviorId behaviorId, enum ModelExtendedId modelId, f32 x, f32 y, f32 z, LuaFunction objSetupFunction);`
+`struct Object* spawn_sync_object(enum BehaviorId behaviorId, enum ModelExtendedId modelId, f32 x, f32 y, f32 z, OPTIONAL LuaFunction objSetupFunction);`
 
 [:arrow_up_small:](#)
 
@@ -4133,7 +4133,7 @@ You can change the fields of the object in `objSetupFunction`
 - [Object](structs.md#Object)
 
 ### C Prototype
-`struct Object* spawn_non_sync_object(enum BehaviorId behaviorId, enum ModelExtendedId modelId, f32 x, f32 y, f32 z, LuaFunction objSetupFunction);`
+`struct Object* spawn_non_sync_object(enum BehaviorId behaviorId, enum ModelExtendedId modelId, f32 x, f32 y, f32 z, OPTIONAL LuaFunction objSetupFunction);`
 
 [:arrow_up_small:](#)
 

--- a/src/game/behavior_actions.c
+++ b/src/game/behavior_actions.c
@@ -113,21 +113,21 @@ s16 D_8032F0CC[] = { 6047, 5664, 5292, 4934, 4587, 4254, 3933, 3624, 3329, 3046,
 #include "behaviors/white_puff_explode.inc.c"
 
 // not in behavior file
-struct SpawnParticlesInfo D_8032F270 = { 2, 20, MODEL_MIST, 0, 40, 5, 30, 20, 252, 30, 330.0f, 10.0f };
+struct SpawnParticlesInfo sMistParticles = { 2, 20, MODEL_MIST, 0, 40, 5, 30, 20, 252, 30, 330.0f, 10.0f };
 
 // generate_wind_puffs/dust (something like that)
 void spawn_mist_particles_variable(s32 count, s32 offsetY, f32 size) {
-    D_8032F270.sizeBase = size;
-    D_8032F270.sizeRange = size / 20.0;
-    D_8032F270.offsetY = offsetY;
+    sMistParticles.sizeBase = size;
+    sMistParticles.sizeRange = size / 20.0;
+    sMistParticles.offsetY = offsetY;
     if (count == 0) {
-        D_8032F270.count = 20;
+        sMistParticles.count = 20;
     } else if (count > 20) {
-        D_8032F270.count = count;
+        sMistParticles.count = count;
     } else {
-        D_8032F270.count = 4;
+        sMistParticles.count = 4;
     }
-    cur_obj_spawn_particles(&D_8032F270);
+    cur_obj_spawn_particles(&sMistParticles);
 }
 
 #include "behaviors/sparkle_spawn_star.inc.c"

--- a/src/game/object_helpers.h
+++ b/src/game/object_helpers.h
@@ -8,8 +8,7 @@
 #include "pc/lua/utils/smlua_model_utils.h"
 
 // used for chain chomp and wiggler
-struct ChainSegment
-{
+struct ChainSegment {
     f32 posX;
     f32 posY;
     f32 posZ;
@@ -26,8 +25,7 @@ struct ChainSegment
 #define WATER_DROPLET_FLAG_RAND_ANGLE_INCR           0x80 // Unused
 
 // Call spawn_water_droplet with this struct to spawn an object.
-struct WaterDropletParams
-{
+struct WaterDropletParams {
     s16 flags; // Droplet spawn flags, see defines above
     s16 model;
     const BehaviorScript *behavior;
@@ -41,9 +39,7 @@ struct WaterDropletParams
     f32 randSizeScale;
 };
 
-// TODO: Field names
-struct SpawnParticlesInfo
-{
+struct SpawnParticlesInfo {
     /*0x00*/ s8 behParam;
     /*0x01*/ s8 count;
     /*0x02*/ u16 model;

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -35013,8 +35013,8 @@ int smlua_func_spawn_sync_object(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
-    if (top != 6) {
-        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "spawn_sync_object", 6, top);
+    if (top < 5 || top > 6) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "spawn_sync_object", 5, 6, top);
         return 0;
     }
 
@@ -35028,8 +35028,11 @@ int smlua_func_spawn_sync_object(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 4, "spawn_sync_object"); return 0; }
     f32 z = smlua_to_number(L, 5);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 5, "spawn_sync_object"); return 0; }
-    LuaFunction objSetupFunction = smlua_to_lua_function(L, 6);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 6, "spawn_sync_object"); return 0; }
+    LuaFunction objSetupFunction = (LuaFunction) 0;
+    if (top >= 6) {
+        objSetupFunction = smlua_to_lua_function(L, 6);
+        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 6, "spawn_sync_object"); return 0; }
+    }
 
     smlua_push_object(L, LOT_OBJECT, spawn_sync_object(behaviorId, modelId, x, y, z, objSetupFunction), NULL);
 
@@ -35040,8 +35043,8 @@ int smlua_func_spawn_non_sync_object(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
-    if (top != 6) {
-        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "spawn_non_sync_object", 6, top);
+    if (top < 5 || top > 6) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "spawn_non_sync_object", 5, 6, top);
         return 0;
     }
 
@@ -35055,8 +35058,11 @@ int smlua_func_spawn_non_sync_object(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 4, "spawn_non_sync_object"); return 0; }
     f32 z = smlua_to_number(L, 5);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 5, "spawn_non_sync_object"); return 0; }
-    LuaFunction objSetupFunction = smlua_to_lua_function(L, 6);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 6, "spawn_non_sync_object"); return 0; }
+    LuaFunction objSetupFunction = (LuaFunction) 0;
+    if (top >= 6) {
+        objSetupFunction = smlua_to_lua_function(L, 6);
+        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 6, "spawn_non_sync_object"); return 0; }
+    }
 
     smlua_push_object(L, LOT_OBJECT, spawn_non_sync_object(behaviorId, modelId, x, y, z, objSetupFunction), NULL);
 

--- a/src/pc/lua/utils/smlua_obj_utils.c
+++ b/src/pc/lua/utils/smlua_obj_utils.c
@@ -76,11 +76,11 @@ static struct Object* spawn_object_internal(enum BehaviorId behaviorId, enum Mod
     return obj;
 }
 
-struct Object* spawn_sync_object(enum BehaviorId behaviorId, enum ModelExtendedId modelId, f32 x, f32 y, f32 z, LuaFunction objSetupFunction) {
+struct Object* spawn_sync_object(enum BehaviorId behaviorId, enum ModelExtendedId modelId, f32 x, f32 y, f32 z, OPTIONAL LuaFunction objSetupFunction) {
     return spawn_object_internal(behaviorId, modelId, x, y, z, objSetupFunction, true);
 }
 
-struct Object* spawn_non_sync_object(enum BehaviorId behaviorId, enum ModelExtendedId modelId, f32 x, f32 y, f32 z, LuaFunction objSetupFunction) {
+struct Object* spawn_non_sync_object(enum BehaviorId behaviorId, enum ModelExtendedId modelId, f32 x, f32 y, f32 z, OPTIONAL LuaFunction objSetupFunction) {
     return spawn_object_internal(behaviorId, modelId, x, y, z, objSetupFunction, false);
 }
 

--- a/src/pc/lua/utils/smlua_obj_utils.h
+++ b/src/pc/lua/utils/smlua_obj_utils.h
@@ -9,12 +9,12 @@
 Spawns a synchronized object at `x`, `y`, and `z` as a child object of the local Mario with his rotation.
 You can change the fields of the object in `objSetupFunction`
 |descriptionEnd| */
-struct Object* spawn_sync_object(enum BehaviorId behaviorId, enum ModelExtendedId modelId, f32 x, f32 y, f32 z, LuaFunction objSetupFunction);
+struct Object* spawn_sync_object(enum BehaviorId behaviorId, enum ModelExtendedId modelId, f32 x, f32 y, f32 z, OPTIONAL LuaFunction objSetupFunction);
 /* |description|
 Spawns a non-synchronized object at `x`, `y`, and `z` as a child object of the local Mario with his rotation.
 You can change the fields of the object in `objSetupFunction`
 |descriptionEnd| */
-struct Object* spawn_non_sync_object(enum BehaviorId behaviorId, enum ModelExtendedId modelId, f32 x, f32 y, f32 z, LuaFunction objSetupFunction);
+struct Object* spawn_non_sync_object(enum BehaviorId behaviorId, enum ModelExtendedId modelId, f32 x, f32 y, f32 z, OPTIONAL LuaFunction objSetupFunction);
 
 /* |description|Checks if an object has `behaviorId`|descriptionEnd| */
 s32 obj_has_behavior_id(struct Object *o, enum BehaviorId behaviorId);


### PR DESCRIPTION
Split from #1310 

You may now omit the setup function instead of simply passing `nil`

Also added a few changes that had nowhere else to go