### PR TITLE
Fix dialog box overflow

### DIFF
--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -1897,6 +1897,25 @@ void render_dialog_entries(void) {
         return;
     }
 
+    s16 dialogLen = (s16)strlen((char *)dialog->str);
+    // this is only triggered if we are oob. That means that technically
+    // only a handful, or even a single character could be rendered on a switch
+    if (gDialogTextPos >= dialogLen) {
+        // look for the last valid page start tex pos index
+        gLastDialogPageStrPos  = 0;
+        s16 strIdx = 0;
+        while (true) { 
+            u8 strChar = dialog->str[strIdx];
+
+            if (strChar == DIALOG_CHAR_TERMINATOR) {
+                gLastDialogPageStrPos = strIdx;
+            }
+            strIdx++;
+            if (strIdx >= dialogLen - 1) { break; }
+        }
+        gDialogTextPos = gLastDialogPageStrPos;
+    }
+
 #ifdef VERSION_EU
     gDialogX = 0;
     gDialogY = 0;

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -1902,18 +1902,24 @@ void render_dialog_entries(void) {
     // only a handful, or even a single character could be rendered on a switch
     if (gDialogTextPos >= dialogLen) {
         // look for the last valid page start tex pos index
-        gLastDialogPageStrPos  = 0;
+        s16 textPos = 0;
+        s16 lineNum = 0;
         s16 strIdx = 0;
         while (true) { 
             u8 strChar = dialog->str[strIdx];
 
-            if (strChar == DIALOG_CHAR_TERMINATOR) {
-                gLastDialogPageStrPos = strIdx;
+            if (strChar == DIALOG_CHAR_NEWLINE) {
+                lineNum++;
+                if (lineNum > dialog->linesPerBox) {
+                    textPos = strIdx + 1;
+                    lineNum = 0;
+                }
             }
             strIdx++;
             if (strIdx >= dialogLen - 1) { break; }
         }
-        gDialogTextPos = gLastDialogPageStrPos;
+        gDialogTextPos = textPos;
+        gLastDialogPageStrPos = -1;
     }
 
 #ifdef VERSION_EU

--- a/src/game/ingame_menu.c
+++ b/src/game/ingame_menu.c
@@ -1897,26 +1897,25 @@ void render_dialog_entries(void) {
         return;
     }
 
-    s16 dialogLen = (s16)strlen((char *)dialog->str);
-    // this is only triggered if we are oob. That means that technically
+    s16 dialogLen = (s16)strlen64(dialog->str);
+    // this prevents overflow. This is only triggered if we are oob. That means that
     // only a handful, or even a single character could be rendered on a switch
     if (gDialogTextPos >= dialogLen) {
         // look for the last valid page start tex pos index
         s16 textPos = 0;
-        s16 lineNum = 0;
+        u16 lineNum = 0;
         s16 strIdx = 0;
-        while (true) { 
+        while (strIdx < dialogLen) { 
             u8 strChar = dialog->str[strIdx];
 
             if (strChar == DIALOG_CHAR_NEWLINE) {
                 lineNum++;
-                if (lineNum > dialog->linesPerBox) {
+                if (lineNum >= dialog->linesPerBox) {
                     textPos = strIdx + 1;
                     lineNum = 0;
                 }
             }
             strIdx++;
-            if (strIdx >= dialogLen - 1) { break; }
         }
         gDialogTextPos = textPos;
         gLastDialogPageStrPos = -1;

--- a/src/game/level_info.c
+++ b/src/game/level_info.c
@@ -205,7 +205,7 @@ u8 *convert_string_ascii_to_sm64(u8 *str64, const char *strAscii, bool menu) {
     return str64;
 }
 
-static inline size_t strlen64(const u8 *str64) {
+inline size_t strlen64(const u8 *str64) {
     const u8 *str64Begin = str64;
     for (; *str64 != 0xFF; str64++);
     return (size_t) (str64 - str64Begin);

--- a/src/game/level_info.c
+++ b/src/game/level_info.c
@@ -205,7 +205,7 @@ u8 *convert_string_ascii_to_sm64(u8 *str64, const char *strAscii, bool menu) {
     return str64;
 }
 
-inline size_t strlen64(const u8 *str64) {
+size_t strlen64(const u8 *str64) {
     const u8 *str64Begin = str64;
     for (; *str64 != 0xFF; str64++);
     return (size_t) (str64 - str64Begin);

--- a/src/game/level_info.h
+++ b/src/game/level_info.h
@@ -8,6 +8,7 @@ void **get_course_name_table_original(void);
 void **get_act_name_table(void);
 void **get_act_name_table_original(void);
 u8 *convert_string_ascii_to_sm64(u8 *str64, const char *strAscii, bool menu);
+size_t strlen64(const u8 *str64);
 char *convert_string_sm64_to_ascii(char *strAscii, const u8 *str64);
 /* |description|
 Returns the name of the level corresponding to `courseNum`, `levelNum` and `areaIndex` as an ASCII (human readable) string.


### PR DESCRIPTION
Before proceeding with render and such, if length is greater than text length, then dialog is oob so we look for the last valid page string position.

Dialogs are very weird so this should be reviewed to make sure I didn't do anything stupid, but this should be fine!