### PR TITLE
fix random_u16 and friends

### DIFF
--- a/autogen/exposed_lists.py
+++ b/autogen/exposed_lists.py
@@ -222,7 +222,7 @@ functions_whitelist = { "__name__": "functions_whitelist",
     "src/engine/level_script.h":            [ "area_create_warp_node" ],
     "src/game/ingame_menu.h":               [ "set_min_dialog_width", "set_dialog_override_pos", "reset_dialog_override_pos", "set_dialog_override_color", "reset_dialog_override_color", "set_menu_mode", "create_dialog_box", "create_dialog_box_with_var", "create_dialog_inverted_box", "create_dialog_box_with_response", "reset_dialog_render_state", "set_dialog_box_state", "handle_special_dialog_text" ],
     "src/audio/seqplayer.h":                [ "sequence_player_set_tempo", "sequence_player_set_tempo_acc", "sequence_player_set_transposition", "sequence_player_get_tempo", "sequence_player_get_tempo_acc", "sequence_player_get_transposition", "sequence_player_get_volume", "sequence_player_get_fade_volume", "sequence_player_get_mute_volume_scale" ],
-    "src/pc/network/sync_object.h":         [ "sync_object_is_initialized", "sync_object_is_owned_locally", "sync_object_get_object" ],
+    "src/pc/network/sync_object.h":         [ "sync_object_is_initialized", "sync_object_is_owned_locally", "sync_object_get_object", "sync_object_get_random_seed"],
     "src/audio/load.h":                     [ "set_sound_bank_override" ],
     "src/pc/djui/djui_gfx.h":               [ "djui_gfx_get_scale" ],
 }

--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -3912,7 +3912,7 @@ end
 --- It decides by checking where you entered the command, and will output to that source directly.<br>
 --- <br>
 --- It should be used in any function that is ran from `hook_chat_command` or `hook_console_command`.<br>
---- If ran independently of any of these hooks, it decides on where to output by checking if the chat box is open. If so, log there, otherwise, log to the console and terminal
+--- If ran independently of any hook, it decides on where to output by checking if the chat box is open. If so, log there, otherwise, log to the console and terminal
 function command_message_create(message, level)
     -- ...
 end
@@ -11994,6 +11994,12 @@ function get_network_area_timer()
 end
 
 --- @return integer
+--- Gets the current area's networked random seed
+function get_network_area_random_seed()
+    -- ...
+end
+
+--- @return integer
 --- Gets the area update counter incremented when objects are updated
 function get_area_update_counter()
     -- ...
@@ -13458,6 +13464,13 @@ end
 --- @return boolean
 --- Checks if a surface has force
 function surface_has_force(surfaceType)
+    -- ...
+end
+
+--- @param syncId integer
+--- @return integer
+--- Retrieves the random seed of a sync object from its sync ID
+function sync_object_get_random_seed(syncId)
     -- ...
 end
 

--- a/docs/lua/functions-7.md
+++ b/docs/lua/functions-7.md
@@ -1952,6 +1952,27 @@ Gets the current area's networked timer
 
 <br />
 
