### PR TITLE
Menu options for resolution and filter

### DIFF
--- a/include/PR/gbi_extension.h
+++ b/include/PR/gbi_extension.h
@@ -9,7 +9,7 @@
 // Please update the following table when implementing a new command.
 //
 // RSP ->                     09 0a 0b 0c 0d 0e 0f
-//             14 15 16 17 18 19 1a 1b 1c 1d 1e 1f
+//                15 16 17 18 19 1a 1b 1c 1d 1e 1f
 // 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f
 // 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f
 // 40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f
@@ -63,6 +63,7 @@
 #define G_VTX_EXT          0x11
 #define G_TRI2_EXT         0x12
 #define G_TEXADDR_DJUI     0x13
+#define G_NATIVERES_DJUI   0x14
 #define G_EXECUTE_DJUI     0xdd
 
 #define G_MTX_INVERSE_CAMERA_EXT   0x08
@@ -71,6 +72,15 @@
 {{ \
 	(_SHIFTL(G_TEXADDR_DJUI,24,8)|_SHIFTL(~(u32)(c),0,24)),(u32)(0)	\
 }}
+
+// marks the point where the internal resolution render target is upscaled to
+// the window and all further rendering happens at native window resolution
+#define gSPNativeResDjui(pkt)                                   \
+{                                                               \
+    Gfx *_g = (Gfx *)(pkt);                                     \
+    _g->words.w0 = _SHIFTL(G_NATIVERES_DJUI, 24, 8);            \
+    _g->words.w1 = 0;                                           \
+}
 
 #define gSetClippingDjui(pkt, cmd, x1, y1, x2, y2)         \
 {                                                               \

--- a/lang/English.ini
+++ b/lang/English.ini
@@ -177,6 +177,11 @@ OFF = "Off"
 MUST_RESTART = "Restart the game to apply changes."
 SHOW_FPS = "Show FPS"
 SHOW_PING = "Show Ping"
+INTERNAL_RESOLUTION = "Internal Resolution"
+UPSCALING = "Upscaling"
+NATIVE = "Native"
+COMPOSITE = "Composite (N64)"
+COMPOSITE_CAPTURE = "Composite Capture"
 
 [DJUI_THEMES]
 DJUI_THEME = "DJUI Theme"

--- a/lang/German.ini
+++ b/lang/German.ini
@@ -177,6 +177,11 @@ OFF = "Aus"
 MUST_RESTART = "Um einige Änderungen zu übernehmen, muss das Spiel neugestartet werden."
 SHOW_FPS = "FPS anzeigen"
 SHOW_PING = "Ping anzeigen"
+INTERNAL_RESOLUTION = "Interne Auflösung"
+UPSCALING = "Hochskalierung"
+NATIVE = "Nativ"
+COMPOSITE = "Composite (N64)"
+COMPOSITE_CAPTURE = "Composite Capture"
 
 [DJUI_THEMES]
 DJUI_THEME = "DJUI-Theme"

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -90,6 +90,8 @@ enum RefreshRateMode configFramerateMode          = RRM_AUTO;
 unsigned int configFrameLimit                     = 60;
 unsigned int configInterpolationMode              = 1;
 unsigned int configDrawDistance                   = 6;
+unsigned int configInternalResHeight              = 0; // 0 = native, otherwise render height in pixels
+unsigned int configInternalResFilter              = 0; // 0 = Nearest, 1 = Linear, 2 = Composite, 3 = Composite Capture
 // sound settings
 unsigned int configMasterVolume                   = 80; // 0 - MAX_VOLUME
 unsigned int configMusicVolume                    = MAX_VOLUME;
@@ -264,6 +266,8 @@ static const struct ConfigOption options[] = {
     {.name = "frame_limit",                    .type = CONFIG_TYPE_UINT, .uintValue = &configFrameLimit},
     {.name = "interpolation_mode",             .type = CONFIG_TYPE_UINT, .uintValue = &configInterpolationMode},
     {.name = "coop_draw_distance",             .type = CONFIG_TYPE_UINT, .uintValue = &configDrawDistance},
+    {.name = "internal_res_height",            .type = CONFIG_TYPE_UINT, .uintValue = &configInternalResHeight},
+    {.name = "internal_res_filter",            .type = CONFIG_TYPE_UINT, .uintValue = &configInternalResFilter},
     // sound settings
     {.name = "master_volume",                  .type = CONFIG_TYPE_UINT, .uintValue = &configMasterVolume},
     {.name = "music_volume",                   .type = CONFIG_TYPE_UINT, .uintValue = &configMusicVolume},

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -64,6 +64,8 @@ extern enum RefreshRateMode configFramerateMode;
 extern unsigned int configFrameLimit;
 extern unsigned int configInterpolationMode;
 extern unsigned int configDrawDistance;
+extern unsigned int configInternalResHeight;
+extern unsigned int configInternalResFilter;
 // sound settings
 extern unsigned int configMasterVolume;
 extern unsigned int configMusicVolume;

--- a/src/pc/djui/djui.c
+++ b/src/pc/djui/djui.c
@@ -196,6 +196,7 @@ void djui_render(void) {
     gDjuiHudUtilsZ = 0;
     djui_reset_hud_params();
 
+    djui_gfx_native_res_begin();
     create_dl_ortho_matrix();
     djui_gfx_displaylist_begin();
 

--- a/src/pc/djui/djui_gfx.c
+++ b/src/pc/djui/djui_gfx.c
@@ -25,6 +25,12 @@ void djui_gfx_displaylist_begin(void) {
     gSPDisplayList(gDisplayListHead++, dl_djui_display_list_begin);
 }
 
+// everything after this marker renders at native window resolution,
+// even when an internal resolution is set for the game
+void djui_gfx_native_res_begin(void) {
+    gSPNativeResDjui(gDisplayListHead++);
+}
+
 void djui_gfx_displaylist_end(void) {
     gSPDisplayList(gDisplayListHead++, dl_djui_display_list_end);
 }

--- a/src/pc/djui/djui_gfx.h
+++ b/src/pc/djui/djui_gfx.h
@@ -11,6 +11,7 @@ extern const Gfx dl_djui_img_begin[];
 extern const Gfx dl_djui_img_end[];
 
 void djui_gfx_displaylist_begin(void);
+void djui_gfx_native_res_begin(void);
 void djui_gfx_displaylist_end(void);
 
 /* |description|Gets the current visual scaling factor of DJUI|descriptionEnd| */

--- a/src/pc/djui/djui_panel_display.c
+++ b/src/pc/djui/djui_panel_display.c
@@ -1,7 +1,10 @@
+#include <stdio.h>
 #include "djui.h"
 #include "djui_panel.h"
 #include "djui_panel_menu.h"
 #include "pc/gfx/gfx_window_manager_api.h"
+#include "pc/gfx/gfx_rendering_api.h"
+#include "pc/gfx/gfx_pc.h"
 #include "pc/pc_main.h"
 #include "pc/utils/misc.h"
 #include "pc/configfile.h"
@@ -43,6 +46,46 @@ static void djui_panel_display_update_restart_text(UNUSED struct DjuiBase* calle
         djui_text_set_text(sRestartText, DLANG(DISPLAY, MUST_RESTART));
     } else {
         djui_text_set_text(sRestartText, "");
+    }
+}
+
+// common resolution heights, from the N64's original 240p up
+static const u32 sInternalResHeights[] = { 240, 360, 480, 720, 1080, 1440, 2160, 4320 };
+#define INTERNAL_RES_MAX_CHOICES (ARRAY_COUNT(sInternalResHeights) + 1)
+static u32 sInternalResSelection = 0;
+static u32 sInternalResCount = 0;
+static u32 sInternalResValues[INTERNAL_RES_MAX_CHOICES] = { 0 };
+static char sInternalResLabels[INTERNAL_RES_MAX_CHOICES][32] = { 0 };
+static char* sInternalResChoices[INTERNAL_RES_MAX_CHOICES] = { 0 };
+
+static void djui_panel_display_internal_res_change(UNUSED struct DjuiBase* caller) {
+    configInternalResHeight = sInternalResValues[sInternalResSelection];
+}
+
+static void djui_panel_display_internal_res_build_choices(void) {
+    u32 displayWidth = 0;
+    u32 displayHeight = 0;
+    if (gWindowApi->get_display_size) {
+        gWindowApi->get_display_size(&displayWidth, &displayHeight);
+    }
+    if (displayHeight == 0) { displayHeight = 1080; }
+
+    // native resolution first, then the common resolutions below it, descending
+    sInternalResCount = 0;
+    sInternalResValues[sInternalResCount] = 0;
+    snprintf(sInternalResLabels[sInternalResCount], 32, "%s (%dp)", DLANG(DISPLAY, NATIVE), displayHeight);
+    sInternalResCount++;
+    for (s32 i = ARRAY_COUNT(sInternalResHeights) - 1; i >= 0; i--) {
+        if (sInternalResHeights[i] >= displayHeight) { continue; }
+        sInternalResValues[sInternalResCount] = sInternalResHeights[i];
+        snprintf(sInternalResLabels[sInternalResCount], 32, "%dp%s", sInternalResHeights[i], (sInternalResHeights[i] == 240) ? " (N64)" : "");
+        sInternalResCount++;
+    }
+
+    sInternalResSelection = 0;
+    for (u32 i = 0; i < sInternalResCount; i++) {
+        sInternalResChoices[i] = sInternalResLabels[i];
+        if (sInternalResValues[i] == configInternalResHeight) { sInternalResSelection = i; }
     }
 }
 
@@ -113,6 +156,15 @@ void djui_panel_display_create(struct DjuiBase* caller) {
 
         char* filterChoices[3] = { DLANG(DISPLAY, NEAREST), DLANG(DISPLAY, LINEAR), DLANG(DISPLAY, TRIPOINT) };
         djui_selectionbox_create(body, DLANG(DISPLAY, FILTERING), filterChoices, 3, &configFiltering, NULL);
+
+        struct GfxRenderingAPI* rapi = gfx_get_current_rendering_api();
+        if (rapi && rapi->get_supports_internal_res && rapi->get_supports_internal_res()) {
+            djui_panel_display_internal_res_build_choices();
+            djui_selectionbox_create(body, DLANG(DISPLAY, INTERNAL_RESOLUTION), sInternalResChoices, sInternalResCount, &sInternalResSelection, djui_panel_display_internal_res_change);
+
+            char* upscalingChoices[4] = { DLANG(DISPLAY, NEAREST), DLANG(DISPLAY, LINEAR), DLANG(DISPLAY, COMPOSITE), DLANG(DISPLAY, COMPOSITE_CAPTURE) };
+            djui_selectionbox_create(body, DLANG(DISPLAY, UPSCALING), upscalingChoices, 4, &configInternalResFilter, NULL);
+        }
 
         int maxMsaa = gWindowApi->get_max_msaa();
         if (maxMsaa >= 2) {

--- a/src/pc/gfx/gfx_dummy.c
+++ b/src/pc/gfx/gfx_dummy.c
@@ -119,6 +119,10 @@ static bool gfx_dummy_wm_has_focus(void) {
     return true;
 }
 
+static void gfx_dummy_wm_get_display_size(uint32_t *width, uint32_t *height) {
+    gfx_dummy_wm_get_dimensions(width, height);
+}
+
 static bool gfx_dummy_renderer_z_is_from_0_to_1(void) {
     return false;
 }
@@ -199,6 +203,10 @@ static const char* gfx_dummy_renderer_get_name(void) {
 static void gfx_dummy_renderer_shutdown(void) {
 }
 
+static bool gfx_dummy_renderer_get_supports_internal_res(void) {
+    return false;
+}
+
 struct GfxWindowManagerAPI gfx_dummy_wm_api = {
     gfx_dummy_wm_init,
     gfx_dummy_wm_set_keyboard_callbacks,
@@ -220,7 +228,8 @@ struct GfxWindowManagerAPI gfx_dummy_wm_api = {
     gfx_dummy_wm_get_max_msaa,
     gfx_dummy_wm_set_window_title,
     gfx_dummy_wm_reset_window_title,
-    gfx_dummy_wm_has_focus
+    gfx_dummy_wm_has_focus,
+    gfx_dummy_wm_get_display_size
 };
 
 struct GfxRenderingAPI gfx_dummy_renderer_api = {
@@ -247,5 +256,6 @@ struct GfxRenderingAPI gfx_dummy_renderer_api = {
     gfx_dummy_renderer_end_frame,
     gfx_dummy_renderer_finish_render,
     gfx_dummy_renderer_get_name,
-    gfx_dummy_renderer_shutdown
+    gfx_dummy_renderer_shutdown,
+    gfx_dummy_renderer_get_supports_internal_res
 };

--- a/src/pc/gfx/gfx_dxgi.cpp
+++ b/src/pc/gfx/gfx_dxgi.cpp
@@ -733,6 +733,11 @@ static bool gfx_dxgi_has_focus(void) {
     return GetFocus() == dxgi.h_wnd;
 }
 
+static void gfx_dxgi_get_display_size(uint32_t *width, uint32_t *height) {
+    if (width) *width = GetSystemMetrics(SM_CXSCREEN);
+    if (height) *height = GetSystemMetrics(SM_CYSCREEN);
+}
+
 extern "C" HWND gfx_dxgi_get_h_wnd(void) {
     return dxgi.h_wnd;
 }
@@ -820,7 +825,8 @@ struct GfxWindowManagerAPI gfx_dxgi = {
     gfx_dxgi_get_max_msaa,
     gfx_dxgi_set_window_title,
     gfx_dxgi_reset_window_title,
-    gfx_dxgi_has_focus
+    gfx_dxgi_has_focus,
+    gfx_dxgi_get_display_size
 };
 
 #endif

--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -790,6 +790,357 @@ static void gfx_opengl_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_
     glDrawArrays(GL_TRIANGLES, 0, 3 * buf_vbo_num_tris);
 }
 
+  ///////////////////////////////
+ // internal resolution (FBO) //
+///////////////////////////////
+
+static bool internal_res_supported = false;
+static bool internal_res_active = false;
+static GLuint internal_res_fbo = 0;
+static GLuint internal_res_tex = 0;
+static GLuint internal_res_depth = 0;
+static uint32_t internal_res_width = 0;
+static uint32_t internal_res_height = 0;
+
+static bool gfx_opengl_get_supports_internal_res(void) {
+    return internal_res_supported;
+}
+
+#ifndef USE_GLES
+
+// approximates the look of an N64 hooked up over composite video:
+// luma stays mostly sharp while chroma bleeds horizontally
+static GLuint composite_prg = 0;
+static GLint composite_texel_loc = -1;
+static bool composite_prg_failed = false;
+
+static const char* composite_vs_src =
+    "#version 120\n"
+    "void main() {\n"
+    "    gl_Position = gl_Vertex;\n"
+    "    gl_TexCoord[0] = gl_MultiTexCoord0;\n"
+    "}\n";
+
+static const char* composite_fs_src =
+    "#version 120\n"
+    "uniform sampler2D uTex;\n"
+    "uniform vec2 uTexelSize;\n"
+    "vec3 to_yiq(vec3 c) {\n"
+    "    return vec3(dot(c, vec3(0.299,  0.587,  0.114)),\n"
+    "                dot(c, vec3(0.596, -0.274, -0.322)),\n"
+    "                dot(c, vec3(0.211, -0.523,  0.312)));\n"
+    "}\n"
+    "vec3 to_rgb(vec3 c) {\n"
+    "    return vec3(c.x + 0.956 * c.y + 0.621 * c.z,\n"
+    "                c.x - 0.272 * c.y - 0.647 * c.z,\n"
+    "                c.x - 1.106 * c.y + 1.703 * c.z);\n"
+    "}\n"
+    "void main() {\n"
+    "    vec2 uv = gl_TexCoord[0].xy;\n"
+    "    float dx = uTexelSize.x;\n"
+    "    vec3 t0 = to_yiq(texture2D(uTex, uv - vec2(3.0 * dx, 0.0)).rgb);\n"
+    "    vec3 t1 = to_yiq(texture2D(uTex, uv - vec2(2.0 * dx, 0.0)).rgb);\n"
+    "    vec3 t2 = to_yiq(texture2D(uTex, uv - vec2(1.0 * dx, 0.0)).rgb);\n"
+    "    vec3 t3 = to_yiq(texture2D(uTex, uv).rgb);\n"
+    "    vec3 t4 = to_yiq(texture2D(uTex, uv + vec2(1.0 * dx, 0.0)).rgb);\n"
+    "    vec3 t5 = to_yiq(texture2D(uTex, uv + vec2(2.0 * dx, 0.0)).rgb);\n"
+    "    vec3 t6 = to_yiq(texture2D(uTex, uv + vec2(3.0 * dx, 0.0)).rgb);\n"
+    "    float luma = t2.x * 0.15 + t3.x * 0.70 + t4.x * 0.15;\n"
+    "    vec2 chroma = t0.yz * 0.07 + t1.yz * 0.12 + t2.yz * 0.19 + t3.yz * 0.24\n"
+    "                + t4.yz * 0.19 + t5.yz * 0.12 + t6.yz * 0.07;\n"
+    "    gl_FragColor = vec4(to_rgb(vec3(luma, chroma)), 1.0);\n"
+    "}\n";
+
+// like the composite filter, but mimics a recorded capture of real N64 video
+// output: sharper luma with edge ringing, line jitter and analog noise
+static GLuint capture_prg = 0;
+static GLint capture_texel_loc = -1;
+static GLint capture_frame_loc = -1;
+static bool capture_prg_failed = false;
+
+static const char* capture_fs_src =
+    "#version 120\n"
+    "uniform sampler2D uTex;\n"
+    "uniform vec2 uTexelSize;\n"
+    "uniform float uFrame;\n"
+    "vec3 to_yiq(vec3 c) {\n"
+    "    return vec3(dot(c, vec3(0.299,  0.587,  0.114)),\n"
+    "                dot(c, vec3(0.596, -0.274, -0.322)),\n"
+    "                dot(c, vec3(0.211, -0.523,  0.312)));\n"
+    "}\n"
+    "vec3 to_rgb(vec3 c) {\n"
+    "    return vec3(c.x + 0.956 * c.y + 0.621 * c.z,\n"
+    "                c.x - 0.272 * c.y - 0.647 * c.z,\n"
+    "                c.x - 1.106 * c.y + 1.703 * c.z);\n"
+    "}\n"
+    "float hash(vec2 p) {\n"
+    "    return fract(sin(dot(p, vec2(12.9898, 78.233)) + uFrame * 0.317) * 43758.5453);\n"
+    "}\n"
+    "void main() {\n"
+    "    vec2 uv = gl_TexCoord[0].xy;\n"
+    "    float dx = uTexelSize.x;\n"
+    "    float dy = uTexelSize.y;\n"
+    "    // capture line index at half-texel granularity (480 lines for 240p)\n"
+    "    float subline = floor(uv.y / (0.5 * dy));\n"
+    "    // vertical: snap to source lines with a narrow transition (hard TV lines)\n"
+    "    float ty = uv.y / dy;\n"
+    "    float baseLine = floor(ty - 0.5) + 0.5;\n"
+    "    float fracY = clamp((ty - baseLine - 0.5) * 4.0 + 0.5, 0.0, 1.0);\n"
+    "    float sy = (baseLine + fracY) * dy;\n"
+    "    // alternate capture lines are shifted, like a deinterlaced recording\n"
+    "    float sx = uv.x + ((mod(subline, 2.0) < 1.0) ? -0.25 : 0.25) * dx;\n"
+    "    // luma samples snap toward texel centers so the upscale smears less\n"
+    "    float tx = sx / dx;\n"
+    "    float baseCol = floor(tx - 0.5) + 0.5;\n"
+    "    float fracX = clamp((tx - baseCol - 0.5) * 2.5 + 0.5, 0.0, 1.0);\n"
+    "    vec2 luv = vec2((baseCol + fracX) * dx, sy);\n"
+    "    vec2 suv = vec2(sx, sy);\n"
+    "    // luma: mostly sharp, with ringing halos around edges\n"
+    "    float l0 = to_yiq(texture2D(uTex, luv - vec2(2.0 * dx, 0.0)).rgb).x;\n"
+    "    float l1 = to_yiq(texture2D(uTex, luv - vec2(1.0 * dx, 0.0)).rgb).x;\n"
+    "    float l2 = to_yiq(texture2D(uTex, luv).rgb).x;\n"
+    "    float l3 = to_yiq(texture2D(uTex, luv + vec2(1.0 * dx, 0.0)).rgb).x;\n"
+    "    float l4 = to_yiq(texture2D(uTex, luv + vec2(2.0 * dx, 0.0)).rgb).x;\n"
+    "    float luma = -0.20 * l0 + 0.10 * l1 + 1.20 * l2 + 0.10 * l3 - 0.20 * l4;\n"
+    "    // chroma: wide horizontal bleed, delayed to the right\n"
+    "    vec2 cuv = suv - vec2(1.0 * dx, 0.0);\n"
+    "    vec2 c0 = to_yiq(texture2D(uTex, cuv - vec2(4.5 * dx, 0.0)).rgb).yz;\n"
+    "    vec2 c1 = to_yiq(texture2D(uTex, cuv - vec2(3.0 * dx, 0.0)).rgb).yz;\n"
+    "    vec2 c2 = to_yiq(texture2D(uTex, cuv - vec2(1.5 * dx, 0.0)).rgb).yz;\n"
+    "    vec2 c3 = to_yiq(texture2D(uTex, cuv).rgb).yz;\n"
+    "    vec2 c4 = to_yiq(texture2D(uTex, cuv + vec2(1.5 * dx, 0.0)).rgb).yz;\n"
+    "    vec2 c5 = to_yiq(texture2D(uTex, cuv + vec2(3.0 * dx, 0.0)).rgb).yz;\n"
+    "    vec2 c6 = to_yiq(texture2D(uTex, cuv + vec2(4.5 * dx, 0.0)).rgb).yz;\n"
+    "    vec2 chroma = c0 * 0.07 + c1 * 0.12 + c2 * 0.19 + c3 * 0.24\n"
+    "                + c4 * 0.19 + c5 * 0.12 + c6 * 0.07;\n"
+    "    // composite captures look saturated: boost the chroma\n"
+    "    chroma *= 1.25;\n"
+    "    // animated analog grain, at half-texel granularity\n"
+    "    float n = hash(floor(vec2(uv.x / (0.5 * dx), subline)));\n"
+    "    luma += (n - 0.5) * 0.06;\n"
+    "    gl_FragColor = vec4(to_rgb(vec3(luma, chroma)), 1.0);\n"
+    "}\n";
+
+static GLuint gfx_opengl_composite_compile(GLenum type, const char* src) {
+    GLuint shader = glCreateShader(type);
+    glShaderSource(shader, 1, &src, NULL);
+    glCompileShader(shader);
+    GLint ok = GL_FALSE;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+    if (!ok) {
+        char log[1024] = { 0 };
+        glGetShaderInfoLog(shader, sizeof(log), NULL, log);
+        fprintf(stderr, "upscale filter shader failed to compile:\n%s\n", log);
+        glDeleteShader(shader);
+        return 0;
+    }
+    return shader;
+}
+
+static GLuint gfx_opengl_filter_prg_link(const char* fs_src) {
+    GLuint vs = gfx_opengl_composite_compile(GL_VERTEX_SHADER, composite_vs_src);
+    GLuint fs = gfx_opengl_composite_compile(GL_FRAGMENT_SHADER, fs_src);
+    if (vs == 0 || fs == 0) {
+        if (vs) { glDeleteShader(vs); }
+        if (fs) { glDeleteShader(fs); }
+        return 0;
+    }
+
+    GLuint prg = glCreateProgram();
+    glAttachShader(prg, vs);
+    glAttachShader(prg, fs);
+    glLinkProgram(prg);
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+
+    GLint ok = GL_FALSE;
+    glGetProgramiv(prg, GL_LINK_STATUS, &ok);
+    if (!ok) {
+        glDeleteProgram(prg);
+        return 0;
+    }
+
+    glUseProgram(prg);
+    glUniform1i(glGetUniformLocation(prg, "uTex"), 0);
+    glUseProgram(0);
+    return prg;
+}
+
+static void gfx_opengl_composite_prg_ensure(void) {
+    if (composite_prg != 0 || composite_prg_failed) { return; }
+    composite_prg = gfx_opengl_filter_prg_link(composite_fs_src);
+    if (composite_prg == 0) {
+        composite_prg_failed = true;
+        return;
+    }
+    composite_texel_loc = glGetUniformLocation(composite_prg, "uTexelSize");
+}
+
+static void gfx_opengl_capture_prg_ensure(void) {
+    if (capture_prg != 0 || capture_prg_failed) { return; }
+    capture_prg = gfx_opengl_filter_prg_link(capture_fs_src);
+    if (capture_prg == 0) {
+        capture_prg_failed = true;
+        return;
+    }
+    capture_texel_loc = glGetUniformLocation(capture_prg, "uTexelSize");
+    capture_frame_loc = glGetUniformLocation(capture_prg, "uFrame");
+}
+
+// rebind the game's texture state after we messed with texture unit 0
+static void gfx_opengl_restore_texture_state(void) {
+    glActiveTexture(GL_TEXTURE0);
+    if (opengl_tex[0]) { glBindTexture(GL_TEXTURE_2D, opengl_tex[0]->gltex); }
+    glActiveTexture(GL_TEXTURE0 + opengl_curtex);
+}
+
+static void gfx_opengl_internal_res_destroy(void) {
+    if (internal_res_fbo != 0) {
+        glDeleteFramebuffers(1, &internal_res_fbo);
+        glDeleteTextures(1, &internal_res_tex);
+        glDeleteRenderbuffers(1, &internal_res_depth);
+        internal_res_fbo = 0;
+        internal_res_tex = 0;
+        internal_res_depth = 0;
+        internal_res_width = 0;
+        internal_res_height = 0;
+    }
+}
+
+static bool gfx_opengl_internal_res_ensure(uint32_t width, uint32_t height) {
+    if (internal_res_fbo != 0 && internal_res_width == width && internal_res_height == height) {
+        return true;
+    }
+
+    if (internal_res_fbo == 0) {
+        glGenFramebuffers(1, &internal_res_fbo);
+        glGenTextures(1, &internal_res_tex);
+        glGenRenderbuffers(1, &internal_res_depth);
+    }
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, internal_res_tex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glBindRenderbuffer(GL_RENDERBUFFER, internal_res_depth);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, internal_res_fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, internal_res_tex, 0);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, internal_res_depth);
+
+    bool complete = (glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
+    if (!complete) {
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        gfx_opengl_internal_res_destroy();
+        internal_res_supported = false;
+    } else {
+        internal_res_width = width;
+        internal_res_height = height;
+    }
+
+    gfx_opengl_restore_texture_state();
+    return complete;
+}
+
+// draw the internal render target to the window as a fullscreen quad,
+// leaving the window framebuffer bound for any further rendering
+static void gfx_opengl_internal_res_blit(void) {
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    GLint prevViewport[4];
+    glGetIntegerv(GL_VIEWPORT, prevViewport);
+    GLboolean prevScissorTest = glIsEnabled(GL_SCISSOR_TEST);
+    GLboolean prevDepthTest = glIsEnabled(GL_DEPTH_TEST);
+    GLboolean prevBlend = glIsEnabled(GL_BLEND);
+    GLboolean prevDepthMask;
+    glGetBooleanv(GL_DEPTH_WRITEMASK, &prevDepthMask);
+
+    glViewport(0, 0, gfx_window_width, gfx_window_height);
+    glDisable(GL_SCISSOR_TEST);
+    glDisable(GL_DEPTH_TEST);
+    glDepthMask(GL_FALSE);
+    glDisable(GL_BLEND);
+
+    if (configInternalResFilter == 2) {
+        gfx_opengl_composite_prg_ensure();
+    } else if (configInternalResFilter == 3) {
+        gfx_opengl_capture_prg_ensure();
+    }
+    if (configInternalResFilter == 2 && composite_prg != 0) {
+        glUseProgram(composite_prg);
+        glUniform2f(composite_texel_loc, 1.0f / (f32)internal_res_width, 1.0f / (f32)internal_res_height);
+    } else if (configInternalResFilter == 3 && capture_prg != 0) {
+        glUseProgram(capture_prg);
+        glUniform2f(capture_texel_loc, 1.0f / (f32)internal_res_width, 1.0f / (f32)internal_res_height);
+        glUniform1f(capture_frame_loc, (f32)(frame_count % 1024u));
+    } else {
+        glUseProgram(0);
+    }
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, internal_res_tex);
+    GLint filter = (configInternalResFilter >= 1) ? GL_LINEAR : GL_NEAREST;
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+    glEnable(GL_TEXTURE_2D);
+
+    glMatrixMode(GL_PROJECTION);
+    glPushMatrix();
+    glLoadIdentity();
+    glMatrixMode(GL_MODELVIEW);
+    glPushMatrix();
+    glLoadIdentity();
+
+    glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+    glBegin(GL_TRIANGLE_STRIP);
+    glTexCoord2f(0.0f, 0.0f); glVertex2f(-1.0f, -1.0f);
+    glTexCoord2f(1.0f, 0.0f); glVertex2f( 1.0f, -1.0f);
+    glTexCoord2f(0.0f, 1.0f); glVertex2f(-1.0f,  1.0f);
+    glTexCoord2f(1.0f, 1.0f); glVertex2f( 1.0f,  1.0f);
+    glEnd();
+
+    glMatrixMode(GL_MODELVIEW);
+    glPopMatrix();
+    glMatrixMode(GL_PROJECTION);
+    glPopMatrix();
+    glDisable(GL_TEXTURE_2D);
+
+    // clear the window depth buffer so any further native res rendering starts fresh
+    glDepthMask(GL_TRUE);
+    glClear(GL_DEPTH_BUFFER_BIT);
+
+    // restore the state the game rendering expects
+    if (opengl_prg != NULL) { glUseProgram(opengl_prg->opengl_program_id); }
+    gfx_opengl_restore_texture_state();
+    glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
+    if (prevScissorTest) { glEnable(GL_SCISSOR_TEST); }
+    if (prevDepthTest) { glEnable(GL_DEPTH_TEST); }
+    if (prevBlend) { glEnable(GL_BLEND); }
+    glDepthMask(prevDepthMask);
+}
+
+#else // USE_GLES
+
+static void gfx_opengl_internal_res_destroy(void) { }
+static bool gfx_opengl_internal_res_ensure(uint32_t width, uint32_t height) { (void)width; (void)height; return false; }
+static void gfx_opengl_internal_res_blit(void) { }
+
+#endif
+
+// called mid-frame when DJUI rendering begins: upscale the internal render
+// target to the window and let everything after render at native resolution
+static void gfx_opengl_end_internal_res(void) {
+    if (!internal_res_active) { return; }
+    internal_res_active = false;
+    gfx_opengl_internal_res_blit();
+}
+
 static inline bool gl_version_is_supported(int major, int minor, bool is_es) {
     if (is_es) {
         return major >= 2;
@@ -840,6 +1191,11 @@ static void gfx_opengl_init(void) {
         glBindVertexArray(opengl_vao);
     }
 
+#ifndef USE_GLES
+    // the internal resolution render target needs framebuffer objects (GL 3.0+)
+    internal_res_supported = (vmajor >= 3 && !is_es);
+#endif
+
     glDepthFunc(GL_LEQUAL);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 }
@@ -861,6 +1217,14 @@ static void gfx_opengl_on_resize(void) {
 static void gfx_opengl_start_frame(void) {
     frame_count++;
 
+    internal_res_active = internal_res_supported && gfx_internal_res_height > 0
+        && gfx_opengl_internal_res_ensure(gfx_internal_res_width, gfx_internal_res_height);
+#ifndef USE_GLES
+    if (internal_res_supported) {
+        glBindFramebuffer(GL_FRAMEBUFFER, internal_res_active ? internal_res_fbo : 0);
+    }
+#endif
+
     glDisable(GL_SCISSOR_TEST);
     glDepthMask(GL_TRUE); // Must be set to clear Z-buffer
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
@@ -872,6 +1236,9 @@ static void gfx_opengl_end_frame(void) {
 }
 
 static void gfx_opengl_finish_render(void) {
+    if (internal_res_active) {
+        gfx_opengl_internal_res_blit();
+    }
 }
 
 static const char* gfx_opengl_get_name(void) {
@@ -879,6 +1246,8 @@ static const char* gfx_opengl_get_name(void) {
 }
 
 static void gfx_opengl_shutdown(void) {
+    gfx_opengl_internal_res_destroy();
+    internal_res_active = false;
 }
 
 struct GfxRenderingAPI gfx_opengl_api = {
@@ -905,5 +1274,7 @@ struct GfxRenderingAPI gfx_opengl_api = {
     gfx_opengl_end_frame,
     gfx_opengl_finish_render,
     gfx_opengl_get_name,
-    gfx_opengl_shutdown
+    gfx_opengl_shutdown,
+    gfx_opengl_get_supports_internal_res,
+    gfx_opengl_end_internal_res
 };

--- a/src/pc/gfx/gfx_pc.c
+++ b/src/pc/gfx/gfx_pc.c
@@ -110,6 +110,14 @@ static struct RenderingState {
 
 struct GfxDimensions gfx_current_dimensions = { 0 };
 
+// actual window size; gfx_current_dimensions holds the internal render size
+uint32_t gfx_window_width = 0;
+uint32_t gfx_window_height = 0;
+
+// internal render target size, 0 when rendering directly at window resolution
+uint32_t gfx_internal_res_width = 0;
+uint32_t gfx_internal_res_height = 0;
+
 static bool dropped_frame = false;
 
 static float buf_vbo[MAX_BUFFERED * (26 * 3)] = { 0.0f }; // 3 vertices in a triangle and 26 floats per vtx
@@ -2063,6 +2071,44 @@ void gfx_get_dimensions(uint32_t *width, uint32_t *height) {
     }
 }
 
+static void gfx_update_dimensions(uint32_t width, uint32_t height) {
+    gfx_current_dimensions.width = width;
+    gfx_current_dimensions.height = height;
+    if (configForce4By3
+        && ((4.0f / 3.0f) * gfx_current_dimensions.height) < gfx_current_dimensions.width) {
+        gfx_current_dimensions.x_adjust_4by3 = (gfx_current_dimensions.width - (4.0f / 3.0f) * gfx_current_dimensions.height) / 2;
+        gfx_current_dimensions.width = (4.0f / 3.0f) * gfx_current_dimensions.height;
+    } else { gfx_current_dimensions.x_adjust_4by3 = 0; }
+    gfx_current_dimensions.aspect_ratio = ((float)gfx_current_dimensions.width / (float)gfx_current_dimensions.height);
+    gfx_current_dimensions.x_adjust_ratio = (4.0f / 3.0f) / gfx_current_dimensions.aspect_ratio;
+}
+
+static bool sRenderingNativeRes = false;
+
+// called via G_NATIVERES_DJUI: upscales the internal render target to the window
+// and switches all further rendering (DJUI) to native window resolution
+static void gfx_native_res_begin(void) {
+    if (gfx_internal_res_height == 0 || sRenderingNativeRes) { return; }
+    sRenderingNativeRes = true;
+
+    gfx_flush();
+    if (gfx_rapi->end_internal_res) { gfx_rapi->end_internal_res(); }
+
+    f32 scale = (f32)gfx_window_height / (f32)gfx_internal_res_height;
+    gfx_update_dimensions(gfx_window_width, gfx_window_height);
+
+    // rescale the cached viewport/scissor from internal to window space
+    rdp.viewport.x      = (uint16_t)(rdp.viewport.x      * scale + 0.5f);
+    rdp.viewport.y      = (uint16_t)(rdp.viewport.y      * scale + 0.5f);
+    rdp.viewport.width  = (uint16_t)(rdp.viewport.width  * scale + 0.5f);
+    rdp.viewport.height = (uint16_t)(rdp.viewport.height * scale + 0.5f);
+    rdp.scissor.x       = (uint16_t)(rdp.scissor.x       * scale + 0.5f);
+    rdp.scissor.y       = (uint16_t)(rdp.scissor.y       * scale + 0.5f);
+    rdp.scissor.width   = (uint16_t)(rdp.scissor.width   * scale + 0.5f);
+    rdp.scissor.height  = (uint16_t)(rdp.scissor.height  * scale + 0.5f);
+    rdp.viewport_or_scissor_changed = true;
+}
+
 void gfx_init(struct GfxWindowManagerAPI *wapi, struct GfxRenderingAPI *rapi, const char *window_title) {
     gfx_wapi = wapi;
     gfx_rapi = rapi;
@@ -2085,18 +2131,30 @@ void gfx_start_frame(void) {
         rdp.loaded_texture[1].size_bytes = 0;
     }
     gfx_wapi->handle_events();
-    gfx_wapi->get_dimensions(&gfx_current_dimensions.width, &gfx_current_dimensions.height);
-    if (gfx_current_dimensions.height == 0) {
+    gfx_wapi->get_dimensions(&gfx_window_width, &gfx_window_height);
+    if (gfx_window_height == 0) {
         // Avoid division by zero
-        gfx_current_dimensions.height = 1;
+        gfx_window_height = 1;
     }
-    if (configForce4By3
-        && ((4.0f / 3.0f) * gfx_current_dimensions.height) < gfx_current_dimensions.width) {
-        gfx_current_dimensions.x_adjust_4by3 = (gfx_current_dimensions.width - (4.0f / 3.0f) * gfx_current_dimensions.height) / 2;
-        gfx_current_dimensions.width = (4.0f / 3.0f) * gfx_current_dimensions.height;
-    } else { gfx_current_dimensions.x_adjust_4by3 = 0; }
-    gfx_current_dimensions.aspect_ratio = ((float)gfx_current_dimensions.width / (float)gfx_current_dimensions.height);
-    gfx_current_dimensions.x_adjust_ratio = (4.0f / 3.0f) / gfx_current_dimensions.aspect_ratio;
+    sRenderingNativeRes = false;
+    gfx_internal_res_width = 0;
+    gfx_internal_res_height = 0;
+    if (gfx_rapi->get_supports_internal_res && gfx_rapi->get_supports_internal_res()) {
+        if (configInternalResHeight >= SCREEN_HEIGHT && configInternalResHeight != gfx_window_height) {
+            gfx_internal_res_height = configInternalResHeight;
+            gfx_internal_res_width = (uint32_t)((f32)gfx_window_width * ((f32)configInternalResHeight / (f32)gfx_window_height) + 0.5f);
+            if (gfx_internal_res_width == 0) { gfx_internal_res_width = 1; }
+        } else if (configInternalResFilter >= 2) {
+            // the composite filters need the offscreen render target even at native resolution
+            gfx_internal_res_width = gfx_window_width;
+            gfx_internal_res_height = gfx_window_height;
+        }
+    }
+    if (gfx_internal_res_height > 0) {
+        gfx_update_dimensions(gfx_internal_res_width, gfx_internal_res_height);
+    } else {
+        gfx_update_dimensions(gfx_window_width, gfx_window_height);
+    }
 }
 
 void gfx_run(Gfx *commands) {
@@ -2479,6 +2537,9 @@ void OPTIMIZE_O3 ext_gfx_run_dl(Gfx* cmd) {
             break;
         case G_TEXADDR_DJUI:
             sOnlyTextureChangeOnAddrChange = !(C0(0, 24) & 0x01);
+            break;
+        case G_NATIVERES_DJUI:
+            gfx_native_res_begin();
             break;
         case G_EXECUTE_DJUI:
             djui_gfx_dp_execute_djui(cmd->words.w1);

--- a/src/pc/gfx/gfx_pc.h
+++ b/src/pc/gfx/gfx_pc.h
@@ -36,6 +36,14 @@ extern bool gShaderFlagsEnabled;
 extern "C" {
 #endif
 
+// actual window size; gfx_current_dimensions holds the internal render size
+extern uint32_t gfx_window_width;
+extern uint32_t gfx_window_height;
+
+// internal render target size, 0 when rendering directly at window resolution
+extern uint32_t gfx_internal_res_width;
+extern uint32_t gfx_internal_res_height;
+
 void gfx_init(struct GfxWindowManagerAPI *wapi, struct GfxRenderingAPI *rapi, const char *window_title);
 struct GfxRenderingAPI *gfx_get_current_rendering_api(void);
 void gfx_start_frame(void);

--- a/src/pc/gfx/gfx_rendering_api.h
+++ b/src/pc/gfx/gfx_rendering_api.h
@@ -33,6 +33,8 @@ struct GfxRenderingAPI {
     void (*finish_render)(void);
     const char* (*get_name)(void);
     void (*shutdown)(void);
+    bool (*get_supports_internal_res)(void);
+    void (*end_internal_res)(void);
 };
 
 #endif

--- a/src/pc/gfx/gfx_sdl.c
+++ b/src/pc/gfx/gfx_sdl.c
@@ -200,6 +200,18 @@ static void gfx_sdl_get_dimensions(uint32_t *width, uint32_t *height) {
     if (height) *height = h;
 }
 
+static void gfx_sdl_get_display_size(uint32_t *width, uint32_t *height) {
+    SDL_DisplayMode mode;
+    int displayIndex = wnd ? SDL_GetWindowDisplayIndex(wnd) : 0;
+    if (displayIndex < 0) { displayIndex = 0; }
+    if (SDL_GetDesktopDisplayMode(displayIndex, &mode) == 0) {
+        if (width) *width = mode.w;
+        if (height) *height = mode.h;
+    } else {
+        gfx_sdl_get_dimensions(width, height);
+    }
+}
+
 static void gfx_sdl_onkeydown(int scancode) {
     const Uint8 *state = SDL_GetKeyboardState(NULL);
 
@@ -391,5 +403,6 @@ struct GfxWindowManagerAPI gfx_sdl = {
     gfx_sdl_get_max_msaa,
     gfx_sdl_set_window_title,
     gfx_sdl_reset_window_title,
-    gfx_sdl_has_focus
+    gfx_sdl_has_focus,
+    gfx_sdl_get_display_size
 };

--- a/src/pc/gfx/gfx_window_manager_api.h
+++ b/src/pc/gfx/gfx_window_manager_api.h
@@ -34,6 +34,7 @@ struct GfxWindowManagerAPI {
     void (*set_window_title)(const char* title);
     void (*reset_window_title)(void);
     bool (*has_focus)(void);
+    void (*get_display_size)(uint32_t *width, uint32_t *height);
 };
 
 #endif

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -406,6 +406,7 @@ void produce_one_dummy_frame(void (*callback)(), u8 clearColorR, u8 clearColorG,
     gfx_start_frame();
     config_gfx_pool();
     init_render_image();
+    djui_gfx_native_res_begin();
     create_dl_ortho_matrix();
     djui_gfx_displaylist_begin();
 


### PR DESCRIPTION
A menu was added to enable the user to choose the internally rendered resolution down to the original N64 resolution. Additionally a seperate menu was added to enable the user to choose a filter that makes it look like composite video output.
<img width="2558" height="1439" alt="2026-07-19_15-43" src="https://github.com/user-attachments/assets/da01e75a-1780-4662-b3be-855e3bffa8b7" />
<img width="1025" height="1316" alt="Menu" src="https://github.com/user-attachments/assets/28062cf8-7b36-4b23-81ae-1a0838a4ccad" />
<img width="2559" height="1439" alt="Unbenannt" src="https://github.com/user-attachments/assets/38a040c0-f963-402c-a6b3-ca6891aaded6" />

