### PR TITLE
Security: disallow loading binary chunks

### DIFF
--- a/src/pc/lua/smlua.c
+++ b/src/pc/lua/smlua.c
@@ -90,9 +90,6 @@ void smlua_exec_str(const char* str) {
     lua_pop(L, lua_gettop(L));
 }
 
-#define LUA_BOM_11 0x0000000000005678llu
-#define LUA_BOM_19 0x4077280000000000llu
-
 static bool smlua_check_binary_header(struct ModFile *file) {
     FILE *f = f_open_r(file->cachedPath);
     if (f) {
@@ -107,88 +104,8 @@ static bool smlua_check_binary_header(struct ModFile *file) {
         }
 
         // Check signature
-        if (strcmp(signature, LUA_SIGNATURE) != 0) {
-            f_close(f);
-            return true; // Not a binary lua
-        }
-
-        // Read version number
-        u8 version;
-        if (f_read(&version, 1, 1, f) != 1) {
-            LOG_LUA("Failed to load lua script '%s': File too short.", file->cachedPath);
-            f_close(f);
-            f_delete(f);
-            return false;
-        }
-
-        // Check version number
-        u8 expectedVersion = strtoul(LUA_VERSION_MAJOR LUA_VERSION_MINOR, NULL, 16);
-        if (version != expectedVersion) {
-            LOG_LUA("Failed to load lua script '%s': Lua versions don't match (%X, expected %X).", file->cachedPath, version, expectedVersion);
-            f_close(f);
-            f_delete(f);
-            return false;
-        }
-
-        // Read the rest of the header
-        u8 header[28];
-        if (f_read(header, 1, 28, f) != 28) {
-            LOG_LUA("Failed to load lua script '%s': File too short.", file->cachedPath);
-            f_close(f);
-            f_delete(f);
-            return false;
-        }
-
-        // The following errors are silent (they're due to non-matching endianness/bitness and shouldn't prevent the rest of the mod from loading)
-
-        // Check endianness
-        u64 bom11 = *((u64 *) (header + 12));
-        u64 bom19 = *((u64 *) (header + 20));
-        if (bom11 != LUA_BOM_11) {
-            LOG_ERROR("Failed to load lua script '%s': BOM at offset 0x11 don't match (%016llX, expected %016llX).", file->cachedPath, bom11, LUA_BOM_11);
-            f_close(f);
-            f_delete(f);
-            return false;
-        }
-        if (bom19 != LUA_BOM_19) {
-            LOG_ERROR("Failed to load lua script '%s': BOM at offset 0x19 don't match (%016llX, expected %016llX).", file->cachedPath, bom19, LUA_BOM_19);
-            f_close(f);
-            f_delete(f);
-            return false;
-        }
-
-        // Check sizes
-        u8 sizeOfCInteger = header[7];
-        u8 sizeOfCPointer = header[8];
-        u8 sizeOfCFloat = header[9];
-        u8 sizeOfLuaInteger = header[10];
-        u8 sizeOfLuaNumber = header[11];
-        if (sizeOfCInteger != sizeof(int)) {
-            LOG_ERROR("Failed to load lua script '%s': sizes of C Integer don't match (%d, expected %llu).", file->cachedPath, sizeOfCInteger, (long long unsigned)sizeof(int));
-            f_close(f);
-            f_delete(f);
-            return false;
-        }
-        if (sizeOfCPointer != sizeof(void *)) { // 4 for 32-bit architectures, 8 for 64-bit
-            LOG_ERROR("Failed to load lua script '%s': sizes of C Pointer don't match (%d, expected %llu).", file->cachedPath, sizeOfCPointer, (long long unsigned)sizeof(void *));
-            f_close(f);
-            f_delete(f);
-            return false;
-        }
-        if (sizeOfCFloat != sizeof(float)) {
-            LOG_ERROR("Failed to load lua script '%s': sizes of C Float don't match (%d, expected %llu).", file->cachedPath, sizeOfCFloat, (long long unsigned)sizeof(float));
-            f_close(f);
-            f_delete(f);
-            return false;
-        }
-        if (sizeOfLuaInteger != sizeof(LUA_INTEGER)) {
-            LOG_ERROR("Failed to load lua script '%s': sizes of Lua Integer don't match (%d, expected %llu).", file->cachedPath, sizeOfLuaInteger, (long long unsigned)sizeof(LUA_INTEGER));
-            f_close(f);
-            f_delete(f);
-            return false;
-        }
-        if (sizeOfLuaNumber != sizeof(LUA_NUMBER)) {
-            LOG_ERROR("Failed to load lua script '%s': sizes of Lua Number don't match (%d, expected %llu).", file->cachedPath, sizeOfLuaNumber, (long long unsigned)sizeof(LUA_NUMBER));
+        if (strcmp(signature, LUA_SIGNATURE) == 0) {
+            LOG_LUA("Failed to load lua script '%s': Disallowed binary chunk.", file->cachedPath);
             f_close(f);
             f_delete(f);
             return false;
@@ -363,7 +280,7 @@ void smlua_init(void) {
         for (int j = 0; j < mod->fileCount; j++) {
             struct ModFile* file = &mod->files[j];
             // skip loading non-lua files
-            if (!(path_ends_with(file->relativePath, ".lua") || path_ends_with(file->relativePath, ".luac"))) {
+            if (!path_ends_with(file->relativePath, ".lua")) {
                 continue;
             }
 

--- a/src/pc/lua/smlua_require.c
+++ b/src/pc/lua/smlua_require.c
@@ -83,9 +83,7 @@ static struct ModFile* smlua_find_mod_file(const char* moduleName) {
     resolve_relative_path(basePath, moduleName, absolutePath);
 
     char luaName[SYS_MAX_PATH] = "";
-    char luacName[SYS_MAX_PATH] = "";
     snprintf(luaName, SYS_MAX_PATH, "%s.lua", absolutePath);
-    snprintf(luacName, SYS_MAX_PATH, "%s.luac", absolutePath);
 
     // since mods' relativePaths are relative to the mod's root, we can do a direct comparison
     for (int i = 0; i < gLuaActiveMod->fileCount; i++) {
@@ -97,14 +95,14 @@ static struct ModFile* smlua_find_mod_file(const char* moduleName) {
         }
 
         // only consider lua files
-        if (!path_ends_with(file->relativePath, ".lua") && !path_ends_with(file->relativePath, ".luac")) {
+        if (!path_ends_with(file->relativePath, ".lua")) {
             continue;
         }
 
         // check for match, normalizing to system separators
         strcpy(normalizedRelative, file->relativePath);
         normalize_path(normalizedRelative);
-        if (!strcmp(normalizedRelative, luaName) || !strcmp(normalizedRelative, luacName)) {
+        if (!strcmp(normalizedRelative, luaName)) {
             return file;
         }
     }

--- a/src/pc/lua/smlua_require.c
+++ b/src/pc/lua/smlua_require.c
@@ -100,7 +100,8 @@ static struct ModFile* smlua_find_mod_file(const char* moduleName) {
         }
 
         // check for match, normalizing to system separators
-        strcpy(normalizedRelative, file->relativePath);
+        strncpy(normalizedRelative, file->relativePath, SYS_MAX_PATH - 1);
+        normalizedRelative[SYS_MAX_PATH - 1] = 0;
         normalize_path(normalizedRelative);
         if (!strcmp(normalizedRelative, luaName)) {
             return file;

--- a/src/pc/mods/mod.c
+++ b/src/pc/mods/mod.c
@@ -24,7 +24,7 @@ size_t mod_get_lua_size(struct Mod* mod) {
 
     for (int i = 0; i < mod->fileCount; i++) {
         struct ModFile* file = &mod->files[i];
-        if (!(path_ends_with(file->relativePath, ".lua") || path_ends_with(file->relativePath, ".luac"))) { continue; }
+        if (!path_ends_with(file->relativePath, ".lua")) { continue; }
         size += file->size;
     }
 
@@ -363,7 +363,7 @@ static bool mod_load_files(struct Mod* mod, char* fullPath) {
 
     // deal with mod directory
     {
-        const char* fileTypes[] = { ".lua", ".luac", NULL };
+        const char* fileTypes[] = { ".lua", NULL };
         if (!mod_load_files_dir(mod, fullPath, "", fileTypes, true)) { return false; }
     }
 

--- a/src/pc/mods/mod_import.c
+++ b/src/pc/mods/mod_import.c
@@ -124,7 +124,7 @@ static bool mod_import_zip(char* path, bool* isLua, bool* isDynos) {
             return false;
         }
 
-        if (path_ends_with(file_stat.m_filename, ".lua") || path_ends_with(file_stat.m_filename, ".luac")) {
+        if (path_ends_with(file_stat.m_filename, ".lua")) {
             path_get_folder(file_stat.m_filename, luaPath);
             *isLua = true;
             break;
@@ -263,7 +263,7 @@ bool mod_import_file(char* path) {
         return false;
     }
 
-    if (path_ends_with(path, ".lua") || path_ends_with(path, ".luac")) {
+    if (path_ends_with(path, ".lua")) {
         isLua = true;
         ret = mod_import_lua(path);
     } else if (path_ends_with(path, ".ini")) {


### PR DESCRIPTION
There is a serious flaw in current security which needs to be remedied ASAP, loading external binary chunks is allowed, with obvious security implications.

From the [manual](https://www.lua.org/manual/5.4/manual.html)
> It is safe to load malformed binary chunks; load signals an appropriate error. However, Lua does not check the consistency of the code inside binary chunks; running maliciously crafted bytecode can crash the interpreter. 

Now let's get ahead of the CVE and fix this before it happens. There is no reason why binary chunks should have ever been allowed as there is no performance win to using binary chunks and the chunks are in fact often larger than the text version which increases the data transferred over the wire for no reason.

Note that any possible POC or such should *not* be posted here before this fix is pushed to clients and the exploit is patched. Or I mean it isn't really an exploit or CVE per-se because even the manual tells you not to do this, leave the door wide open.
