### PR TITLE
Add internal render resolution setting with N64 composite video filters

### DIFF
--- a/include/PR/gbi_extension.h
+++ b/include/PR/gbi_extension.h
@@ -9,7 +9,7 @@
 // Please update the following table when implementing a new command.
 //
 // RSP ->                     09 0a 0b 0c 0d 0e 0f
-//             14 15 16 17 18 19 1a 1b 1c 1d 1e 1f
+//                15 16 17 18 19 1a 1b 1c 1d 1e 1f
 // 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f
 // 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f
 // 40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f
@@ -63,6 +63,7 @@
 #define G_VTX_EXT          0x11
 #define G_TRI2_EXT         0x12
 #define G_TEXADDR_DJUI     0x13
+#define G_NATIVERES_DJUI   0x14
 #define G_EXECUTE_DJUI     0xdd
 
 #define G_MTX_INVERSE_CAMERA_EXT   0x08
@@ -71,6 +72,15 @@
 {{ \
 	(_SHIFTL(G_TEXADDR_DJUI,24,8)|_SHIFTL(~(u32)(c),0,24)),(u32)(0)	\
 }}
+
+// marks the point where the internal resolution render target is upscaled to
+// the window and all further rendering happens at native window resolution
+#define gSPNativeResDjui(pkt)                                   \
+{                                                               \
+    Gfx *_g = (Gfx *)(pkt);                                     \
+    _g->words.w0 = _SHIFTL(G_NATIVERES_DJUI, 24, 8);            \
+    _g->words.w1 = 0;                                           \
+}
 
 #define gSetClippingDjui(pkt, cmd, x1, y1, x2, y2)         \
 {                                                               \

--- a/lang/Czech.ini
+++ b/lang/Czech.ini
@@ -175,6 +175,11 @@ OFF = "Vypnuto"
 MUST_RESTART = "Musíte restartovat hru pro aplikování změn."
 SHOW_FPS = "Zobrazit FPS"
 SHOW_PING = "Zobrazit Ping"
+INTERNAL_RESOLUTION = "Vnitřní rozlišení"
+UPSCALING = "Škálování"
+NATIVE = "Nativní"
+COMPOSITE = "Composite (N64)"
+COMPOSITE_CAPTURE = "Composite Capture"
 
 [DJUI_THEMES]
 DJUI_THEME = "Téma DJUI"

--- a/lang/Dutch.ini
+++ b/lang/Dutch.ini
@@ -175,6 +175,11 @@ OFF = "UIT"
 MUST_RESTART = "Je moet de game opnieuw opstarten voor sommige veranderingen om effect te hebben."
 SHOW_FPS = "Toon FPS"
 SHOW_PING = "Toon Ping"
+INTERNAL_RESOLUTION = "Interne resolutie"
+UPSCALING = "Opschalen"
+NATIVE = "Systeemeigen"
+COMPOSITE = "Composite (N64)"
+COMPOSITE_CAPTURE = "Composite Capture"
 
 [DJUI_THEMES]
 DJUI_THEME = "DJUI Thema"

--- a/lang/English.ini
+++ b/lang/English.ini
@@ -175,6 +175,11 @@ OFF = "Off"
 MUST_RESTART = "Restart the game to apply changes."
 SHOW_FPS = "Show FPS"
 SHOW_PING = "Show Ping"
+INTERNAL_RESOLUTION = "Internal Resolution"
+UPSCALING = "Upscaling"
+NATIVE = "Native"
+COMPOSITE = "Composite (N64)"
+COMPOSITE_CAPTURE = "Composite Capture"
 
 [DJUI_THEMES]
 DJUI_THEME = "DJUI Theme"

--- a/lang/French.ini
+++ b/lang/French.ini
@@ -175,6 +175,11 @@ OFF = "Désactivé"
 MUST_RESTART = "Vous devez relancer le jeu pour que certains changements prennent effet."
 SHOW_FPS = "Afficher les FPS"
 SHOW_PING = "Afficher le ping"
+INTERNAL_RESOLUTION = "Résolution interne"
+UPSCALING = "Mise à l'échelle"
+NATIVE = "Native"
+COMPOSITE = "Composite (N64)"
+COMPOSITE_CAPTURE = "Capture composite"
 
 [DJUI_THEMES]
 DJUI_THEME = "Thème"

--- a/lang/German.ini
+++ b/lang/German.ini
@@ -175,6 +175,11 @@ OFF = "Aus"
 MUST_RESTART = "Starte das Spiel neu, um die Änderungen anzuwenden."
 SHOW_FPS = "FPS anzeigen"
 SHOW_PING = "Ping anzeigen"
+INTERNAL_RESOLUTION = "Interne Auflösung"
+UPSCALING = "Hochskalierung"
+NATIVE = "Nativ"
+COMPOSITE = "Composite (N64)"
+COMPOSITE_CAPTURE = "Composite Capture"
 
 [DJUI_THEMES]
 DJUI_THEME = "Design"

--- a/lang/Italian.ini
+++ b/lang/Italian.ini
@@ -173,6 +173,11 @@ OFF = "Off"
 MUST_RESTART = "Devi riavviare il gioco perché alcuni cambiamenti abbiano effetto."
 SHOW_FPS = "Mostra FPS"
 SHOW_PING = "Mostra Ping"
+INTERNAL_RESOLUTION = "Risoluzione interna"
+UPSCALING = "Ridimensionamento"
+NATIVE = "Nativa"
+COMPOSITE = "Composito (N64)"
+COMPOSITE_CAPTURE = "Cattura composita"
 
 [DJUI_THEMES]
 DJUI_THEME = "Tema DJUI"

--- a/lang/Japanese.ini
+++ b/lang/Japanese.ini
@@ -175,6 +175,11 @@ OFF = "オフ"
 MUST_RESTART = "変更を適用するにはゲームを再起動してください。"
 SHOW_FPS = "FPSを表示する"
 SHOW_PING = "Pingを表示する"
+INTERNAL_RESOLUTION = "内部解像度"
+UPSCALING = "アップスケーリング"
+NATIVE = "ネイティブ"
+COMPOSITE = "コンポジット (N64)"
+COMPOSITE_CAPTURE = "コンポジットキャプチャ"
 
 [DJUI_THEMES]
 DJUI_THEME = "DJUIのテーマ"

--- a/lang/Polish.ini
+++ b/lang/Polish.ini
@@ -175,6 +175,11 @@ OFF = "Wyłączone"
 MUST_RESTART = "Musisz zrestartować grę, aby zastosować zmiany."
 SHOW_FPS = "Pokaż Klatki na Sekundę"
 SHOW_PING = "Pokaż Ping"
+INTERNAL_RESOLUTION = "Rozdzielczość wewnętrzna"
+UPSCALING = "Skalowanie"
+NATIVE = "Natywna"
+COMPOSITE = "Composite (N64)"
+COMPOSITE_CAPTURE = "Przechwycenie composite"
 
 [DJUI_THEMES]
 DJUI_THEME = "Motyw DJUI"

--- a/lang/Portuguese.ini
+++ b/lang/Portuguese.ini
@@ -175,6 +175,11 @@ OFF = "Desligado"
 MUST_RESTART = "Reinicie o jogo para aplicar as mudanças."
 SHOW_FPS = "Mostrar FPS"
 SHOW_PING = "Mostrar Ping"
+INTERNAL_RESOLUTION = "Resolução interna"
+UPSCALING = "Escalonamento"
+NATIVE = "Nativa"
+COMPOSITE = "Composto (N64)"
+COMPOSITE_CAPTURE = "Captura composta"
 
 [DJUI_THEMES]
 DJUI_THEME = "Tema da DJUI"

--- a/lang/Russian.ini
+++ b/lang/Russian.ini
@@ -174,6 +174,11 @@ OFF = "Выкл"
 MUST_RESTART = "Перезапустите игру, чтобы изменения вступили в силу."
 SHOW_FPS = "Показывать FPS"
 SHOW_PING = "Показывать пинг"
+INTERNAL_RESOLUTION = "Внутреннее разрешение"
+UPSCALING = "Масштабирование"
+NATIVE = "Родное"
+COMPOSITE = "Композитный (N64)"
+COMPOSITE_CAPTURE = "Композитный захват"
 
 [DJUI_THEMES]
 DJUI_THEME = "Темы DJUI"

--- a/lang/Spanish.ini
+++ b/lang/Spanish.ini
@@ -175,6 +175,11 @@ OFF = "Desactivado"
 MUST_RESTART = "Tienes que reiniciar el juego para aplicar los cambios."
 SHOW_FPS = "Mostrar FPS"
 SHOW_PING = "Mostrar Ping"
+INTERNAL_RESOLUTION = "Resolución interna"
+UPSCALING = "Escalado"
+NATIVE = "Nativa"
+COMPOSITE = "Compuesto (N64)"
+COMPOSITE_CAPTURE = "Captura compuesta"
 
 [DJUI_THEMES]
 DJUI_THEME = "Tema de DJUI"

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -90,6 +90,8 @@ enum RefreshRateMode configFramerateMode          = RRM_AUTO;
 unsigned int configFrameLimit                     = 60;
 unsigned int configInterpolationMode              = 1;
 unsigned int configDrawDistance                   = 6;
+unsigned int configInternalResHeight              = 0; // 0 = native, otherwise render height in pixels
+unsigned int configInternalResFilter              = 0; // 0 = Nearest, 1 = Linear, 2 = Composite, 3 = Composite Capture
 // sound settings
 unsigned int configMasterVolume                   = 80; // 0 - MAX_VOLUME
 unsigned int configMusicVolume                    = MAX_VOLUME;
@@ -264,6 +266,8 @@ static const struct ConfigOption options[] = {
     {.name = "frame_limit",                    .type = CONFIG_TYPE_UINT, .uintValue = &configFrameLimit},
     {.name = "interpolation_mode",             .type = CONFIG_TYPE_UINT, .uintValue = &configInterpolationMode},
     {.name = "coop_draw_distance",             .type = CONFIG_TYPE_UINT, .uintValue = &configDrawDistance},
+    {.name = "internal_res_height",            .type = CONFIG_TYPE_UINT, .uintValue = &configInternalResHeight},
+    {.name = "internal_res_filter",            .type = CONFIG_TYPE_UINT, .uintValue = &configInternalResFilter},
     // sound settings
     {.name = "master_volume",                  .type = CONFIG_TYPE_UINT, .uintValue = &configMasterVolume},
     {.name = "music_volume",                   .type = CONFIG_TYPE_UINT, .uintValue = &configMusicVolume},

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -64,6 +64,8 @@ extern enum RefreshRateMode configFramerateMode;
 extern unsigned int configFrameLimit;
 extern unsigned int configInterpolationMode;
 extern unsigned int configDrawDistance;
+extern unsigned int configInternalResHeight;
+extern unsigned int configInternalResFilter;
 // sound settings
 extern unsigned int configMasterVolume;
 extern unsigned int configMusicVolume;

--- a/src/pc/djui/djui.c
+++ b/src/pc/djui/djui.c
@@ -196,6 +196,7 @@ void djui_render(void) {
     gDjuiHudUtilsZ = 0;
     djui_reset_hud_params();
 
+    djui_gfx_native_res_begin();
     create_dl_ortho_matrix();
     djui_gfx_displaylist_begin();
 

--- a/src/pc/djui/djui_gfx.c
+++ b/src/pc/djui/djui_gfx.c
@@ -25,6 +25,12 @@ void djui_gfx_displaylist_begin(void) {
     gSPDisplayList(gDisplayListHead++, dl_djui_display_list_begin);
 }
 
+// everything after this marker renders at native window resolution,
+// even when an internal resolution is set for the game
+void djui_gfx_native_res_begin(void) {
+    gSPNativeResDjui(gDisplayListHead++);
+}
+
 void djui_gfx_displaylist_end(void) {
     gSPDisplayList(gDisplayListHead++, dl_djui_display_list_end);
 }

--- a/src/pc/djui/djui_gfx.h
+++ b/src/pc/djui/djui_gfx.h
@@ -11,6 +11,7 @@ extern const Gfx dl_djui_img_begin[];
 extern const Gfx dl_djui_img_end[];
 
 void djui_gfx_displaylist_begin(void);
+void djui_gfx_native_res_begin(void);
 void djui_gfx_displaylist_end(void);
 
 /* |description|Gets the current visual scaling factor of DJUI|descriptionEnd| */

--- a/src/pc/djui/djui_panel_display.c
+++ b/src/pc/djui/djui_panel_display.c
@@ -1,7 +1,10 @@
+#include <stdio.h>
 #include "djui.h"
 #include "djui_panel.h"
 #include "djui_panel_menu.h"
 #include "pc/gfx/gfx_window_manager_api.h"
+#include "pc/gfx/gfx_rendering_api.h"
+#include "pc/gfx/gfx_pc.h"
 #include "pc/pc_main.h"
 #include "pc/utils/misc.h"
 #include "pc/configfile.h"
@@ -43,6 +46,46 @@ static void djui_panel_display_update_restart_text(UNUSED struct DjuiBase* calle
         djui_text_set_text(sRestartText, DLANG(DISPLAY, MUST_RESTART));
     } else {
         djui_text_set_text(sRestartText, "");
+    }
+}
+
+// common resolution heights, from the N64's original 240p up
+static const u32 sInternalResHeights[] = { 240, 360, 480, 720, 1080, 1440, 2160, 4320 };
+#define INTERNAL_RES_MAX_CHOICES (ARRAY_COUNT(sInternalResHeights) + 1)
+static u32 sInternalResSelection = 0;
+static u32 sInternalResCount = 0;
+static u32 sInternalResValues[INTERNAL_RES_MAX_CHOICES] = { 0 };
+static char sInternalResLabels[INTERNAL_RES_MAX_CHOICES][32] = { 0 };
+static char* sInternalResChoices[INTERNAL_RES_MAX_CHOICES] = { 0 };
+
+static void djui_panel_display_internal_res_change(UNUSED struct DjuiBase* caller) {
+    configInternalResHeight = sInternalResValues[sInternalResSelection];
+}
+
+static void djui_panel_display_internal_res_build_choices(void) {
+    u32 displayWidth = 0;
+    u32 displayHeight = 0;
+    if (gWindowApi->get_display_size) {
+        gWindowApi->get_display_size(&displayWidth, &displayHeight);
+    }
+    if (displayHeight == 0) { displayHeight = 1080; }
+
+    // native resolution first, then the common resolutions below it, descending
+    sInternalResCount = 0;
+    sInternalResValues[sInternalResCount] = 0;
+    snprintf(sInternalResLabels[sInternalResCount], 32, "%s (%dp)", DLANG(DISPLAY, NATIVE), displayHeight);
+    sInternalResCount++;
+    for (s32 i = ARRAY_COUNT(sInternalResHeights) - 1; i >= 0; i--) {
+        if (sInternalResHeights[i] >= displayHeight) { continue; }
+        sInternalResValues[sInternalResCount] = sInternalResHeights[i];
+        snprintf(sInternalResLabels[sInternalResCount], 32, "%dp%s", sInternalResHeights[i], (sInternalResHeights[i] == 240) ? " (N64)" : "");
+        sInternalResCount++;
+    }
+
+    sInternalResSelection = 0;
+    for (u32 i = 0; i < sInternalResCount; i++) {
+        sInternalResChoices[i] = sInternalResLabels[i];
+        if (sInternalResValues[i] == configInternalResHeight) { sInternalResSelection = i; }
     }
 }
 
@@ -113,6 +156,15 @@ void djui_panel_display_create(struct DjuiBase* caller) {
 
         char* filterChoices[3] = { DLANG(DISPLAY, NEAREST), DLANG(DISPLAY, LINEAR), DLANG(DISPLAY, TRIPOINT) };
         djui_selectionbox_create(body, DLANG(DISPLAY, FILTERING), filterChoices, 3, &configFiltering, NULL);
+
+        struct GfxRenderingAPI* rapi = gfx_get_current_rendering_api();
+        if (rapi && rapi->get_supports_internal_res && rapi->get_supports_internal_res()) {
+            djui_panel_display_internal_res_build_choices();
+            djui_selectionbox_create(body, DLANG(DISPLAY, INTERNAL_RESOLUTION), sInternalResChoices, sInternalResCount, &sInternalResSelection, djui_panel_display_internal_res_change);
+
+            char* upscalingChoices[4] = { DLANG(DISPLAY, NEAREST), DLANG(DISPLAY, LINEAR), DLANG(DISPLAY, COMPOSITE), DLANG(DISPLAY, COMPOSITE_CAPTURE) };
+            djui_selectionbox_create(body, DLANG(DISPLAY, UPSCALING), upscalingChoices, 4, &configInternalResFilter, NULL);
+        }
 
         int maxMsaa = gWindowApi->get_max_msaa();
         if (maxMsaa >= 2) {

--- a/src/pc/gfx/gfx_direct3d11.cpp
+++ b/src/pc/gfx/gfx_direct3d11.cpp
@@ -143,7 +143,6 @@ static struct {
     ComPtr<ID3D11PixelShader> blit_pixel_shader_passthrough;
     ComPtr<ID3D11PixelShader> blit_pixel_shader_composite;
     ComPtr<ID3D11PixelShader> blit_pixel_shader_capture;
-    ComPtr<ID3D11InputLayout> blit_input_layout;
     ComPtr<ID3D11SamplerState> blit_sampler_point;
     ComPtr<ID3D11SamplerState> blit_sampler_linear;
     ComPtr<ID3D11Buffer> blit_cb;
@@ -958,13 +957,10 @@ static bool d3d11_ensure_blit_resources(void) {
         return false;
     }
 
-    // the vertex shader only uses SV_VertexID, so it needs no input elements
-    // or vertex buffer -- an empty input layout is valid and still required
-    // to satisfy IASetInputLayout()
-    if (FAILED(d3d.device->CreateInputLayout(nullptr, 0, vs_blob->GetBufferPointer(), vs_blob->GetBufferSize(), d3d.blit_input_layout.GetAddressOf()))) {
-        d3d.blit_resources_failed = true;
-        return false;
-    }
+    // the vertex shader only uses SV_VertexID and has no input signature to
+    // satisfy, so no input layout object is needed -- IASetInputLayout(nullptr)
+    // unbinds any layout, which some drivers require anyway since
+    // CreateInputLayout(nullptr, 0, ...) is rejected with E_INVALIDARG
 
     D3D11_SAMPLER_DESC sampler_desc;
     ZeroMemory(&sampler_desc, sizeof(sampler_desc));
@@ -1148,7 +1144,7 @@ static void gfx_d3d11_end_internal_res(void) {
 
         ID3D11Buffer* null_vb = nullptr;
         UINT stride = 0, offset = 0;
-        d3d.context->IASetInputLayout(d3d.blit_input_layout.Get());
+        d3d.context->IASetInputLayout(nullptr);
         d3d.context->IASetVertexBuffers(0, 1, &null_vb, &stride, &offset);
         d3d.context->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
         d3d.context->VSSetShader(d3d.blit_vertex_shader.Get(), nullptr, 0);

--- a/src/pc/gfx/gfx_direct3d11.cpp
+++ b/src/pc/gfx/gfx_direct3d11.cpp
@@ -3,6 +3,7 @@
 #include <cstdio>
 #include <vector>
 #include <cmath>
+#include <string>
 
 #include <windows.h>
 #include <versionhelpers.h>
@@ -28,7 +29,6 @@
 
 extern "C" {
     #include "pc/controller/controller_bind_mapping.h"
-    extern Color gVertexColor;
 }
 
 #define DECLARE_GFX_DXGI_FUNCTIONS
@@ -152,6 +152,11 @@ static struct {
     ComPtr<ID3D11BlendState> blit_blend_state;
     bool blit_resources_ready;
     bool blit_resources_failed;
+    // dedicated counter for the capture filter's grain animation -- kept
+    // separate from per_frame_cb_data.noise_frame, which is capped at 150
+    // for the unrelated built-in dithering effect and would otherwise make
+    // the grain repeat far more often than the OpenGL backend's 1024-frame cycle
+    uint32_t blit_frame_counter;
 
     // Current state
 
@@ -1030,7 +1035,7 @@ static bool d3d11_ensure_blit_resources(void) {
 // level 10.0; feature levels 9.x have enough restrictions around this that
 // it's not worth supporting (mirrors gfx_opengl.c requiring GL 3.0+).
 static bool d3d11_supports_internal_res(void) {
-    return d3d.feature_level >= D3D_FEATURE_LEVEL_10_0 && !d3d.internal_res_create_failed;
+    return d3d.feature_level >= D3D_FEATURE_LEVEL_10_0 && !d3d.internal_res_create_failed && !d3d.blit_resources_failed;
 }
 
 static bool gfx_d3d11_get_supports_internal_res(void) {
@@ -1120,7 +1125,7 @@ static void gfx_d3d11_end_internal_res(void) {
         BlitCB cb_data;
         cb_data.texel_size[0] = 1.0f / (float)d3d.internal_res_width;
         cb_data.texel_size[1] = 1.0f / (float)d3d.internal_res_height;
-        cb_data.frame_num = (float)(d3d.per_frame_cb_data.noise_frame % 1024u);
+        cb_data.frame_num = (float)(d3d.blit_frame_counter % 1024u);
         cb_data.padding = 0.0f;
 
         D3D11_MAPPED_SUBRESOURCE ms;
@@ -1220,6 +1225,7 @@ static void gfx_d3d11_start_frame(void) {
         // No high values, as noise starts to look ugly
         d3d.per_frame_cb_data.noise_frame = 0;
     }
+    d3d.blit_frame_counter++;
 
     d3d.per_frame_cb_data.noise_scale_x = (float) d3d.render_width;
     d3d.per_frame_cb_data.noise_scale_y = (float) d3d.render_height;

--- a/src/pc/gfx/gfx_direct3d11.cpp
+++ b/src/pc/gfx/gfx_direct3d11.cpp
@@ -24,6 +24,7 @@
 #include "gfx_window_manager_api.h"
 #include "gfx_rendering_api.h"
 #include "gfx_direct3d_common.h"
+#include "gfx_pc.h"
 
 extern "C" {
     #include "pc/controller/controller_bind_mapping.h"
@@ -124,11 +125,45 @@ static struct {
     int current_tile;
     uint32_t current_texture_ids[2];
 
+    // Internal resolution render target (offscreen game render, upscaled to the
+    // window by end_internal_res() before DJUI renders natively). See the
+    // equivalent FBO logic in gfx_opengl.c for the OpenGL backend.
+    ComPtr<ID3D11Texture2D> internal_res_color_texture;
+    ComPtr<ID3D11RenderTargetView> internal_res_rtv;
+    ComPtr<ID3D11ShaderResourceView> internal_res_srv;
+    ComPtr<ID3D11Texture2D> internal_res_depth_texture;
+    ComPtr<ID3D11DepthStencilView> internal_res_dsv;
+    uint32_t internal_res_width;
+    uint32_t internal_res_height;
+    bool internal_res_active; // true while the game is rendering into the offscreen target this frame
+    bool internal_res_create_failed;
+
+    // Blit pipeline (fullscreen triangle, no vertex/index buffer needed)
+    ComPtr<ID3D11VertexShader> blit_vertex_shader;
+    ComPtr<ID3D11PixelShader> blit_pixel_shader_passthrough;
+    ComPtr<ID3D11PixelShader> blit_pixel_shader_composite;
+    ComPtr<ID3D11PixelShader> blit_pixel_shader_capture;
+    ComPtr<ID3D11InputLayout> blit_input_layout;
+    ComPtr<ID3D11SamplerState> blit_sampler_point;
+    ComPtr<ID3D11SamplerState> blit_sampler_linear;
+    ComPtr<ID3D11Buffer> blit_cb;
+    ComPtr<ID3D11RasterizerState> blit_rasterizer_state;
+    ComPtr<ID3D11DepthStencilState> blit_depth_stencil_state;
+    ComPtr<ID3D11BlendState> blit_blend_state;
+    bool blit_resources_ready;
+    bool blit_resources_failed;
+
     // Current state
 
     struct ShaderProgramD3D11 *shader_program;
 
     uint32_t current_width, current_height;
+
+    // Dimensions of whatever render target is currently bound (either the window
+    // backbuffer, or the internal-res offscreen target while internal_res_active).
+    // gfx_d3d11_set_viewport/set_scissor need this (not current_width/height) to
+    // flip Y into the bound target's own space.
+    uint32_t render_width, render_height;
 
     int8_t depth_test;
     int8_t depth_mask;
@@ -203,6 +238,9 @@ static void create_render_target_views(bool is_resize) {
 
     d3d.current_width = desc1.Width;
     d3d.current_height = desc1.Height;
+    // keep render_width/height valid even before the first start_frame() call
+    d3d.render_width = desc1.Width;
+    d3d.render_height = desc1.Height;
 }
 
 static void gfx_d3d11_init(void) {
@@ -564,7 +602,10 @@ static void gfx_d3d11_set_zmode_decal(bool zmode_decal) {
 static void gfx_d3d11_set_viewport(int x, int y, int width, int height) {
     D3D11_VIEWPORT viewport;
     viewport.TopLeftX = x;
-    viewport.TopLeftY = d3d.current_height - y - height;
+    // flip into whichever render target is currently bound -- the window
+    // backbuffer normally, or the (typically smaller) internal-res offscreen
+    // target while the game is rendering at a reduced resolution
+    viewport.TopLeftY = d3d.render_height - y - height;
     viewport.Width = width;
     viewport.Height = height;
     viewport.MinDepth = 0.0f;
@@ -576,9 +617,9 @@ static void gfx_d3d11_set_viewport(int x, int y, int width, int height) {
 static void gfx_d3d11_set_scissor(int x, int y, int width, int height) {
     D3D11_RECT rect;
     rect.left = x;
-    rect.top = d3d.current_height - y - height;
+    rect.top = d3d.render_height - y - height;
     rect.right = x + width;
-    rect.bottom = d3d.current_height - y;
+    rect.bottom = d3d.render_height - y;
 
     d3d.context->RSSetScissorRects(1, &rect);
 }
@@ -722,20 +763,455 @@ static void gfx_d3d11_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_t
     d3d.context->Draw(buf_vbo_num_tris * 3, 0);
 }
 
+  ///////////////////////////////////////
+ // internal resolution render target //
+///////////////////////////////////////
+//
+// Mirrors the OpenGL backend's FBO + GLSL shaders in gfx_opengl.c: the game
+// renders into an offscreen target sized to gfx_internal_res_width/height,
+// which is then upscaled into the window backbuffer by end_internal_res()
+// right before DJUI starts rendering (see gfx_native_res_begin() in
+// gfx_pc.c), so DJUI always renders sharp at native window resolution.
+
+struct BlitCB {
+    float texel_size[2];
+    float frame_num;
+    float padding;
+};
+
+// Fullscreen triangle without any vertex/index buffer (the classic
+// SV_VertexID trick: 3 vertices covering (-1,-3)-(3,1) in NDC, which is a
+// superset of the screen -- clipped down to the visible (-1,-1)-(1,1) quad).
+static const char* sBlitVertexShaderSrc = R"HLSL(
+struct VSOut {
+    float4 pos : SV_POSITION;
+    float2 uv : TEXCOORD0;
+};
+
+VSOut VSMain(uint vid : SV_VertexID) {
+    VSOut o;
+    float2 uv = float2((vid << 1) & 2, vid & 2);
+    o.pos = float4(uv * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+    o.uv = uv;
+    return o;
+}
+)HLSL";
+
+static const char* sBlitPassthroughPixelShaderSrc = R"HLSL(
+struct VSOut {
+    float4 pos : SV_POSITION;
+    float2 uv : TEXCOORD0;
+};
+
+Texture2D uTex : register(t0);
+SamplerState uSamp : register(s0);
+
+float4 PSMain(VSOut i) : SV_TARGET {
+    return uTex.Sample(uSamp, i.uv);
+}
+)HLSL";
+
+// Shared declarations + YIQ helpers for the two composite filters below.
+// Translated 1:1 from the GLSL shaders in gfx_opengl.c (composite_fs_src /
+// capture_fs_src) -- keep the math in both files in sync when tuning either.
+static const char* sBlitFilterCommonSrc = R"HLSL(
+struct VSOut {
+    float4 pos : SV_POSITION;
+    float2 uv : TEXCOORD0;
+};
+
+cbuffer BlitCB : register(b3) {
+    float2 uTexelSize;
+    float uFrame;
+    float uPad;
+};
+
+Texture2D uTex : register(t0);
+SamplerState uSamp : register(s0);
+
+float3 to_yiq(float3 c) {
+    return float3(dot(c, float3(0.299,  0.587,  0.114)),
+                  dot(c, float3(0.596, -0.274, -0.322)),
+                  dot(c, float3(0.211, -0.523,  0.312)));
+}
+
+float3 to_rgb(float3 c) {
+    return float3(c.x + 0.956 * c.y + 0.621 * c.z,
+                  c.x - 0.272 * c.y - 0.647 * c.z,
+                  c.x - 1.106 * c.y + 1.703 * c.z);
+}
+)HLSL";
+
+// Soft look: luma gets a light horizontal blur, chroma a wide one.
+static const char* sBlitCompositePixelShaderSrc = R"HLSL(
+float4 PSMain(VSOut i) : SV_TARGET {
+    float2 uv = i.uv;
+    float dx = uTexelSize.x;
+    float3 t0 = to_yiq(uTex.Sample(uSamp, uv - float2(3.0 * dx, 0.0)).rgb);
+    float3 t1 = to_yiq(uTex.Sample(uSamp, uv - float2(2.0 * dx, 0.0)).rgb);
+    float3 t2 = to_yiq(uTex.Sample(uSamp, uv - float2(1.0 * dx, 0.0)).rgb);
+    float3 t3 = to_yiq(uTex.Sample(uSamp, uv).rgb);
+    float3 t4 = to_yiq(uTex.Sample(uSamp, uv + float2(1.0 * dx, 0.0)).rgb);
+    float3 t5 = to_yiq(uTex.Sample(uSamp, uv + float2(2.0 * dx, 0.0)).rgb);
+    float3 t6 = to_yiq(uTex.Sample(uSamp, uv + float2(3.0 * dx, 0.0)).rgb);
+    float luma = t2.x * 0.15 + t3.x * 0.70 + t4.x * 0.15;
+    float2 chroma = t0.yz * 0.07 + t1.yz * 0.12 + t2.yz * 0.19 + t3.yz * 0.24
+                  + t4.yz * 0.19 + t5.yz * 0.12 + t6.yz * 0.07;
+    return float4(to_rgb(float3(luma, chroma)), 1.0);
+}
+)HLSL";
+
+// Mimics a recorded capture of real N64 composite video output: sharper
+// luma with edge ringing, hard scanlines, line jitter and analog grain.
+static const char* sBlitCapturePixelShaderSrc = R"HLSL(
+float hash(float2 p) {
+    return frac(sin(dot(p, float2(12.9898, 78.233)) + uFrame * 0.317) * 43758.5453);
+}
+
+float4 PSMain(VSOut i) : SV_TARGET {
+    float2 uv = i.uv;
+    float dx = uTexelSize.x;
+    float dy = uTexelSize.y;
+    // capture line index at half-texel granularity (480 lines for 240p)
+    float subline = floor(uv.y / (0.5 * dy));
+    // vertical: snap to source lines with a narrow transition (hard TV lines)
+    float ty = uv.y / dy;
+    float baseLine = floor(ty - 0.5) + 0.5;
+    float fracY = saturate((ty - baseLine - 0.5) * 4.0 + 0.5);
+    float sy = (baseLine + fracY) * dy;
+    // alternate capture lines are shifted, like a deinterlaced recording
+    float sx = uv.x + ((fmod(subline, 2.0) < 1.0) ? -0.25 : 0.25) * dx;
+    // luma samples snap toward texel centers so the upscale smears less
+    float tx = sx / dx;
+    float baseCol = floor(tx - 0.5) + 0.5;
+    float fracX = saturate((tx - baseCol - 0.5) * 2.5 + 0.5);
+    float2 luv = float2((baseCol + fracX) * dx, sy);
+    float2 suv = float2(sx, sy);
+    // luma: mostly sharp, with ringing halos around edges
+    float l0 = to_yiq(uTex.Sample(uSamp, luv - float2(2.0 * dx, 0.0)).rgb).x;
+    float l1 = to_yiq(uTex.Sample(uSamp, luv - float2(1.0 * dx, 0.0)).rgb).x;
+    float l2 = to_yiq(uTex.Sample(uSamp, luv).rgb).x;
+    float l3 = to_yiq(uTex.Sample(uSamp, luv + float2(1.0 * dx, 0.0)).rgb).x;
+    float l4 = to_yiq(uTex.Sample(uSamp, luv + float2(2.0 * dx, 0.0)).rgb).x;
+    float luma = -0.20 * l0 + 0.10 * l1 + 1.20 * l2 + 0.10 * l3 - 0.20 * l4;
+    // chroma: wide horizontal bleed, delayed to the right
+    float2 cuv = suv - float2(1.0 * dx, 0.0);
+    float2 c0 = to_yiq(uTex.Sample(uSamp, cuv - float2(4.5 * dx, 0.0)).rgb).yz;
+    float2 c1 = to_yiq(uTex.Sample(uSamp, cuv - float2(3.0 * dx, 0.0)).rgb).yz;
+    float2 c2 = to_yiq(uTex.Sample(uSamp, cuv - float2(1.5 * dx, 0.0)).rgb).yz;
+    float2 c3 = to_yiq(uTex.Sample(uSamp, cuv).rgb).yz;
+    float2 c4 = to_yiq(uTex.Sample(uSamp, cuv + float2(1.5 * dx, 0.0)).rgb).yz;
+    float2 c5 = to_yiq(uTex.Sample(uSamp, cuv + float2(3.0 * dx, 0.0)).rgb).yz;
+    float2 c6 = to_yiq(uTex.Sample(uSamp, cuv + float2(4.5 * dx, 0.0)).rgb).yz;
+    float2 chroma = c0 * 0.07 + c1 * 0.12 + c2 * 0.19 + c3 * 0.24
+                  + c4 * 0.19 + c5 * 0.12 + c6 * 0.07;
+    // composite captures look saturated: boost the chroma
+    chroma *= 1.25;
+    // animated analog grain, at half-texel granularity
+    float n = hash(floor(float2(uv.x / (0.5 * dx), subline)));
+    luma += (n - 0.5) * 0.06;
+    return float4(to_rgb(float3(luma, chroma)), 1.0);
+}
+)HLSL";
+
+static ComPtr<ID3DBlob> d3d11_compile_blit_shader(const std::string& src, const char* entry, const char* target) {
+    ComPtr<ID3DBlob> blob;
+    ComPtr<ID3DBlob> error_blob;
+    HRESULT hr = d3d.D3DCompile(src.c_str(), src.size(), nullptr, nullptr, nullptr, entry, target,
+                                 D3DCOMPILE_OPTIMIZATION_LEVEL2, 0, blob.GetAddressOf(), error_blob.GetAddressOf());
+    if (FAILED(hr)) {
+        fprintf(stderr, "upscale filter shader failed to compile (%s):\n%s\n", entry,
+                error_blob ? (const char*)error_blob->GetBufferPointer() : "(no error message)");
+        return nullptr;
+    }
+    return blob;
+}
+
+// Lazily compiles and creates the blit pipeline (shaders, input layout,
+// samplers, constant buffer, pipeline state). Failure disables the feature
+// instead of crashing the renderer -- an upscale filter is optional, unlike
+// the main color-combiner shaders.
+static bool d3d11_ensure_blit_resources(void) {
+    if (d3d.blit_resources_ready) { return true; }
+    if (d3d.blit_resources_failed) { return false; }
+
+    ComPtr<ID3DBlob> vs_blob = d3d11_compile_blit_shader(sBlitVertexShaderSrc, "VSMain", "vs_4_0");
+    ComPtr<ID3DBlob> ps_pass_blob = d3d11_compile_blit_shader(sBlitPassthroughPixelShaderSrc, "PSMain", "ps_4_0");
+    ComPtr<ID3DBlob> ps_composite_blob = d3d11_compile_blit_shader(std::string(sBlitFilterCommonSrc) + sBlitCompositePixelShaderSrc, "PSMain", "ps_4_0");
+    ComPtr<ID3DBlob> ps_capture_blob = d3d11_compile_blit_shader(std::string(sBlitFilterCommonSrc) + sBlitCapturePixelShaderSrc, "PSMain", "ps_4_0");
+
+    if (!vs_blob || !ps_pass_blob || !ps_composite_blob || !ps_capture_blob) {
+        d3d.blit_resources_failed = true;
+        return false;
+    }
+
+    if (FAILED(d3d.device->CreateVertexShader(vs_blob->GetBufferPointer(), vs_blob->GetBufferSize(), nullptr, d3d.blit_vertex_shader.GetAddressOf()))
+        || FAILED(d3d.device->CreatePixelShader(ps_pass_blob->GetBufferPointer(), ps_pass_blob->GetBufferSize(), nullptr, d3d.blit_pixel_shader_passthrough.GetAddressOf()))
+        || FAILED(d3d.device->CreatePixelShader(ps_composite_blob->GetBufferPointer(), ps_composite_blob->GetBufferSize(), nullptr, d3d.blit_pixel_shader_composite.GetAddressOf()))
+        || FAILED(d3d.device->CreatePixelShader(ps_capture_blob->GetBufferPointer(), ps_capture_blob->GetBufferSize(), nullptr, d3d.blit_pixel_shader_capture.GetAddressOf()))) {
+        d3d.blit_resources_failed = true;
+        return false;
+    }
+
+    // the vertex shader only uses SV_VertexID, so it needs no input elements
+    // or vertex buffer -- an empty input layout is valid and still required
+    // to satisfy IASetInputLayout()
+    if (FAILED(d3d.device->CreateInputLayout(nullptr, 0, vs_blob->GetBufferPointer(), vs_blob->GetBufferSize(), d3d.blit_input_layout.GetAddressOf()))) {
+        d3d.blit_resources_failed = true;
+        return false;
+    }
+
+    D3D11_SAMPLER_DESC sampler_desc;
+    ZeroMemory(&sampler_desc, sizeof(sampler_desc));
+    sampler_desc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+    sampler_desc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+    sampler_desc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+    sampler_desc.MinLOD = 0;
+    sampler_desc.MaxLOD = D3D11_FLOAT32_MAX;
+
+    sampler_desc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
+    if (FAILED(d3d.device->CreateSamplerState(&sampler_desc, d3d.blit_sampler_point.GetAddressOf()))) {
+        d3d.blit_resources_failed = true;
+        return false;
+    }
+
+    sampler_desc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+    if (FAILED(d3d.device->CreateSamplerState(&sampler_desc, d3d.blit_sampler_linear.GetAddressOf()))) {
+        d3d.blit_resources_failed = true;
+        return false;
+    }
+
+    D3D11_BUFFER_DESC cb_desc;
+    ZeroMemory(&cb_desc, sizeof(cb_desc));
+    cb_desc.Usage = D3D11_USAGE_DYNAMIC;
+    cb_desc.ByteWidth = (sizeof(BlitCB) + 15) / 16 * 16;
+    cb_desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+    cb_desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+    if (FAILED(d3d.device->CreateBuffer(&cb_desc, nullptr, d3d.blit_cb.GetAddressOf()))) {
+        d3d.blit_resources_failed = true;
+        return false;
+    }
+
+    D3D11_RASTERIZER_DESC rasterizer_desc;
+    ZeroMemory(&rasterizer_desc, sizeof(rasterizer_desc));
+    rasterizer_desc.FillMode = D3D11_FILL_SOLID;
+    rasterizer_desc.CullMode = D3D11_CULL_NONE;
+    rasterizer_desc.DepthClipEnable = true;
+    rasterizer_desc.ScissorEnable = false;
+    if (FAILED(d3d.device->CreateRasterizerState(&rasterizer_desc, d3d.blit_rasterizer_state.GetAddressOf()))) {
+        d3d.blit_resources_failed = true;
+        return false;
+    }
+
+    D3D11_DEPTH_STENCIL_DESC depth_stencil_desc;
+    ZeroMemory(&depth_stencil_desc, sizeof(depth_stencil_desc));
+    depth_stencil_desc.DepthEnable = false;
+    depth_stencil_desc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ZERO;
+    depth_stencil_desc.StencilEnable = false;
+    if (FAILED(d3d.device->CreateDepthStencilState(&depth_stencil_desc, d3d.blit_depth_stencil_state.GetAddressOf()))) {
+        d3d.blit_resources_failed = true;
+        return false;
+    }
+
+    D3D11_BLEND_DESC blend_desc;
+    ZeroMemory(&blend_desc, sizeof(blend_desc));
+    blend_desc.RenderTarget[0].BlendEnable = false;
+    blend_desc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+    if (FAILED(d3d.device->CreateBlendState(&blend_desc, d3d.blit_blend_state.GetAddressOf()))) {
+        d3d.blit_resources_failed = true;
+        return false;
+    }
+
+    d3d.blit_resources_ready = true;
+    return true;
+}
+
+// Render-to-texture + shader model 4 blit shaders need at least feature
+// level 10.0; feature levels 9.x have enough restrictions around this that
+// it's not worth supporting (mirrors gfx_opengl.c requiring GL 3.0+).
+static bool d3d11_supports_internal_res(void) {
+    return d3d.feature_level >= D3D_FEATURE_LEVEL_10_0 && !d3d.internal_res_create_failed;
+}
+
+static bool gfx_d3d11_get_supports_internal_res(void) {
+    return d3d11_supports_internal_res();
+}
+
+static bool d3d11_internal_res_ensure(uint32_t width, uint32_t height) {
+    if (d3d.internal_res_color_texture.Get() != nullptr && d3d.internal_res_width == width && d3d.internal_res_height == height) {
+        return true;
+    }
+
+    d3d.internal_res_rtv.Reset();
+    d3d.internal_res_srv.Reset();
+    d3d.internal_res_color_texture.Reset();
+    d3d.internal_res_dsv.Reset();
+    d3d.internal_res_depth_texture.Reset();
+
+    D3D11_TEXTURE2D_DESC color_desc;
+    ZeroMemory(&color_desc, sizeof(color_desc));
+    color_desc.Width = width;
+    color_desc.Height = height;
+    color_desc.MipLevels = 1;
+    color_desc.ArraySize = 1;
+    color_desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    color_desc.SampleDesc.Count = 1;
+    color_desc.SampleDesc.Quality = 0;
+    color_desc.Usage = D3D11_USAGE_DEFAULT;
+    color_desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+
+    if (FAILED(d3d.device->CreateTexture2D(&color_desc, nullptr, d3d.internal_res_color_texture.GetAddressOf()))) {
+        d3d.internal_res_create_failed = true;
+        return false;
+    }
+    if (FAILED(d3d.device->CreateRenderTargetView(d3d.internal_res_color_texture.Get(), nullptr, d3d.internal_res_rtv.GetAddressOf()))
+        || FAILED(d3d.device->CreateShaderResourceView(d3d.internal_res_color_texture.Get(), nullptr, d3d.internal_res_srv.GetAddressOf()))) {
+        d3d.internal_res_create_failed = true;
+        return false;
+    }
+
+    D3D11_TEXTURE2D_DESC depth_desc;
+    ZeroMemory(&depth_desc, sizeof(depth_desc));
+    depth_desc.Width = width;
+    depth_desc.Height = height;
+    depth_desc.MipLevels = 1;
+    depth_desc.ArraySize = 1;
+    depth_desc.Format = DXGI_FORMAT_D32_FLOAT;
+    depth_desc.SampleDesc.Count = 1;
+    depth_desc.SampleDesc.Quality = 0;
+    depth_desc.Usage = D3D11_USAGE_DEFAULT;
+    depth_desc.BindFlags = D3D11_BIND_DEPTH_STENCIL;
+
+    if (FAILED(d3d.device->CreateTexture2D(&depth_desc, nullptr, d3d.internal_res_depth_texture.GetAddressOf()))
+        || FAILED(d3d.device->CreateDepthStencilView(d3d.internal_res_depth_texture.Get(), nullptr, d3d.internal_res_dsv.GetAddressOf()))) {
+        d3d.internal_res_create_failed = true;
+        return false;
+    }
+
+    d3d.internal_res_width = width;
+    d3d.internal_res_height = height;
+    return true;
+}
+
+// Called mid-frame (via the G_NATIVERES_DJUI opcode, see gfx_native_res_begin()
+// in gfx_pc.c) when DJUI rendering begins: upscales the internal render
+// target into the window backbuffer and leaves the window backbuffer bound
+// (with its own depth buffer, cleared) for any further native-res rendering.
+static void gfx_d3d11_end_internal_res(void) {
+    if (!d3d.internal_res_active) { return; }
+    d3d.internal_res_active = false;
+
+    d3d.render_width = d3d.current_width;
+    d3d.render_height = d3d.current_height;
+
+    if (d3d11_ensure_blit_resources()) {
+        ID3D11PixelShader* ps = d3d.blit_pixel_shader_passthrough.Get();
+        ID3D11SamplerState* samp = d3d.blit_sampler_point.Get();
+        if (configInternalResFilter == 1) {
+            samp = d3d.blit_sampler_linear.Get();
+        } else if (configInternalResFilter == 2) {
+            ps = d3d.blit_pixel_shader_composite.Get();
+            samp = d3d.blit_sampler_linear.Get();
+        } else if (configInternalResFilter == 3) {
+            ps = d3d.blit_pixel_shader_capture.Get();
+            samp = d3d.blit_sampler_linear.Get();
+        }
+
+        BlitCB cb_data;
+        cb_data.texel_size[0] = 1.0f / (float)d3d.internal_res_width;
+        cb_data.texel_size[1] = 1.0f / (float)d3d.internal_res_height;
+        cb_data.frame_num = (float)(d3d.per_frame_cb_data.noise_frame % 1024u);
+        cb_data.padding = 0.0f;
+
+        D3D11_MAPPED_SUBRESOURCE ms;
+        ZeroMemory(&ms, sizeof(ms));
+        d3d.context->Map(d3d.blit_cb.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &ms);
+        memcpy(ms.pData, &cb_data, sizeof(cb_data));
+        d3d.context->Unmap(d3d.blit_cb.Get(), 0);
+
+        // bind the window backbuffer without a depth buffer for the blit itself
+        d3d.context->OMSetRenderTargets(1, d3d.backbuffer_view.GetAddressOf(), nullptr);
+
+        D3D11_VIEWPORT viewport;
+        viewport.TopLeftX = 0;
+        viewport.TopLeftY = 0;
+        viewport.Width = (float)d3d.current_width;
+        viewport.Height = (float)d3d.current_height;
+        viewport.MinDepth = 0.0f;
+        viewport.MaxDepth = 1.0f;
+        d3d.context->RSSetViewports(1, &viewport);
+
+        ID3D11Buffer* null_vb = nullptr;
+        UINT stride = 0, offset = 0;
+        d3d.context->IASetInputLayout(d3d.blit_input_layout.Get());
+        d3d.context->IASetVertexBuffers(0, 1, &null_vb, &stride, &offset);
+        d3d.context->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+        d3d.context->VSSetShader(d3d.blit_vertex_shader.Get(), nullptr, 0);
+        d3d.context->PSSetShader(ps, nullptr, 0);
+        d3d.context->PSSetShaderResources(0, 1, d3d.internal_res_srv.GetAddressOf());
+        d3d.context->PSSetSamplers(0, 1, &samp);
+        d3d.context->PSSetConstantBuffers(3, 1, d3d.blit_cb.GetAddressOf());
+        d3d.context->OMSetDepthStencilState(d3d.blit_depth_stencil_state.Get(), 0);
+        d3d.context->OMSetBlendState(d3d.blit_blend_state.Get(), nullptr, 0xFFFFFFFF);
+        d3d.context->RSSetState(d3d.blit_rasterizer_state.Get());
+
+        d3d.context->Draw(3, 0);
+
+        // unbind the offscreen SRV: it needs to be bindable as a render target
+        // again next frame, and D3D11 forbids a resource being simultaneously
+        // bound as both an input and an output
+        ID3D11ShaderResourceView* null_srv = nullptr;
+        d3d.context->PSSetShaderResources(0, 1, &null_srv);
+
+        // the blit changed VS/PS/IA/OM state directly, bypassing the "last_*"
+        // change-detection caches in gfx_d3d11_draw_triangles() -- invalidate
+        // them so the next real draw call (DJUI, at native resolution)
+        // reapplies its own state instead of trusting stale cached pointers
+        d3d.last_shader_program = nullptr;
+        d3d.last_vertex_buffer_stride = 0;
+        d3d.last_blend_state = nullptr;
+        d3d.last_resource_views[0] = nullptr;
+        d3d.last_resource_views[1] = nullptr;
+        d3d.last_sampler_states[0] = nullptr;
+        d3d.last_sampler_states[1] = nullptr;
+        d3d.last_depth_test = -1;
+        d3d.last_depth_mask = -1;
+        d3d.last_zmode_decal = -1;
+        d3d.last_primitive_topology = D3D_PRIMITIVE_TOPOLOGY_UNDEFINED;
+    }
+
+    // rebind the window depth buffer (cleared) for subsequent native-res
+    // rendering, mirroring gfx_opengl_internal_res_blit() clearing the window
+    // depth buffer so DJUI starts with a fresh depth test
+    d3d.context->ClearDepthStencilView(d3d.depth_stencil_view.Get(), D3D11_CLEAR_DEPTH, 1.0f, 0);
+    d3d.context->OMSetRenderTargets(1, d3d.backbuffer_view.GetAddressOf(), d3d.depth_stencil_view.Get());
+}
+
 static void gfx_d3d11_on_resize(void) {
     create_render_target_views(true);
 }
 
 static void gfx_d3d11_start_frame(void) {
+    // Decide whether the game renders into the internal-res offscreen target
+    // this frame (see the "internal resolution render target" section above)
+
+    d3d.internal_res_active = d3d11_supports_internal_res() && gfx_internal_res_height > 0
+        && d3d11_internal_res_ensure(gfx_internal_res_width, gfx_internal_res_height);
+
+    ID3D11RenderTargetView *rtv = d3d.internal_res_active ? d3d.internal_res_rtv.Get() : d3d.backbuffer_view.Get();
+    ID3D11DepthStencilView *dsv = d3d.internal_res_active ? d3d.internal_res_dsv.Get() : d3d.depth_stencil_view.Get();
+    d3d.render_width = d3d.internal_res_active ? d3d.internal_res_width : d3d.current_width;
+    d3d.render_height = d3d.internal_res_active ? d3d.internal_res_height : d3d.current_height;
+
     // Set render targets
 
-    d3d.context->OMSetRenderTargets(1, d3d.backbuffer_view.GetAddressOf(), d3d.depth_stencil_view.Get());
+    d3d.context->OMSetRenderTargets(1, &rtv, dsv);
 
     // Clear render targets
 
     const float clearColor[] = { 0.0f, 0.0f, 0.0f, 1.0f };
-    d3d.context->ClearRenderTargetView(d3d.backbuffer_view.Get(), clearColor);
-    d3d.context->ClearDepthStencilView(d3d.depth_stencil_view.Get(), D3D11_CLEAR_DEPTH, 1.0f, 0);
+    d3d.context->ClearRenderTargetView(rtv, clearColor);
+    d3d.context->ClearDepthStencilView(dsv, D3D11_CLEAR_DEPTH, 1.0f, 0);
 
     // Set per-frame constant buffer
 
@@ -745,8 +1221,8 @@ static void gfx_d3d11_start_frame(void) {
         d3d.per_frame_cb_data.noise_frame = 0;
     }
 
-    d3d.per_frame_cb_data.noise_scale_x = (float) d3d.current_width;
-    d3d.per_frame_cb_data.noise_scale_y = (float) d3d.current_height;
+    d3d.per_frame_cb_data.noise_scale_x = (float) d3d.render_width;
+    d3d.per_frame_cb_data.noise_scale_y = (float) d3d.render_height;
 
     D3D11_MAPPED_SUBRESOURCE ms;
     ZeroMemory(&ms, sizeof(D3D11_MAPPED_SUBRESOURCE));
@@ -763,6 +1239,12 @@ static const char* gfx_d3d11_get_name(void) {
 }
 
 static void gfx_d3d11_finish_render(void) {
+    // normally end_internal_res() already ran mid-frame (right before DJUI
+    // rendering); this is the fallback for when DJUI is disabled and the
+    // G_NATIVERES_DJUI opcode never fires
+    if (d3d.internal_res_active) {
+        gfx_d3d11_end_internal_res();
+    }
 }
 
 } // namespace
@@ -791,6 +1273,9 @@ struct GfxRenderingAPI gfx_direct3d11_api = {
     gfx_d3d11_end_frame,
     gfx_d3d11_finish_render,
     gfx_d3d11_get_name,
+    nullptr, // shutdown: not implemented
+    gfx_d3d11_get_supports_internal_res,
+    gfx_d3d11_end_internal_res,
 };
 
 #endif

--- a/src/pc/gfx/gfx_dummy.c
+++ b/src/pc/gfx/gfx_dummy.c
@@ -119,6 +119,10 @@ static bool gfx_dummy_wm_has_focus(void) {
     return true;
 }
 
+static void gfx_dummy_wm_get_display_size(uint32_t *width, uint32_t *height) {
+    gfx_dummy_wm_get_dimensions(width, height);
+}
+
 static bool gfx_dummy_renderer_z_is_from_0_to_1(void) {
     return false;
 }
@@ -199,6 +203,10 @@ static const char* gfx_dummy_renderer_get_name(void) {
 static void gfx_dummy_renderer_shutdown(void) {
 }
 
+static bool gfx_dummy_renderer_get_supports_internal_res(void) {
+    return false;
+}
+
 struct GfxWindowManagerAPI gfx_dummy_wm_api = {
     gfx_dummy_wm_init,
     gfx_dummy_wm_set_keyboard_callbacks,
@@ -220,7 +228,8 @@ struct GfxWindowManagerAPI gfx_dummy_wm_api = {
     gfx_dummy_wm_get_max_msaa,
     gfx_dummy_wm_set_window_title,
     gfx_dummy_wm_reset_window_title,
-    gfx_dummy_wm_has_focus
+    gfx_dummy_wm_has_focus,
+    gfx_dummy_wm_get_display_size
 };
 
 struct GfxRenderingAPI gfx_dummy_renderer_api = {
@@ -247,5 +256,6 @@ struct GfxRenderingAPI gfx_dummy_renderer_api = {
     gfx_dummy_renderer_end_frame,
     gfx_dummy_renderer_finish_render,
     gfx_dummy_renderer_get_name,
-    gfx_dummy_renderer_shutdown
+    gfx_dummy_renderer_shutdown,
+    gfx_dummy_renderer_get_supports_internal_res
 };

--- a/src/pc/gfx/gfx_dummy.c
+++ b/src/pc/gfx/gfx_dummy.c
@@ -207,6 +207,9 @@ static bool gfx_dummy_renderer_get_supports_internal_res(void) {
     return false;
 }
 
+static void gfx_dummy_renderer_end_internal_res(void) {
+}
+
 struct GfxWindowManagerAPI gfx_dummy_wm_api = {
     gfx_dummy_wm_init,
     gfx_dummy_wm_set_keyboard_callbacks,
@@ -257,5 +260,6 @@ struct GfxRenderingAPI gfx_dummy_renderer_api = {
     gfx_dummy_renderer_finish_render,
     gfx_dummy_renderer_get_name,
     gfx_dummy_renderer_shutdown,
-    gfx_dummy_renderer_get_supports_internal_res
+    gfx_dummy_renderer_get_supports_internal_res,
+    gfx_dummy_renderer_end_internal_res
 };

--- a/src/pc/gfx/gfx_dxgi.cpp
+++ b/src/pc/gfx/gfx_dxgi.cpp
@@ -629,6 +629,11 @@ static bool gfx_dxgi_has_focus(void) {
     return GetFocus() == dxgi.h_wnd;
 }
 
+static void gfx_dxgi_get_display_size(uint32_t *width, uint32_t *height) {
+    if (width) *width = GetSystemMetrics(SM_CXSCREEN);
+    if (height) *height = GetSystemMetrics(SM_CYSCREEN);
+}
+
 extern "C" HWND gfx_dxgi_get_h_wnd(void) {
     return dxgi.h_wnd;
 }
@@ -716,7 +721,8 @@ struct GfxWindowManagerAPI gfx_dxgi = {
     gfx_dxgi_get_max_msaa,
     gfx_dxgi_set_window_title,
     gfx_dxgi_reset_window_title,
-    gfx_dxgi_has_focus
+    gfx_dxgi_has_focus,
+    gfx_dxgi_get_display_size
 };
 
 #endif

--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -794,6 +794,357 @@ static void gfx_opengl_draw_triangles(float buf_vbo[], size_t buf_vbo_len, size_
     glDrawArrays(GL_TRIANGLES, 0, 3 * buf_vbo_num_tris);
 }
 
+  ///////////////////////////////
+ // internal resolution (FBO) //
+///////////////////////////////
+
+static bool internal_res_supported = false;
+static bool internal_res_active = false;
+static GLuint internal_res_fbo = 0;
+static GLuint internal_res_tex = 0;
+static GLuint internal_res_depth = 0;
+static uint32_t internal_res_width = 0;
+static uint32_t internal_res_height = 0;
+
+static bool gfx_opengl_get_supports_internal_res(void) {
+    return internal_res_supported;
+}
+
+#ifndef USE_GLES
+
+// approximates the look of an N64 hooked up over composite video:
+// luma stays mostly sharp while chroma bleeds horizontally
+static GLuint composite_prg = 0;
+static GLint composite_texel_loc = -1;
+static bool composite_prg_failed = false;
+
+static const char* composite_vs_src =
+    "#version 120\n"
+    "void main() {\n"
+    "    gl_Position = gl_Vertex;\n"
+    "    gl_TexCoord[0] = gl_MultiTexCoord0;\n"
+    "}\n";
+
+static const char* composite_fs_src =
+    "#version 120\n"
+    "uniform sampler2D uTex;\n"
+    "uniform vec2 uTexelSize;\n"
+    "vec3 to_yiq(vec3 c) {\n"
+    "    return vec3(dot(c, vec3(0.299,  0.587,  0.114)),\n"
+    "                dot(c, vec3(0.596, -0.274, -0.322)),\n"
+    "                dot(c, vec3(0.211, -0.523,  0.312)));\n"
+    "}\n"
+    "vec3 to_rgb(vec3 c) {\n"
+    "    return vec3(c.x + 0.956 * c.y + 0.621 * c.z,\n"
+    "                c.x - 0.272 * c.y - 0.647 * c.z,\n"
+    "                c.x - 1.106 * c.y + 1.703 * c.z);\n"
+    "}\n"
+    "void main() {\n"
+    "    vec2 uv = gl_TexCoord[0].xy;\n"
+    "    float dx = uTexelSize.x;\n"
+    "    vec3 t0 = to_yiq(texture2D(uTex, uv - vec2(3.0 * dx, 0.0)).rgb);\n"
+    "    vec3 t1 = to_yiq(texture2D(uTex, uv - vec2(2.0 * dx, 0.0)).rgb);\n"
+    "    vec3 t2 = to_yiq(texture2D(uTex, uv - vec2(1.0 * dx, 0.0)).rgb);\n"
+    "    vec3 t3 = to_yiq(texture2D(uTex, uv).rgb);\n"
+    "    vec3 t4 = to_yiq(texture2D(uTex, uv + vec2(1.0 * dx, 0.0)).rgb);\n"
+    "    vec3 t5 = to_yiq(texture2D(uTex, uv + vec2(2.0 * dx, 0.0)).rgb);\n"
+    "    vec3 t6 = to_yiq(texture2D(uTex, uv + vec2(3.0 * dx, 0.0)).rgb);\n"
+    "    float luma = t2.x * 0.15 + t3.x * 0.70 + t4.x * 0.15;\n"
+    "    vec2 chroma = t0.yz * 0.07 + t1.yz * 0.12 + t2.yz * 0.19 + t3.yz * 0.24\n"
+    "                + t4.yz * 0.19 + t5.yz * 0.12 + t6.yz * 0.07;\n"
+    "    gl_FragColor = vec4(to_rgb(vec3(luma, chroma)), 1.0);\n"
+    "}\n";
+
+// like the composite filter, but mimics a recorded capture of real N64 video
+// output: sharper luma with edge ringing, line jitter and analog noise
+static GLuint capture_prg = 0;
+static GLint capture_texel_loc = -1;
+static GLint capture_frame_loc = -1;
+static bool capture_prg_failed = false;
+
+static const char* capture_fs_src =
+    "#version 120\n"
+    "uniform sampler2D uTex;\n"
+    "uniform vec2 uTexelSize;\n"
+    "uniform float uFrame;\n"
+    "vec3 to_yiq(vec3 c) {\n"
+    "    return vec3(dot(c, vec3(0.299,  0.587,  0.114)),\n"
+    "                dot(c, vec3(0.596, -0.274, -0.322)),\n"
+    "                dot(c, vec3(0.211, -0.523,  0.312)));\n"
+    "}\n"
+    "vec3 to_rgb(vec3 c) {\n"
+    "    return vec3(c.x + 0.956 * c.y + 0.621 * c.z,\n"
+    "                c.x - 0.272 * c.y - 0.647 * c.z,\n"
+    "                c.x - 1.106 * c.y + 1.703 * c.z);\n"
+    "}\n"
+    "float hash(vec2 p) {\n"
+    "    return fract(sin(dot(p, vec2(12.9898, 78.233)) + uFrame * 0.317) * 43758.5453);\n"
+    "}\n"
+    "void main() {\n"
+    "    vec2 uv = gl_TexCoord[0].xy;\n"
+    "    float dx = uTexelSize.x;\n"
+    "    float dy = uTexelSize.y;\n"
+    "    // capture line index at half-texel granularity (480 lines for 240p)\n"
+    "    float subline = floor(uv.y / (0.5 * dy));\n"
+    "    // vertical: snap to source lines with a narrow transition (hard TV lines)\n"
+    "    float ty = uv.y / dy;\n"
+    "    float baseLine = floor(ty - 0.5) + 0.5;\n"
+    "    float fracY = clamp((ty - baseLine - 0.5) * 4.0 + 0.5, 0.0, 1.0);\n"
+    "    float sy = (baseLine + fracY) * dy;\n"
+    "    // alternate capture lines are shifted, like a deinterlaced recording\n"
+    "    float sx = uv.x + ((mod(subline, 2.0) < 1.0) ? -0.25 : 0.25) * dx;\n"
+    "    // luma samples snap toward texel centers so the upscale smears less\n"
+    "    float tx = sx / dx;\n"
+    "    float baseCol = floor(tx - 0.5) + 0.5;\n"
+    "    float fracX = clamp((tx - baseCol - 0.5) * 2.5 + 0.5, 0.0, 1.0);\n"
+    "    vec2 luv = vec2((baseCol + fracX) * dx, sy);\n"
+    "    vec2 suv = vec2(sx, sy);\n"
+    "    // luma: mostly sharp, with ringing halos around edges\n"
+    "    float l0 = to_yiq(texture2D(uTex, luv - vec2(2.0 * dx, 0.0)).rgb).x;\n"
+    "    float l1 = to_yiq(texture2D(uTex, luv - vec2(1.0 * dx, 0.0)).rgb).x;\n"
+    "    float l2 = to_yiq(texture2D(uTex, luv).rgb).x;\n"
+    "    float l3 = to_yiq(texture2D(uTex, luv + vec2(1.0 * dx, 0.0)).rgb).x;\n"
+    "    float l4 = to_yiq(texture2D(uTex, luv + vec2(2.0 * dx, 0.0)).rgb).x;\n"
+    "    float luma = -0.20 * l0 + 0.10 * l1 + 1.20 * l2 + 0.10 * l3 - 0.20 * l4;\n"
+    "    // chroma: wide horizontal bleed, delayed to the right\n"
+    "    vec2 cuv = suv - vec2(1.0 * dx, 0.0);\n"
+    "    vec2 c0 = to_yiq(texture2D(uTex, cuv - vec2(4.5 * dx, 0.0)).rgb).yz;\n"
+    "    vec2 c1 = to_yiq(texture2D(uTex, cuv - vec2(3.0 * dx, 0.0)).rgb).yz;\n"
+    "    vec2 c2 = to_yiq(texture2D(uTex, cuv - vec2(1.5 * dx, 0.0)).rgb).yz;\n"
+    "    vec2 c3 = to_yiq(texture2D(uTex, cuv).rgb).yz;\n"
+    "    vec2 c4 = to_yiq(texture2D(uTex, cuv + vec2(1.5 * dx, 0.0)).rgb).yz;\n"
+    "    vec2 c5 = to_yiq(texture2D(uTex, cuv + vec2(3.0 * dx, 0.0)).rgb).yz;\n"
+    "    vec2 c6 = to_yiq(texture2D(uTex, cuv + vec2(4.5 * dx, 0.0)).rgb).yz;\n"
+    "    vec2 chroma = c0 * 0.07 + c1 * 0.12 + c2 * 0.19 + c3 * 0.24\n"
+    "                + c4 * 0.19 + c5 * 0.12 + c6 * 0.07;\n"
+    "    // composite captures look saturated: boost the chroma\n"
+    "    chroma *= 1.25;\n"
+    "    // animated analog grain, at half-texel granularity\n"
+    "    float n = hash(floor(vec2(uv.x / (0.5 * dx), subline)));\n"
+    "    luma += (n - 0.5) * 0.06;\n"
+    "    gl_FragColor = vec4(to_rgb(vec3(luma, chroma)), 1.0);\n"
+    "}\n";
+
+static GLuint gfx_opengl_composite_compile(GLenum type, const char* src) {
+    GLuint shader = glCreateShader(type);
+    glShaderSource(shader, 1, &src, NULL);
+    glCompileShader(shader);
+    GLint ok = GL_FALSE;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+    if (!ok) {
+        char log[1024] = { 0 };
+        glGetShaderInfoLog(shader, sizeof(log), NULL, log);
+        fprintf(stderr, "upscale filter shader failed to compile:\n%s\n", log);
+        glDeleteShader(shader);
+        return 0;
+    }
+    return shader;
+}
+
+static GLuint gfx_opengl_filter_prg_link(const char* fs_src) {
+    GLuint vs = gfx_opengl_composite_compile(GL_VERTEX_SHADER, composite_vs_src);
+    GLuint fs = gfx_opengl_composite_compile(GL_FRAGMENT_SHADER, fs_src);
+    if (vs == 0 || fs == 0) {
+        if (vs) { glDeleteShader(vs); }
+        if (fs) { glDeleteShader(fs); }
+        return 0;
+    }
+
+    GLuint prg = glCreateProgram();
+    glAttachShader(prg, vs);
+    glAttachShader(prg, fs);
+    glLinkProgram(prg);
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+
+    GLint ok = GL_FALSE;
+    glGetProgramiv(prg, GL_LINK_STATUS, &ok);
+    if (!ok) {
+        glDeleteProgram(prg);
+        return 0;
+    }
+
+    glUseProgram(prg);
+    glUniform1i(glGetUniformLocation(prg, "uTex"), 0);
+    glUseProgram(0);
+    return prg;
+}
+
+static void gfx_opengl_composite_prg_ensure(void) {
+    if (composite_prg != 0 || composite_prg_failed) { return; }
+    composite_prg = gfx_opengl_filter_prg_link(composite_fs_src);
+    if (composite_prg == 0) {
+        composite_prg_failed = true;
+        return;
+    }
+    composite_texel_loc = glGetUniformLocation(composite_prg, "uTexelSize");
+}
+
+static void gfx_opengl_capture_prg_ensure(void) {
+    if (capture_prg != 0 || capture_prg_failed) { return; }
+    capture_prg = gfx_opengl_filter_prg_link(capture_fs_src);
+    if (capture_prg == 0) {
+        capture_prg_failed = true;
+        return;
+    }
+    capture_texel_loc = glGetUniformLocation(capture_prg, "uTexelSize");
+    capture_frame_loc = glGetUniformLocation(capture_prg, "uFrame");
+}
+
+// rebind the game's texture state after we messed with texture unit 0
+static void gfx_opengl_restore_texture_state(void) {
+    glActiveTexture(GL_TEXTURE0);
+    if (opengl_tex[0]) { glBindTexture(GL_TEXTURE_2D, opengl_tex[0]->gltex); }
+    glActiveTexture(GL_TEXTURE0 + opengl_curtex);
+}
+
+static void gfx_opengl_internal_res_destroy(void) {
+    if (internal_res_fbo != 0) {
+        glDeleteFramebuffers(1, &internal_res_fbo);
+        glDeleteTextures(1, &internal_res_tex);
+        glDeleteRenderbuffers(1, &internal_res_depth);
+        internal_res_fbo = 0;
+        internal_res_tex = 0;
+        internal_res_depth = 0;
+        internal_res_width = 0;
+        internal_res_height = 0;
+    }
+}
+
+static bool gfx_opengl_internal_res_ensure(uint32_t width, uint32_t height) {
+    if (internal_res_fbo != 0 && internal_res_width == width && internal_res_height == height) {
+        return true;
+    }
+
+    if (internal_res_fbo == 0) {
+        glGenFramebuffers(1, &internal_res_fbo);
+        glGenTextures(1, &internal_res_tex);
+        glGenRenderbuffers(1, &internal_res_depth);
+    }
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, internal_res_tex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glBindRenderbuffer(GL_RENDERBUFFER, internal_res_depth);
+    glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
+    glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, internal_res_fbo);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, internal_res_tex, 0);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, internal_res_depth);
+
+    bool complete = (glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
+    if (!complete) {
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        gfx_opengl_internal_res_destroy();
+        internal_res_supported = false;
+    } else {
+        internal_res_width = width;
+        internal_res_height = height;
+    }
+
+    gfx_opengl_restore_texture_state();
+    return complete;
+}
+
+// draw the internal render target to the window as a fullscreen quad,
+// leaving the window framebuffer bound for any further rendering
+static void gfx_opengl_internal_res_blit(void) {
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+    GLint prevViewport[4];
+    glGetIntegerv(GL_VIEWPORT, prevViewport);
+    GLboolean prevScissorTest = glIsEnabled(GL_SCISSOR_TEST);
+    GLboolean prevDepthTest = glIsEnabled(GL_DEPTH_TEST);
+    GLboolean prevBlend = glIsEnabled(GL_BLEND);
+    GLboolean prevDepthMask;
+    glGetBooleanv(GL_DEPTH_WRITEMASK, &prevDepthMask);
+
+    glViewport(0, 0, gfx_window_width, gfx_window_height);
+    glDisable(GL_SCISSOR_TEST);
+    glDisable(GL_DEPTH_TEST);
+    glDepthMask(GL_FALSE);
+    glDisable(GL_BLEND);
+
+    if (configInternalResFilter == 2) {
+        gfx_opengl_composite_prg_ensure();
+    } else if (configInternalResFilter == 3) {
+        gfx_opengl_capture_prg_ensure();
+    }
+    if (configInternalResFilter == 2 && composite_prg != 0) {
+        glUseProgram(composite_prg);
+        glUniform2f(composite_texel_loc, 1.0f / (f32)internal_res_width, 1.0f / (f32)internal_res_height);
+    } else if (configInternalResFilter == 3 && capture_prg != 0) {
+        glUseProgram(capture_prg);
+        glUniform2f(capture_texel_loc, 1.0f / (f32)internal_res_width, 1.0f / (f32)internal_res_height);
+        glUniform1f(capture_frame_loc, (f32)(frame_count % 1024u));
+    } else {
+        glUseProgram(0);
+    }
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, internal_res_tex);
+    GLint filter = (configInternalResFilter >= 1) ? GL_LINEAR : GL_NEAREST;
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
+    glEnable(GL_TEXTURE_2D);
+
+    glMatrixMode(GL_PROJECTION);
+    glPushMatrix();
+    glLoadIdentity();
+    glMatrixMode(GL_MODELVIEW);
+    glPushMatrix();
+    glLoadIdentity();
+
+    glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+    glBegin(GL_TRIANGLE_STRIP);
+    glTexCoord2f(0.0f, 0.0f); glVertex2f(-1.0f, -1.0f);
+    glTexCoord2f(1.0f, 0.0f); glVertex2f( 1.0f, -1.0f);
+    glTexCoord2f(0.0f, 1.0f); glVertex2f(-1.0f,  1.0f);
+    glTexCoord2f(1.0f, 1.0f); glVertex2f( 1.0f,  1.0f);
+    glEnd();
+
+    glMatrixMode(GL_MODELVIEW);
+    glPopMatrix();
+    glMatrixMode(GL_PROJECTION);
+    glPopMatrix();
+    glDisable(GL_TEXTURE_2D);
+
+    // clear the window depth buffer so any further native res rendering starts fresh
+    glDepthMask(GL_TRUE);
+    glClear(GL_DEPTH_BUFFER_BIT);
+
+    // restore the state the game rendering expects
+    if (opengl_prg != NULL) { glUseProgram(opengl_prg->opengl_program_id); }
+    gfx_opengl_restore_texture_state();
+    glViewport(prevViewport[0], prevViewport[1], prevViewport[2], prevViewport[3]);
+    if (prevScissorTest) { glEnable(GL_SCISSOR_TEST); }
+    if (prevDepthTest) { glEnable(GL_DEPTH_TEST); }
+    if (prevBlend) { glEnable(GL_BLEND); }
+    glDepthMask(prevDepthMask);
+}
+
+#else // USE_GLES
+
+static void gfx_opengl_internal_res_destroy(void) { }
+static bool gfx_opengl_internal_res_ensure(uint32_t width, uint32_t height) { (void)width; (void)height; return false; }
+static void gfx_opengl_internal_res_blit(void) { }
+
+#endif
+
+// called mid-frame when DJUI rendering begins: upscale the internal render
+// target to the window and let everything after render at native resolution
+static void gfx_opengl_end_internal_res(void) {
+    if (!internal_res_active) { return; }
+    internal_res_active = false;
+    gfx_opengl_internal_res_blit();
+}
+
 static inline bool gl_version_is_supported(int major, int minor, bool is_es) {
     if (is_es) {
         return major >= 2;
@@ -844,6 +1195,11 @@ static void gfx_opengl_init(void) {
         glBindVertexArray(opengl_vao);
     }
 
+#ifndef USE_GLES
+    // the internal resolution render target needs framebuffer objects (GL 3.0+)
+    internal_res_supported = (vmajor >= 3 && !is_es);
+#endif
+
     glDepthFunc(GL_LEQUAL);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 }
@@ -865,6 +1221,14 @@ static void gfx_opengl_on_resize(void) {
 static void gfx_opengl_start_frame(void) {
     frame_count++;
 
+    internal_res_active = internal_res_supported && gfx_internal_res_height > 0
+        && gfx_opengl_internal_res_ensure(gfx_internal_res_width, gfx_internal_res_height);
+#ifndef USE_GLES
+    if (internal_res_supported) {
+        glBindFramebuffer(GL_FRAMEBUFFER, internal_res_active ? internal_res_fbo : 0);
+    }
+#endif
+
     glDisable(GL_SCISSOR_TEST);
     glDepthMask(GL_TRUE); // Must be set to clear Z-buffer
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
@@ -876,6 +1240,9 @@ static void gfx_opengl_end_frame(void) {
 }
 
 static void gfx_opengl_finish_render(void) {
+    if (internal_res_active) {
+        gfx_opengl_internal_res_blit();
+    }
 }
 
 static const char* gfx_opengl_get_name(void) {
@@ -883,6 +1250,8 @@ static const char* gfx_opengl_get_name(void) {
 }
 
 static void gfx_opengl_shutdown(void) {
+    gfx_opengl_internal_res_destroy();
+    internal_res_active = false;
 }
 
 struct GfxRenderingAPI gfx_opengl_api = {
@@ -909,5 +1278,7 @@ struct GfxRenderingAPI gfx_opengl_api = {
     gfx_opengl_end_frame,
     gfx_opengl_finish_render,
     gfx_opengl_get_name,
-    gfx_opengl_shutdown
+    gfx_opengl_shutdown,
+    gfx_opengl_get_supports_internal_res,
+    gfx_opengl_end_internal_res
 };

--- a/src/pc/gfx/gfx_pc.c
+++ b/src/pc/gfx/gfx_pc.c
@@ -110,6 +110,14 @@ static struct RenderingState {
 
 struct GfxDimensions gfx_current_dimensions = { 0 };
 
+// actual window size; gfx_current_dimensions holds the internal render size
+uint32_t gfx_window_width = 0;
+uint32_t gfx_window_height = 0;
+
+// internal render target size, 0 when rendering directly at window resolution
+uint32_t gfx_internal_res_width = 0;
+uint32_t gfx_internal_res_height = 0;
+
 static bool dropped_frame = false;
 
 static float buf_vbo[MAX_BUFFERED * (26 * 3)] = { 0.0f }; // 3 vertices in a triangle and 26 floats per vtx
@@ -2063,6 +2071,44 @@ void gfx_get_dimensions(uint32_t *width, uint32_t *height) {
     }
 }
 
+static void gfx_update_dimensions(uint32_t width, uint32_t height) {
+    gfx_current_dimensions.width = width;
+    gfx_current_dimensions.height = height;
+    if (configForce4By3
+        && ((4.0f / 3.0f) * gfx_current_dimensions.height) < gfx_current_dimensions.width) {
+        gfx_current_dimensions.x_adjust_4by3 = (gfx_current_dimensions.width - (4.0f / 3.0f) * gfx_current_dimensions.height) / 2;
+        gfx_current_dimensions.width = (4.0f / 3.0f) * gfx_current_dimensions.height;
+    } else { gfx_current_dimensions.x_adjust_4by3 = 0; }
+    gfx_current_dimensions.aspect_ratio = ((float)gfx_current_dimensions.width / (float)gfx_current_dimensions.height);
+    gfx_current_dimensions.x_adjust_ratio = (4.0f / 3.0f) / gfx_current_dimensions.aspect_ratio;
+}
+
+static bool sRenderingNativeRes = false;
+
+// called via G_NATIVERES_DJUI: upscales the internal render target to the window
+// and switches all further rendering (DJUI) to native window resolution
+static void gfx_native_res_begin(void) {
+    if (gfx_internal_res_height == 0 || sRenderingNativeRes) { return; }
+    sRenderingNativeRes = true;
+
+    gfx_flush();
+    if (gfx_rapi->end_internal_res) { gfx_rapi->end_internal_res(); }
+
+    f32 scale = (f32)gfx_window_height / (f32)gfx_internal_res_height;
+    gfx_update_dimensions(gfx_window_width, gfx_window_height);
+
+    // rescale the cached viewport/scissor from internal to window space
+    rdp.viewport.x      = (uint16_t)(rdp.viewport.x      * scale + 0.5f);
+    rdp.viewport.y      = (uint16_t)(rdp.viewport.y      * scale + 0.5f);
+    rdp.viewport.width  = (uint16_t)(rdp.viewport.width  * scale + 0.5f);
+    rdp.viewport.height = (uint16_t)(rdp.viewport.height * scale + 0.5f);
+    rdp.scissor.x       = (uint16_t)(rdp.scissor.x       * scale + 0.5f);
+    rdp.scissor.y       = (uint16_t)(rdp.scissor.y       * scale + 0.5f);
+    rdp.scissor.width   = (uint16_t)(rdp.scissor.width   * scale + 0.5f);
+    rdp.scissor.height  = (uint16_t)(rdp.scissor.height  * scale + 0.5f);
+    rdp.viewport_or_scissor_changed = true;
+}
+
 void gfx_init(struct GfxWindowManagerAPI *wapi, struct GfxRenderingAPI *rapi, const char *window_title) {
     gfx_wapi = wapi;
     gfx_rapi = rapi;
@@ -2085,18 +2131,30 @@ void gfx_start_frame(void) {
         rdp.loaded_texture[1].size_bytes = 0;
     }
     gfx_wapi->handle_events();
-    gfx_wapi->get_dimensions(&gfx_current_dimensions.width, &gfx_current_dimensions.height);
-    if (gfx_current_dimensions.height == 0) {
+    gfx_wapi->get_dimensions(&gfx_window_width, &gfx_window_height);
+    if (gfx_window_height == 0) {
         // Avoid division by zero
-        gfx_current_dimensions.height = 1;
+        gfx_window_height = 1;
     }
-    if (configForce4By3
-        && ((4.0f / 3.0f) * gfx_current_dimensions.height) < gfx_current_dimensions.width) {
-        gfx_current_dimensions.x_adjust_4by3 = (gfx_current_dimensions.width - (4.0f / 3.0f) * gfx_current_dimensions.height) / 2;
-        gfx_current_dimensions.width = (4.0f / 3.0f) * gfx_current_dimensions.height;
-    } else { gfx_current_dimensions.x_adjust_4by3 = 0; }
-    gfx_current_dimensions.aspect_ratio = ((float)gfx_current_dimensions.width / (float)gfx_current_dimensions.height);
-    gfx_current_dimensions.x_adjust_ratio = (4.0f / 3.0f) / gfx_current_dimensions.aspect_ratio;
+    sRenderingNativeRes = false;
+    gfx_internal_res_width = 0;
+    gfx_internal_res_height = 0;
+    if (gfx_rapi->get_supports_internal_res && gfx_rapi->get_supports_internal_res()) {
+        if (configInternalResHeight >= SCREEN_HEIGHT && configInternalResHeight != gfx_window_height) {
+            gfx_internal_res_height = configInternalResHeight;
+            gfx_internal_res_width = (uint32_t)((f32)gfx_window_width * ((f32)configInternalResHeight / (f32)gfx_window_height) + 0.5f);
+            if (gfx_internal_res_width == 0) { gfx_internal_res_width = 1; }
+        } else if (configInternalResFilter >= 2) {
+            // the composite filters need the offscreen render target even at native resolution
+            gfx_internal_res_width = gfx_window_width;
+            gfx_internal_res_height = gfx_window_height;
+        }
+    }
+    if (gfx_internal_res_height > 0) {
+        gfx_update_dimensions(gfx_internal_res_width, gfx_internal_res_height);
+    } else {
+        gfx_update_dimensions(gfx_window_width, gfx_window_height);
+    }
 }
 
 void gfx_run(Gfx *commands) {
@@ -2479,6 +2537,9 @@ void OPTIMIZE_O3 ext_gfx_run_dl(Gfx* cmd) {
             break;
         case G_TEXADDR_DJUI:
             sOnlyTextureChangeOnAddrChange = !(C0(0, 24) & 0x01);
+            break;
+        case G_NATIVERES_DJUI:
+            gfx_native_res_begin();
             break;
         case G_EXECUTE_DJUI:
             djui_gfx_dp_execute_djui(cmd->words.w1);

--- a/src/pc/gfx/gfx_pc.h
+++ b/src/pc/gfx/gfx_pc.h
@@ -19,6 +19,14 @@ enum ShaderFlag {
 struct GfxRenderingAPI;
 struct GfxWindowManagerAPI;
 
+// all of these are defined in the C translation unit gfx_pc.c; the extern "C"
+// block (below) must cover them too, not just the function declarations, so
+// that C++ backends (e.g. gfx_direct3d11.cpp) reference them with the same
+// (unmangled) linkage they were actually defined with
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern Vec3f gLightingDir;
 extern Color gLightingColor[2];
 extern Color gVertexColor;
@@ -31,10 +39,6 @@ extern int gShaderFlags[SHADER_FLAG_MAX];
 extern f32 gDefaultShaderFlagValues[SHADER_FLAG_MAX];
 extern f32 gShaderFlagValues[SHADER_FLAG_MAX];
 extern bool gShaderFlagsEnabled;
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 // actual window size; gfx_current_dimensions holds the internal render size
 extern uint32_t gfx_window_width;

--- a/src/pc/gfx/gfx_pc.h
+++ b/src/pc/gfx/gfx_pc.h
@@ -36,6 +36,14 @@ extern bool gShaderFlagsEnabled;
 extern "C" {
 #endif
 
+// actual window size; gfx_current_dimensions holds the internal render size
+extern uint32_t gfx_window_width;
+extern uint32_t gfx_window_height;
+
+// internal render target size, 0 when rendering directly at window resolution
+extern uint32_t gfx_internal_res_width;
+extern uint32_t gfx_internal_res_height;
+
 void gfx_init(struct GfxWindowManagerAPI *wapi, struct GfxRenderingAPI *rapi, const char *window_title);
 struct GfxRenderingAPI *gfx_get_current_rendering_api(void);
 void gfx_start_frame(void);

--- a/src/pc/gfx/gfx_rendering_api.h
+++ b/src/pc/gfx/gfx_rendering_api.h
@@ -33,6 +33,8 @@ struct GfxRenderingAPI {
     void (*finish_render)(void);
     const char* (*get_name)(void);
     void (*shutdown)(void);
+    bool (*get_supports_internal_res)(void);
+    void (*end_internal_res)(void);
 };
 
 #endif

--- a/src/pc/gfx/gfx_sdl.c
+++ b/src/pc/gfx/gfx_sdl.c
@@ -200,6 +200,18 @@ static void gfx_sdl_get_dimensions(uint32_t *width, uint32_t *height) {
     if (height) *height = h;
 }
 
+static void gfx_sdl_get_display_size(uint32_t *width, uint32_t *height) {
+    SDL_DisplayMode mode;
+    int displayIndex = wnd ? SDL_GetWindowDisplayIndex(wnd) : 0;
+    if (displayIndex < 0) { displayIndex = 0; }
+    if (SDL_GetDesktopDisplayMode(displayIndex, &mode) == 0) {
+        if (width) *width = mode.w;
+        if (height) *height = mode.h;
+    } else {
+        gfx_sdl_get_dimensions(width, height);
+    }
+}
+
 static void gfx_sdl_onkeydown(int scancode) {
     const Uint8 *state = SDL_GetKeyboardState(NULL);
 
@@ -391,5 +403,6 @@ struct GfxWindowManagerAPI gfx_sdl = {
     gfx_sdl_get_max_msaa,
     gfx_sdl_set_window_title,
     gfx_sdl_reset_window_title,
-    gfx_sdl_has_focus
+    gfx_sdl_has_focus,
+    gfx_sdl_get_display_size
 };

--- a/src/pc/gfx/gfx_window_manager_api.h
+++ b/src/pc/gfx/gfx_window_manager_api.h
@@ -34,6 +34,7 @@ struct GfxWindowManagerAPI {
     void (*set_window_title)(const char* title);
     void (*reset_window_title)(void);
     bool (*has_focus)(void);
+    void (*get_display_size)(uint32_t *width, uint32_t *height);
 };
 
 #endif

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -408,6 +408,7 @@ void produce_one_dummy_frame(void (*callback)(), u8 clearColorR, u8 clearColorG,
     gfx_start_frame();
     config_gfx_pool();
     init_render_image();
+    djui_gfx_native_res_begin();
     create_dl_ortho_matrix();
     djui_gfx_displaylist_begin();
 


### PR DESCRIPTION
- Adds a new "Internal Resolution" setting (Options → Display) that renders the 3D game at a lower resolution than the window — from common resolutions down to the N64's native 240p — while menus/HUD (DJUI) always stay sharp at native window resolution.
- Adds two new upscale filters alongside Nearest/Linear: "Composite" (soft video-cable look) and "Composite Capture" (mimics a recorded capture of real N64 composite output — scanlines, edge ringing, chroma bleed, analog grain).
- Implemented for both OpenGL and DirectX 11.
- Translated the new menu strings into all supported languages.
<img width="2558" height="1439" alt="2026-07-19_15-43" src="https://github.com/user-attachments/assets/34de013c-55ce-4e94-9ea2-8e9708fd4974" />
<img width="1025" height="1316" alt="Menu" src="https://github.com/user-attachments/assets/23abc972-b33e-4280-ad0a-10cf112b25bc" />
<img width="2559" height="1439" alt="Unbenannt" src="https://github.com/user-attachments/assets/d041b76b-8791-4c09-81e7-a19dbcbeb05f" />

The D3D11 implementation is not tested yet