+## [get_network_area_random_seed](#get_network_area_random_seed)
+
+### Description
+Gets the current area's networked random seed
+
+### Lua Example
+`local integerValue = get_network_area_random_seed()`
+
+### Parameters
+- None
+
+### Returns
+- `integer`
+
+### C Prototype
+`u32 get_network_area_random_seed(void);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ## [get_area_update_counter](#get_area_update_counter)
 
 ### Description
@@ -6836,6 +6857,29 @@ Checks if a surface has force
 
 <br />
 
+
+## [sync_object_get_random_seed](#sync_object_get_random_seed)
+
+### Description
+Retrieves the random seed of a sync object from its sync ID
+
+### Lua Example
+`local integerValue = sync_object_get_random_seed(syncId)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| syncId | `integer` |
+
+### Returns
+- `integer`
+
+### C Prototype
+`u16 sync_object_get_random_seed(u32 syncId);`
+
+[:arrow_up_small:](#)
+
+<br />
 
 ## [sync_object_get_object](#sync_object_get_object)
 

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -2033,6 +2033,7 @@
 
 - smlua_misc_utils.h
    - [get_network_area_timer](functions-7.md#get_network_area_timer)
+   - [get_network_area_random_seed](functions-7.md#get_network_area_random_seed)
    - [get_area_update_counter](functions-7.md#get_area_update_counter)
    - [get_temp_s32_pointer](functions-7.md#get_temp_s32_pointer)
    - [deref_s32_pointer](functions-7.md#deref_s32_pointer)
@@ -2275,6 +2276,7 @@
 <br />
 
 - sync_object.h
+   - [sync_object_get_random_seed](functions-7.md#sync_object_get_random_seed)
    - [sync_object_get_object](functions-7.md#sync_object_get_object)
    - [sync_object_is_initialized](functions-7.md#sync_object_is_initialized)
    - [sync_object_is_owned_locally](functions-7.md#sync_object_is_owned_locally)

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -32352,6 +32352,20 @@ int smlua_func_get_network_area_timer(lua_State* L) {
     return 1;
 }
 
+int smlua_func_get_network_area_random_seed(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 0) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "get_network_area_random_seed", 0, top);
+        return 0;
+    }
+
+    lua_pushinteger(L, get_network_area_random_seed());
+
+    return 1;
+}
+
 int smlua_func_get_area_update_counter(lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -36073,6 +36087,23 @@ int smlua_func_surface_has_force(lua_State* L) {
  // sync_object.h //
 ///////////////////
 
+int smlua_func_sync_object_get_random_seed(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 1) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "sync_object_get_random_seed", 1, top);
+        return 0;
+    }
+
+    u32 syncId = smlua_to_integer(L, 1);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "sync_object_get_random_seed"); return 0; }
+
+    lua_pushinteger(L, sync_object_get_random_seed(syncId));
+
+    return 1;
+}
+
 int smlua_func_sync_object_get_object(lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -38036,6 +38067,7 @@ void smlua_bind_functions_autogen(void) {
 
     // smlua_misc_utils.h
     smlua_bind_function(L, "get_network_area_timer", smlua_func_get_network_area_timer);
+    smlua_bind_function(L, "get_network_area_random_seed", smlua_func_get_network_area_random_seed);
     smlua_bind_function(L, "get_area_update_counter", smlua_func_get_area_update_counter);
     smlua_bind_function(L, "get_temp_s32_pointer", smlua_func_get_temp_s32_pointer);
     smlua_bind_function(L, "deref_s32_pointer", smlua_func_deref_s32_pointer);
@@ -38264,6 +38296,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "surface_has_force", smlua_func_surface_has_force);
 
     // sync_object.h
+    smlua_bind_function(L, "sync_object_get_random_seed", smlua_func_sync_object_get_random_seed);
     smlua_bind_function(L, "sync_object_get_object", smlua_func_sync_object_get_object);
     smlua_bind_function(L, "sync_object_is_initialized", smlua_func_sync_object_is_initialized);
     smlua_bind_function(L, "sync_object_is_owned_locally", smlua_func_sync_object_is_owned_locally);

--- a/src/pc/lua/utils/smlua_misc_utils.c
+++ b/src/pc/lua/utils/smlua_misc_utils.c
@@ -48,6 +48,10 @@ u32 get_network_area_timer(void) {
     return gNetworkAreaTimer;
 }
 
+u32 get_network_area_random_seed(void) {
+    return gNetworkAreaRandomSeed;
+}
+
 u16 get_area_update_counter(void) {
     return gAreaUpdateCounter;
 }

--- a/src/pc/lua/utils/smlua_misc_utils.h
+++ b/src/pc/lua/utils/smlua_misc_utils.h
@@ -54,6 +54,8 @@ struct DateTime {
 
 /* |description|Gets the current area's networked timer|descriptionEnd| */
 u32 get_network_area_timer(void);
+/* |description|Gets the current area's networked random seed|descriptionEnd| */
+u32 get_network_area_random_seed(void);
 /* |description|Gets the area update counter incremented when objects are updated|descriptionEnd| */
 u16 get_area_update_counter(void);
 

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -63,6 +63,7 @@ bool gNetworkAreaLoaded = false;
 bool gNetworkAreaSyncing = true;
 u32 gNetworkAreaTimerClock = 0;
 u32 gNetworkAreaTimer = 0;
+u32 gNetworkAreaRandomSeed = 0;
 void* gNetworkServerAddr = NULL;
 bool gNetworkSentJoin = false;
 u16 gNetworkRequestLocationTimer = 0;
@@ -201,6 +202,7 @@ void network_on_init_area(void) {
     gNetworkAreaSyncing = true;
     gNetworkAreaTimer = 0;
     gNetworkAreaTimerClock = clock_elapsed_ticks();
+    gNetworkAreaRandomSeed = rand();
 }
 
 void network_on_loaded_area(void) {

--- a/src/pc/network/network.h
+++ b/src/pc/network/network.h
@@ -108,6 +108,7 @@ extern bool gNetworkAreaLoaded;
 extern bool gNetworkAreaSyncing;
 extern u32 gNetworkAreaTimer;
 extern u32 gNetworkAreaTimerClock;
+extern u32 gNetworkAreaRandomSeed;
 extern void* gNetworkServerAddr;
 extern struct ServerSettings gServerSettings;
 extern struct NametagsSettings gNametagsSettings;

--- a/src/pc/network/packets/packet_area.c
+++ b/src/pc/network/packets/packet_area.c
@@ -49,6 +49,7 @@ void network_send_area(struct NetworkPlayer* toNp) {
 
         // area variables
         packet_write(&p, &gNetworkAreaTimer, sizeof(u32));
+        packet_write(&p, &gNetworkAreaRandomSeed, sizeof(u32));
         packet_write(&p, gEnvironmentLevels, sizeof(s32));
 
         // level control timer
@@ -151,6 +152,7 @@ void network_receive_area(struct Packet* p) {
 
     // read area variables
     packet_read(p, &gNetworkAreaTimer, sizeof(u32));
+    packet_read(p, &gNetworkAreaRandomSeed, sizeof(u32));
     gNetworkAreaTimerClock = clock_elapsed_ticks() - gNetworkAreaTimer;
     packet_read(p, gEnvironmentLevels, sizeof(s32));
     if (gCurrLevelNum == LEVEL_WDW && gEnvironmentRegions != NULL && gEnvironmentRegionsLength > 6) {

--- a/src/pc/network/sync_object.c
+++ b/src/pc/network/sync_object.c
@@ -125,6 +125,19 @@ void sync_object_forget_last_reliable_packet(u32 syncId) {
     so->lastReliablePacket.error = true;
 }
 
+// MurmurHash3 finalizer
+u16 sync_object_get_random_seed(u32 syncId) {
+    u32 h = syncId ^ gNetworkAreaRandomSeed;
+
+    h ^= h >> 16;
+    h *= 0x85ebca6b;
+    h ^= h >> 13;
+    h *= 0xc2b2ae35;
+    h ^= h >> 16;
+
+    return (u16)h;
+}
+
 struct SyncObject* sync_object_init(struct Object *o, float maxSyncDistance) {
     if (!o) { return NULL; }
 
@@ -178,10 +191,12 @@ struct SyncObject* sync_object_init(struct Object *o, float maxSyncDistance) {
     so->on_forget = NULL;
     so->syncDeathEvent = true;
     so->ctx = 0;
+
     if (!hadSyncId) {
         so->extendedModelId = 0xFFFF;
+        so->randomSeed = sync_object_get_random_seed(o->oSyncID);
     }
-    so->randomSeed = (u16)(o->oSyncID * 7951);
+
     memset(so->extraFields, 0, sizeof(so->extraFields));
     memset(so->extraFieldsSizeBytes, 0, sizeof(so->extraFieldsSizeBytes));
 
@@ -386,6 +401,7 @@ bool sync_object_set_id(struct Object* o) {
     if (!so) {
         so = calloc(1, sizeof(struct SyncObject));
         so->extendedModelId = 0xFFFF;
+        so->randomSeed = sync_object_get_random_seed(syncId);
         hmap_put(sSoMap, syncId, so);
         //LOG_INFO("Allocated sync object @ %u, size %ld", syncId, (long int)hmap_len(sSoMap));
     } else if (so->o != o) {

--- a/src/pc/network/sync_object.h
+++ b/src/pc/network/sync_object.h
@@ -62,6 +62,8 @@ void sync_object_init_field_with_size(struct Object *o, void *field, u8 sizeByte
 struct SyncObject* sync_object_get(u32 syncId);
 struct SyncObject* sync_object_get_first(void);
 struct SyncObject* sync_object_get_next(void);
+/* |description|Retrieves the random seed of a sync object from its sync ID|descriptionEnd| */
+u16 sync_object_get_random_seed(u32 syncId);
 /* |description|Retrieves an object from a sync ID|descriptionEnd| */
 struct Object* sync_object_get_object(u32 syncId);
 /* |description|Checks if a sync object is initialized using a `syncId`|descriptionEnd| */


### PR DESCRIPTION
This fixes a few issues with `random_u16` and friends:

1 - New sync objects get calloc'd in `sync_object_set_id`, so their random seed is 0 until `network_init_object` is called, so any random calls made before that point always returned 57460 (random u16 returns 57460 when the seed is 0)
2 - random seed generation wasn't good enough, sequential sync ids would produce similar looking values
3 - random functions would always return the same sequence of values for a given sync id

Random seeds are now generated using a MurmurHash finalizer (https://en.wikipedia.org/wiki/MurmurHash) to scramble the seed. There's also a new gNetworkAreaRandomSeed, which works similarly to gNetworkAreaTimer and is rerolled every time the area loads, it's used to make sync object random seeds non deterministic (while still matching across clients)