### PR TITLE
add DynOS delayed warps + warp to act selector

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -11999,7 +11999,7 @@ end
 --- @param aGotoActSelect? boolean
 --- @return boolean
 --- Warps to `aWarpId` of `aArea` in `aLevel` during `aAct` with a transition
-function warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect)
+function warp_with_transition(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect)
     -- ...
 end
 

--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -11987,6 +11987,19 @@ function warp_to_castle(aLevel)
     -- ...
 end
 
+--- @param aLevel integer
+--- @param aArea integer
+--- @param aAct integer
+--- @param aTransType integer
+--- @param aDelay integer
+--- @param aColor Color
+--- @param aWarpId? integer
+--- @return boolean
+--- Warps to `aWarpId` of `aArea` in `aLevel` during `aAct` with a transition
+function warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId)
+    -- ...
+end
+
 --- @return integer
 --- Gets the current area's networked timer
 function get_network_area_timer()

--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -11946,18 +11946,20 @@ end
 --- @param aArea integer
 --- @param aAct integer
 --- @param aWarpId integer
+--- @param aGotoActSelect? boolean
 --- @return boolean
 --- Warps to `aWarpId` of `aArea` in `aLevel` during `aAct`
-function warp_to_warpnode(aLevel, aArea, aAct, aWarpId)
+function warp_to_warpnode(aLevel, aArea, aAct, aWarpId, aGotoActSelect)
     -- ...
 end
 
 --- @param aLevel integer
 --- @param aArea integer
 --- @param aAct integer
+--- @param aGotoActSelect? boolean
 --- @return boolean
 --- Warps to `aArea` of `aLevel` in `aAct`
-function warp_to_level(aLevel, aArea, aAct)
+function warp_to_level(aLevel, aArea, aAct, aGotoActSelect)
     -- ...
 end
 
@@ -11994,9 +11996,10 @@ end
 --- @param aDelay integer
 --- @param aColor Color
 --- @param aWarpId? integer
+--- @param aGotoActSelect? boolean
 --- @return boolean
 --- Warps to `aWarpId` of `aArea` in `aLevel` during `aAct` with a transition
-function warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId)
+function warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect)
     -- ...
 end
 

--- a/data/dynos.c.h
+++ b/data/dynos.c.h
@@ -18,13 +18,13 @@ void  dynos_gfx_swap_animations(void *ptr);
 
 // -- warps -- //
 LevelScript* dynos_get_level_script(const char* scriptEntryName);
-bool dynos_warp_to_warpnode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId);
-bool dynos_warp_to_level(s32 aLevel, s32 aArea, s32 aAct);
+bool dynos_warp_to_warpnode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId, bool aGotoActSelect);
+bool dynos_warp_to_level(s32 aLevel, s32 aArea, s32 aAct, bool aGotoActSelect);
 bool dynos_warp_restart_level(void);
 bool dynos_warp_to_start_level(void);
 bool dynos_warp_exit_level(s32 aDelay);
 bool dynos_warp_to_castle(s32 aLevel);
-bool dynos_warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId);
+bool dynos_warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect);
 
 // -- dynos packs -- //
 void dynos_gfx_init(void);

--- a/data/dynos.c.h
+++ b/data/dynos.c.h
@@ -24,6 +24,7 @@ bool dynos_warp_restart_level(void);
 bool dynos_warp_to_start_level(void);
 bool dynos_warp_exit_level(s32 aDelay);
 bool dynos_warp_to_castle(s32 aLevel);
+bool dynos_warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId);
 
 // -- dynos packs -- //
 void dynos_gfx_init(void);

--- a/data/dynos.c.h
+++ b/data/dynos.c.h
@@ -24,7 +24,7 @@ bool dynos_warp_restart_level(void);
 bool dynos_warp_to_start_level(void);
 bool dynos_warp_exit_level(s32 aDelay);
 bool dynos_warp_to_castle(s32 aLevel);
-bool dynos_warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect);
+bool dynos_warp_with_transition(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect);
 
 // -- dynos packs -- //
 void dynos_gfx_init(void);

--- a/data/dynos.cpp.h
+++ b/data/dynos.cpp.h
@@ -864,6 +864,7 @@ bool DynOS_Warp_ToLevel(s32 aLevel, s32 aArea, s32 aAct);
 bool DynOS_Warp_RestartLevel();
 bool DynOS_Warp_ExitLevel(s32 aDelay);
 bool DynOS_Warp_ToCastle(s32 aLevel);
+bool DynOS_Warp_Delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId);
 
 //
 // Builtin

--- a/data/dynos.cpp.h
+++ b/data/dynos.cpp.h
@@ -859,12 +859,12 @@ void DynOS_Level_ParseScript(const void *aScript, s32 (*aPreprocessFunction)(u8,
 //
 
 void *DynOS_Warp_Update(void *aCmd, bool aIsLevelInitDone);
-bool DynOS_Warp_ToWarpNode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId);
-bool DynOS_Warp_ToLevel(s32 aLevel, s32 aArea, s32 aAct);
+bool DynOS_Warp_ToWarpNode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId, bool aGotoActSelect);
+bool DynOS_Warp_ToLevel(s32 aLevel, s32 aArea, s32 aAct, bool aGotoActSelect);
 bool DynOS_Warp_RestartLevel();
 bool DynOS_Warp_ExitLevel(s32 aDelay);
 bool DynOS_Warp_ToCastle(s32 aLevel);
-bool DynOS_Warp_Delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId);
+bool DynOS_Warp_Delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect);
 
 //
 // Builtin

--- a/data/dynos.cpp.h
+++ b/data/dynos.cpp.h
@@ -864,7 +864,7 @@ bool DynOS_Warp_ToLevel(s32 aLevel, s32 aArea, s32 aAct, bool aGotoActSelect);
 bool DynOS_Warp_RestartLevel();
 bool DynOS_Warp_ExitLevel(s32 aDelay);
 bool DynOS_Warp_ToCastle(s32 aLevel);
-bool DynOS_Warp_Delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect);
+bool DynOS_Warp_WithTransition(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect);
 
 //
 // Builtin

--- a/data/dynos_c.cpp
+++ b/data/dynos_c.cpp
@@ -31,12 +31,12 @@ LevelScript* dynos_get_level_script(const char* scriptEntryName) {
     return DynOS_Lvl_GetScript(scriptEntryName);
 }
 
-bool dynos_warp_to_warpnode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId) {
-    return DynOS_Warp_ToWarpNode(aLevel, aArea, aAct, aWarpId);
+bool dynos_warp_to_warpnode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId, bool aGotoActSelect) {
+    return DynOS_Warp_ToWarpNode(aLevel, aArea, aAct, aWarpId, aGotoActSelect);
 }
 
-bool dynos_warp_to_level(s32 aLevel, s32 aArea, s32 aAct) {
-    return DynOS_Warp_ToLevel(aLevel, aArea, aAct);
+bool dynos_warp_to_level(s32 aLevel, s32 aArea, s32 aAct, bool aGotoActSelect) {
+    return DynOS_Warp_ToLevel(aLevel, aArea, aAct, aGotoActSelect);
 }
 
 bool dynos_warp_to_start_level(void) {
@@ -60,8 +60,8 @@ bool dynos_warp_to_castle(s32 aLevel) {
     return DynOS_Warp_ToCastle(aLevel);
 }
 
-bool dynos_warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, OPTIONAL s32 aWarpId) {
-    return DynOS_Warp_Delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId);
+bool dynos_warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect) {
+    return DynOS_Warp_Delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect);
 }
 
 // -- dynos packs -- //

--- a/data/dynos_c.cpp
+++ b/data/dynos_c.cpp
@@ -60,6 +60,10 @@ bool dynos_warp_to_castle(s32 aLevel) {
     return DynOS_Warp_ToCastle(aLevel);
 }
 
+bool dynos_warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, OPTIONAL s32 aWarpId) {
+    return DynOS_Warp_Delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId);
+}
+
 // -- dynos packs -- //
 
 void dynos_gfx_init(void) {

--- a/data/dynos_c.cpp
+++ b/data/dynos_c.cpp
@@ -60,8 +60,8 @@ bool dynos_warp_to_castle(s32 aLevel) {
     return DynOS_Warp_ToCastle(aLevel);
 }
 
-bool dynos_warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect) {
-    return DynOS_Warp_Delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect);
+bool dynos_warp_with_transition(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect) {
+    return DynOS_Warp_WithTransition(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect);
 }
 
 // -- dynos packs -- //

--- a/data/dynos_warps.cpp
+++ b/data/dynos_warps.cpp
@@ -28,6 +28,8 @@ static s32 sDynosWarpLevelNum = -1;
 static s32 sDynosWarpAreaNum  = -1;
 static s32 sDynosWarpActNum   = -1;
 static s32 sDynosWarpNodeNum  = -1;
+static bool sDynosWarpIsDelayed = false;
+
 static s32 sDynosExitLevelNum = -1;
 static s32 sDynosExitAreaNum  = -1;
 
@@ -134,6 +136,28 @@ bool DynOS_Warp_ToCastle(s32 aLevel) {
     set_play_mode(0);
     sDynosExitLevelNum = aLevel;
     sDynosExitAreaNum = 1;
+    return true;
+}
+
+bool DynOS_Warp_Delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId) {   
+    if (aWarpId != 0) {
+        if (!DynOS_Level_GetWarp(aLevel, aArea, aWarpId)) {
+            return false;
+        }
+
+        sDynosWarpNodeNum = aWarpId;
+    } else if (!DynOS_Level_GetWarpEntry(aLevel, aArea)) {
+        return false;
+    }
+
+    sDynosWarpLevelNum = aLevel;
+    sDynosWarpAreaNum = aArea;
+    sDynosWarpActNum = aAct;
+    sDynosWarpIsDelayed = true;
+
+    play_transition(aTransType, aDelay, aColor[0], aColor[1], aColor[2]);
+    fadeout_music((3 * aDelay / 2) * 8 - 2);
+
     return true;
 }
 
@@ -426,6 +450,16 @@ static void *DynOS_Warp_UpdateExit(void *aCmd, bool aIsLevelInitDone) {
     return NULL;
 }
 
+void *DynOS_Warp_UpdateDelayed(void *aCmd, bool aIsLevelInitDone) {
+    // Wait for the warp transition to end
+    if (DynOS_IsTransitionActive()) {
+        return NULL;
+    }
+
+    sDynosWarpIsDelayed = false;
+    return DynOS_Warp_UpdateWarp(aCmd, aIsLevelInitDone);
+}
+
 void *DynOS_Warp_Update(void *aCmd, bool aIsLevelInitDone) {
 
     // Level Exit
@@ -438,6 +472,11 @@ void *DynOS_Warp_Update(void *aCmd, bool aIsLevelInitDone) {
     if (sDynosWarpLevelNum != -1 &&
         sDynosWarpAreaNum != -1 &&
         sDynosWarpActNum != -1) {
+        
+        if (sDynosWarpIsDelayed) {
+            return DynOS_Warp_UpdateDelayed(aCmd, aIsLevelInitDone);
+        }
+
         return DynOS_Warp_UpdateWarp(aCmd, aIsLevelInitDone);
     }
 

--- a/data/dynos_warps.cpp
+++ b/data/dynos_warps.cpp
@@ -183,9 +183,12 @@ bool DynOS_Warp_Delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDe
         }
 
         sDynosWarpNodeNum = aWarpId;
-    } else if (!DynOS_Level_GetWarpEntry(aLevel, aArea)) {
+    } else {
         sDynosWarpNodeNum = -1;
-        return false;
+        
+        if (!DynOS_Level_GetWarpEntry(aLevel, aArea)) {      
+            return false;
+        }
     }
 
     sDynosWarpLevelNum = aLevel;

--- a/data/dynos_warps.cpp
+++ b/data/dynos_warps.cpp
@@ -13,6 +13,8 @@ extern "C" {
 #include "game/object_list_processor.h"
 #include "pc/network/packets/packet.h"
 #include "pc/lua/smlua_hooks.h"
+#include "level_commands.h"
+
 extern s32 gWdwWaterLevelSet;
 extern u8 sSpawnTypeFromWarpBhv[];
 extern void set_mario_initial_action(struct MarioState *, u32, u32);
@@ -33,11 +35,42 @@ static bool sDynosWarpIsDelayed = false;
 static s32 sDynosExitLevelNum = -1;
 static s32 sDynosExitAreaNum  = -1;
 
+static bool sDynosWarpGotoActSelect = false;
+static bool sDynosActSelectStarted  = false;
+static bool sDynosActSelectDone     = false;
+
+static void DynOS_Warp_BeforeActSelect(UNUSED s32 arg, UNUSED s32 unused) {
+    gCurrActNum = 0;
+    gCurrActStarNum = 0;
+    gHudDisplay.flags = HUD_DISPLAY_NONE;
+}
+
+static s32 DynOS_Warp_AfterActSelect(UNUSED s32 arg, UNUSED s32 unused) {
+    // Set by the actor selector 
+    // GET_OR_SET(/*op*/ OP_SET, /*var*/ VAR_CURR_ACT_NUM),
+    sDynosWarpActNum = gCurrActNum;
+    sDynosActSelectDone = true;
+
+    return 0;
+}
+
+extern const LevelScript level_main_menu_entry_2[];
+
+static const LevelScript sDynosActSelectScript[] = {
+    CALL(/*arg*/ 0, /*func*/ DynOS_Warp_BeforeActSelect),
+    GET_OR_SET(/*op*/ OP_GET, /*var*/ VAR_CURR_LEVEL_NUM),
+    EXECUTE(/*seg*/ 0, /*script*/ NULL, /*scriptEnd*/ NULL, /*entry*/ level_main_menu_entry_2),
+    CALL(/*arg*/ 0, /*func*/ DynOS_Warp_AfterActSelect),
+    // Put something after CALL so we don't return out of bounds
+    // this will be overriden by update warp
+    JUMP(sDynosActSelectScript),
+};
+
 //
 // Specific Warp Node
 //
 
-bool DynOS_Warp_ToWarpNode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId) {
+bool DynOS_Warp_ToWarpNode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId, bool aGotoActSelect) {
     if (!DynOS_Level_GetWarp(aLevel, aArea, aWarpId)) {
         return false;
     }
@@ -51,6 +84,8 @@ bool DynOS_Warp_ToWarpNode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId) {
     sDynosWarpAreaNum  = aArea;
     sDynosWarpActNum   = aAct;
     sDynosWarpNodeNum  = aWarpId;
+    sDynosWarpGotoActSelect = aGotoActSelect;
+
     return true;
 }
 
@@ -58,7 +93,7 @@ bool DynOS_Warp_ToWarpNode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId) {
 // Level Entry
 //
 
-bool DynOS_Warp_ToLevel(s32 aLevel, s32 aArea, s32 aAct) {
+bool DynOS_Warp_ToLevel(s32 aLevel, s32 aArea, s32 aAct, bool aGotoActSelect) {
     if (!DynOS_Level_GetWarpEntry(aLevel, aArea)) {
         return false;
     }
@@ -69,11 +104,13 @@ bool DynOS_Warp_ToLevel(s32 aLevel, s32 aArea, s32 aAct) {
     sDynosWarpLevelNum = aLevel;
     sDynosWarpAreaNum  = aArea;
     sDynosWarpActNum   = aAct;
+    sDynosWarpGotoActSelect = aGotoActSelect;
+
     return true;
 }
 
 bool DynOS_Warp_RestartLevel() {
-    return DynOS_Warp_ToLevel(gCurrLevelNum, 1, gCurrActNum);
+    return DynOS_Warp_ToLevel(gCurrLevelNum, 1, gCurrActNum, false);
 }
 
 //
@@ -139,7 +176,7 @@ bool DynOS_Warp_ToCastle(s32 aLevel) {
     return true;
 }
 
-bool DynOS_Warp_Delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId) {   
+bool DynOS_Warp_Delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect) {   
     if (aWarpId != 0) {
         if (!DynOS_Level_GetWarp(aLevel, aArea, aWarpId)) {
             return false;
@@ -154,6 +191,7 @@ bool DynOS_Warp_Delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDe
     sDynosWarpAreaNum = aArea;
     sDynosWarpActNum = aAct;
     sDynosWarpIsDelayed = true;
+    sDynosWarpGotoActSelect = aGotoActSelect;
 
     play_transition(aTransType, aDelay, aColor[0], aColor[1], aColor[2]);
     fadeout_music((3 * aDelay / 2) * 8 - 2);
@@ -173,26 +211,45 @@ static void *DynOS_Warp_UpdateWarp(void *aCmd, bool aIsLevelInitDone) {
     // Phase 1 - Clear the previous level and set up the new level
     if (sDynosWarpTargetArea == -1) {
 
-        // Close the pause menu if it was open
-        level_set_transition(0, NULL);
-        gDialogBoxState = 0;
-        gMenuMode = -1;
+        // One time teardown for this warp. Runs once before we either
+        // (a) show the act selector
+        // (b) jump straight to the target level
+        // and once again after the act selector finishes, before (b)
+        if (!sDynosActSelectStarted || sDynosActSelectDone) {
+            level_set_transition(0, NULL);
+            gDialogBoxState = 0;
+            gMenuMode = -1;
 
-        // Cancel out every music/sound/sequence
-        for (u16 seqid = 0; seqid != SEQ_COUNT; ++seqid) {
-            stop_background_music(seqid);
+            // Cancel out every music/sound/sequence
+            for (u16 seqid = 0; seqid != SEQ_COUNT; ++seqid) {
+                stop_background_music(seqid);
+            }
+            play_shell_music();
+            stop_shell_music();
+            stop_cap_music();
+            stop_secondary_music(0);
+            fadeout_music(0);
+            fadeout_level_music(0);
+
+            // Free everything from the current level
+            clear_objects();
+            clear_area_graph_nodes();
+            clear_areas();
+
+            gCurrLevelNum = sDynosWarpLevelNum;
+            gCurrCourseNum = DynOS_Level_GetCourse(gCurrLevelNum);
+            gSavedCourseNum = gCurrCourseNum;
         }
-        play_shell_music();
-        stop_shell_music();
-        stop_cap_music();
-        stop_secondary_music(0);
-        fadeout_music(0);
-        fadeout_level_music(0);
 
-        // Free everything from the current level
-        clear_objects();
-        clear_area_graph_nodes();
-        clear_areas();
+        if (sDynosWarpGotoActSelect && !sDynosActSelectDone) {
+            // Let the act selector run
+            if (sDynosActSelectStarted) {
+                return NULL;
+            }
+            
+            sDynosActSelectStarted = true;
+            return (void *)sDynosActSelectScript;
+        }
 
         // Reset Mario's state
         gMarioState->healCounter = 0;
@@ -204,9 +261,6 @@ static void *DynOS_Warp_UpdateWarp(void *aCmd, bool aIsLevelInitDone) {
         gHudDisplay.coins = 0;
 
         // Set up new level values
-        gCurrLevelNum = sDynosWarpLevelNum;
-        gCurrCourseNum = DynOS_Level_GetCourse(gCurrLevelNum);
-        gSavedCourseNum = gCurrCourseNum;
         gCurrActNum = MAX(0, sDynosWarpActNum * (gCurrCourseNum <= COURSE_STAGES_MAX));
         gDialogCourseActNum = gCurrActNum;
         gCurrAreaIndex = sDynosWarpAreaNum;
@@ -296,6 +350,10 @@ static void *DynOS_Warp_UpdateWarp(void *aCmd, bool aIsLevelInitDone) {
             sDynosWarpAreaNum    = -1;
             sDynosWarpActNum     = -1;
             sDynosWarpNodeNum    = -1;
+
+            sDynosWarpGotoActSelect = false;
+            sDynosActSelectDone = false;
+            sDynosActSelectStarted = false;
         }
     }
 

--- a/data/dynos_warps.cpp
+++ b/data/dynos_warps.cpp
@@ -176,7 +176,7 @@ bool DynOS_Warp_ToCastle(s32 aLevel) {
     return true;
 }
 
-bool DynOS_Warp_Delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect) {   
+bool DynOS_Warp_WithTransition(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect) {   
     if (aWarpId != 0) {
         if (!DynOS_Level_GetWarp(aLevel, aArea, aWarpId)) {
             return false;

--- a/data/dynos_warps.cpp
+++ b/data/dynos_warps.cpp
@@ -191,6 +191,7 @@ bool DynOS_Warp_Delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDe
         }
     }
 
+    aDelay = MAX(1, aDelay);
     sDynosWarpLevelNum = aLevel;
     sDynosWarpAreaNum = aArea;
     sDynosWarpActNum = aAct;

--- a/data/dynos_warps.cpp
+++ b/data/dynos_warps.cpp
@@ -184,6 +184,7 @@ bool DynOS_Warp_Delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDe
 
         sDynosWarpNodeNum = aWarpId;
     } else if (!DynOS_Level_GetWarpEntry(aLevel, aArea)) {
+        sDynosWarpNodeNum = -1;
         return false;
     }
 

--- a/docs/lua/functions-7.md
+++ b/docs/lua/functions-7.md
@@ -1925,6 +1925,35 @@ Warps back to the castle from `aLevel`
 
 <br />
 
+## [warp_delayed](#warp_delayed)
+
+### Description
+Warps to `aWarpId` of `aArea` in `aLevel` during `aAct` with a transition
+
+### Lua Example
+`local booleanValue = warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| aLevel | `integer` |
+| aArea | `integer` |
+| aAct | `integer` |
+| aTransType | `integer` |
+| aDelay | `integer` |
+| aColor | [Color](structs.md#Color) |
+| aWarpId | `integer` |
+
+### Returns
+- `boolean`
+
+### C Prototype
+`bool warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, OPTIONAL s32 aWarpId);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ---
 # functions from smlua_misc_utils.h
 

--- a/docs/lua/functions-7.md
+++ b/docs/lua/functions-7.md
@@ -1927,13 +1927,13 @@ Warps back to the castle from `aLevel`
 
 <br />
 
-## [warp_delayed](#warp_delayed)
+## [warp_with_transition](#warp_with_transition)
 
 ### Description
 Warps to `aWarpId` of `aArea` in `aLevel` during `aAct` with a transition
 
 ### Lua Example
-`local booleanValue = warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect)`
+`local booleanValue = warp_with_transition(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect)`
 
 ### Parameters
 | Field | Type |
@@ -1951,7 +1951,7 @@ Warps to `aWarpId` of `aArea` in `aLevel` during `aAct` with a transition
 - `boolean`
 
 ### C Prototype
-`bool warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, OPTIONAL s32 aWarpId, OPTIONAL bool aGotoActSelect);`
+`bool warp_with_transition(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, OPTIONAL s32 aWarpId, OPTIONAL bool aGotoActSelect);`
 
 [:arrow_up_small:](#)
 

--- a/docs/lua/functions-7.md
+++ b/docs/lua/functions-7.md
@@ -1792,7 +1792,7 @@ Checks if `levelNum` is a vanilla level
 Warps to `aWarpId` of `aArea` in `aLevel` during `aAct`
 
 ### Lua Example
-`local booleanValue = warp_to_warpnode(aLevel, aArea, aAct, aWarpId)`
+`local booleanValue = warp_to_warpnode(aLevel, aArea, aAct, aWarpId, aGotoActSelect)`
 
 ### Parameters
 | Field | Type |
@@ -1801,12 +1801,13 @@ Warps to `aWarpId` of `aArea` in `aLevel` during `aAct`
 | aArea | `integer` |
 | aAct | `integer` |
 | aWarpId | `integer` |
+| aGotoActSelect | `boolean` |
 
 ### Returns
 - `boolean`
 
 ### C Prototype
-`bool warp_to_warpnode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId);`
+`bool warp_to_warpnode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId, OPTIONAL bool aGotoActSelect);`
 
 [:arrow_up_small:](#)
 
@@ -1818,7 +1819,7 @@ Warps to `aWarpId` of `aArea` in `aLevel` during `aAct`
 Warps to `aArea` of `aLevel` in `aAct`
 
 ### Lua Example
-`local booleanValue = warp_to_level(aLevel, aArea, aAct)`
+`local booleanValue = warp_to_level(aLevel, aArea, aAct, aGotoActSelect)`
 
 ### Parameters
 | Field | Type |
@@ -1826,12 +1827,13 @@ Warps to `aArea` of `aLevel` in `aAct`
 | aLevel | `integer` |
 | aArea | `integer` |
 | aAct | `integer` |
+| aGotoActSelect | `boolean` |
 
 ### Returns
 - `boolean`
 
 ### C Prototype
-`bool warp_to_level(s32 aLevel, s32 aArea, s32 aAct);`
+`bool warp_to_level(s32 aLevel, s32 aArea, s32 aAct, OPTIONAL bool aGotoActSelect);`
 
 [:arrow_up_small:](#)
 
@@ -1931,7 +1933,7 @@ Warps back to the castle from `aLevel`
 Warps to `aWarpId` of `aArea` in `aLevel` during `aAct` with a transition
 
 ### Lua Example
-`local booleanValue = warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId)`
+`local booleanValue = warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect)`
 
 ### Parameters
 | Field | Type |
@@ -1943,12 +1945,13 @@ Warps to `aWarpId` of `aArea` in `aLevel` during `aAct` with a transition
 | aDelay | `integer` |
 | aColor | [Color](structs.md#Color) |
 | aWarpId | `integer` |
+| aGotoActSelect | `boolean` |
 
 ### Returns
 - `boolean`
 
 ### C Prototype
-`bool warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, OPTIONAL s32 aWarpId);`
+`bool warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, OPTIONAL s32 aWarpId, OPTIONAL bool aGotoActSelect);`
 
 [:arrow_up_small:](#)
 

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -2587,7 +2587,7 @@ level_script_parse(LEVEL_BOB, func)
 ### Parameters
 | Field | Type |
 | ----- | ---- |
-| levelNum | [LevelNum](./structs.md#LevelNum) \| `integer` |
+| levelNum | [enum LevelNum](./constants.md#enum-LevelNum) \| `integer` |
 | func | `function` |
 
 ### Returns
@@ -2640,7 +2640,7 @@ log_to_console("sm64coopdx FTW", CONSOLE_MESSAGE_INFO)
 | Field | Type |
 | ----- | ---- |
 | message | `string` |
-| level | [ConsoleMessageLevel](./structs.md#ConsoleMessageLevel) |
+| level | [enum ConsoleMessageLevel](./constants.md#enum-ConsoleMessageLevel) |
 
 ### Returns
 - None

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -2032,6 +2032,7 @@
    - [warp_to_start_level](functions-7.md#warp_to_start_level)
    - [warp_exit_level](functions-7.md#warp_exit_level)
    - [warp_to_castle](functions-7.md#warp_to_castle)
+   - [warp_delayed](functions-7.md#warp_delayed)
 
 <br />
 
@@ -2586,7 +2587,7 @@ level_script_parse(LEVEL_BOB, func)
 ### Parameters
 | Field | Type |
 | ----- | ---- |
-| levelNum | [enum LevelNum](./constants.md#enum-LevelNum) \| `integer` |
+| levelNum | [LevelNum](./structs.md#LevelNum) \| `integer` |
 | func | `function` |
 
 ### Returns
@@ -2639,7 +2640,7 @@ log_to_console("sm64coopdx FTW", CONSOLE_MESSAGE_INFO)
 | Field | Type |
 | ----- | ---- |
 | message | `string` |
-| level | [enum ConsoleMessageLevel](./constants.md#enum-ConsoleMessageLevel) |
+| level | [ConsoleMessageLevel](./structs.md#ConsoleMessageLevel) |
 
 ### Returns
 - None

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -2032,7 +2032,7 @@
    - [warp_to_start_level](functions-7.md#warp_to_start_level)
    - [warp_exit_level](functions-7.md#warp_exit_level)
    - [warp_to_castle](functions-7.md#warp_to_castle)
-   - [warp_delayed](functions-7.md#warp_delayed)
+   - [warp_with_transition](functions-7.md#warp_with_transition)
 
 <br />
 

--- a/docs/lua/guides/hooks.md
+++ b/docs/lua/guides/hooks.md
@@ -46,15 +46,15 @@ id_bhvExample = hook_behavior(nil, OBJ_LIST_DEFAULT, true, bhv_example_init, bhv
 ### Parameters
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| behaviorId | [enum BehaviorId](../constants.md#enum-BehaviorId) \| `integer` \| `nil` | The behavior id of the object to modify. Pass in as `nil` to create a custom object |
-| objectList | [enum ObjectList](../constants.md#enum-ObjectList) \| `integer` \| `nil` | Object list. Pass in as `nil` to use the vanilla object list or the already assigned object list in case of multiple hooks |
+| behaviorId | [BehaviorId](../structs.md#BehaviorId) \| `integer` \| `nil` | The behavior id of the object to modify. Pass in as `nil` to create a custom object |
+| objectList | [ObjectList](../structs.md#ObjectList) \| `integer` \| `nil` | Object list. Pass in as `nil` to use the vanilla object list or the already assigned object list in case of multiple hooks |
 | replaceBehavior | `bool` | Whether or not to completely replace the behavior (ignored for non-vanilla behaviors, which are always replaced) |
 | initFunction | `function` | Run on object creation |
 | loopFunction | `function` | Run every frame |
 | behaviorName | `string` | Optional, name to give to the behavior to be able to retrieve it with `get_id_from_behavior_name` |
 
 ### Returns
-- [enum BehaviorId](../constants.md#enum-BehaviorId)
+- [BehaviorId](../structs.md#BehaviorId)
 
 [:arrow_up_small:](#)
 
@@ -197,7 +197,7 @@ hook_event(HOOK_MARIO_UPDATE, mario_update)
 ### Parameters
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| hookEventType | [enum LuaHookedEventType](../constants.md#enum-LuaHookedEventType) | When a function should run |
+| hookEventType | [LuaHookedEventType](../structs.md#LuaHookedEventType) | When a function should run |
 | func | `function` | The function to run |
 
 ### Returns
@@ -280,7 +280,7 @@ hook_mario_action(ACT_WALL_SLIDE, { every_frame = act_wall_slide, gravity = act_
 | ----- | ---- | ----------- |
 | actionId | `integer` | The action to replace |
 | funcOrFuncTable | `function` \| `table` | Action function or table with entries for action hooks |
-| interactionType | [enum InteractionFlag](../constants.md#enum-InteractionFlag) | Optional; The flag that determines how the action interacts with other objects |
+| interactionType | [InteractionFlag](../structs.md#InteractionFlag) | Optional; The flag that determines how the action interacts with other objects |
 
 ### Returns
 - None

--- a/docs/lua/guides/hooks.md
+++ b/docs/lua/guides/hooks.md
@@ -46,15 +46,15 @@ id_bhvExample = hook_behavior(nil, OBJ_LIST_DEFAULT, true, bhv_example_init, bhv
 ### Parameters
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| behaviorId | [BehaviorId](../structs.md#BehaviorId) \| `integer` \| `nil` | The behavior id of the object to modify. Pass in as `nil` to create a custom object |
-| objectList | [ObjectList](../structs.md#ObjectList) \| `integer` \| `nil` | Object list. Pass in as `nil` to use the vanilla object list or the already assigned object list in case of multiple hooks |
+| behaviorId | [enum BehaviorId](../constants.md#enum-BehaviorId) \| `integer` \| `nil` | The behavior id of the object to modify. Pass in as `nil` to create a custom object |
+| objectList | [enum ObjectList](../constants.md#enum-ObjectList) \| `integer` \| `nil` | Object list. Pass in as `nil` to use the vanilla object list or the already assigned object list in case of multiple hooks |
 | replaceBehavior | `bool` | Whether or not to completely replace the behavior (ignored for non-vanilla behaviors, which are always replaced) |
 | initFunction | `function` | Run on object creation |
 | loopFunction | `function` | Run every frame |
 | behaviorName | `string` | Optional, name to give to the behavior to be able to retrieve it with `get_id_from_behavior_name` |
 
 ### Returns
-- [BehaviorId](../structs.md#BehaviorId)
+- [enum BehaviorId](../constants.md#enum-BehaviorId)
 
 [:arrow_up_small:](#)
 
@@ -197,7 +197,7 @@ hook_event(HOOK_MARIO_UPDATE, mario_update)
 ### Parameters
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| hookEventType | [LuaHookedEventType](../structs.md#LuaHookedEventType) | When a function should run |
+| hookEventType | [enum LuaHookedEventType](../constants.md#enum-LuaHookedEventType) | When a function should run |
 | func | `function` | The function to run |
 
 ### Returns
@@ -280,7 +280,7 @@ hook_mario_action(ACT_WALL_SLIDE, { every_frame = act_wall_slide, gravity = act_
 | ----- | ---- | ----------- |
 | actionId | `integer` | The action to replace |
 | funcOrFuncTable | `function` \| `table` | Action function or table with entries for action hooks |
-| interactionType | [InteractionFlag](../structs.md#InteractionFlag) | Optional; The flag that determines how the action interacts with other objects |
+| interactionType | [enum InteractionFlag](../constants.md#enum-InteractionFlag) | Optional; The flag that determines how the action interacts with other objects |
 
 ### Returns
 - None

--- a/src/pc/dev/chat.c
+++ b/src/pc/dev/chat.c
@@ -147,7 +147,7 @@ bool exec_dev_chat_command(char* command) {
         }
 
         // Warp
-        if (!dynos_warp_to_level(level, area, act)) {
+        if (!dynos_warp_to_level(level, area, act, false)) {
             char message[256];
             snprintf(message, 256, "Unable to warp to: %s %d %d", paramLevel, area, act);
             command_message_create(message, CONSOLE_MESSAGE_ERROR);

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -32344,39 +32344,39 @@ int smlua_func_warp_to_castle(lua_State* L) {
     return 1;
 }
 
-int smlua_func_warp_delayed(lua_State* L) {
+int smlua_func_warp_with_transition(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
     if (top < 6 || top > 8) {
-        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "warp_delayed", 6, 8, top);
+        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "warp_with_transition", 6, 8, top);
         return 0;
     }
 
     s32 aLevel = smlua_to_integer(L, 1);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "warp_delayed"); return 0; }
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "warp_with_transition"); return 0; }
     s32 aArea = smlua_to_integer(L, 2);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "warp_delayed"); return 0; }
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "warp_with_transition"); return 0; }
     s32 aAct = smlua_to_integer(L, 3);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "warp_delayed"); return 0; }
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "warp_with_transition"); return 0; }
     s16 aTransType = smlua_to_integer(L, 4);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 4, "warp_delayed"); return 0; }
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 4, "warp_with_transition"); return 0; }
     s16 aDelay = smlua_to_integer(L, 5);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 5, "warp_delayed"); return 0; }
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 5, "warp_with_transition"); return 0; }
     Color aColor; smlua_get_color(aColor, 6);
-    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 6, "warp_delayed"); return 0; }
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 6, "warp_with_transition"); return 0; }
     s32 aWarpId = (s32) 0;
     if (top >= 7) {
         aWarpId = smlua_to_integer(L, 7);
-        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 7, "warp_delayed"); return 0; }
+        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 7, "warp_with_transition"); return 0; }
     }
     bool aGotoActSelect = (bool) 0;
     if (top >= 8) {
         aGotoActSelect = smlua_to_boolean(L, 8);
-        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 8, "warp_delayed"); return 0; }
+        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 8, "warp_with_transition"); return 0; }
     }
 
-    lua_pushboolean(L, warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect));
+    lua_pushboolean(L, warp_with_transition(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect));
 
     return 1;
 }
@@ -38164,7 +38164,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "warp_to_start_level", smlua_func_warp_to_start_level);
     smlua_bind_function(L, "warp_exit_level", smlua_func_warp_exit_level);
     smlua_bind_function(L, "warp_to_castle", smlua_func_warp_to_castle);
-    smlua_bind_function(L, "warp_delayed", smlua_func_warp_delayed);
+    smlua_bind_function(L, "warp_with_transition", smlua_func_warp_with_transition);
 
     // smlua_misc_utils.h
     smlua_bind_function(L, "get_network_area_timer", smlua_func_get_network_area_timer);

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -32232,8 +32232,8 @@ int smlua_func_warp_to_warpnode(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
-    if (top != 4) {
-        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "warp_to_warpnode", 4, top);
+    if (top < 4 || top > 5) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "warp_to_warpnode", 4, 5, top);
         return 0;
     }
 
@@ -32245,8 +32245,13 @@ int smlua_func_warp_to_warpnode(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "warp_to_warpnode"); return 0; }
     s32 aWarpId = smlua_to_integer(L, 4);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 4, "warp_to_warpnode"); return 0; }
+    bool aGotoActSelect = (bool) 0;
+    if (top >= 5) {
+        aGotoActSelect = smlua_to_boolean(L, 5);
+        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 5, "warp_to_warpnode"); return 0; }
+    }
 
-    lua_pushboolean(L, warp_to_warpnode(aLevel, aArea, aAct, aWarpId));
+    lua_pushboolean(L, warp_to_warpnode(aLevel, aArea, aAct, aWarpId, aGotoActSelect));
 
     return 1;
 }
@@ -32255,8 +32260,8 @@ int smlua_func_warp_to_level(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
-    if (top != 3) {
-        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "warp_to_level", 3, top);
+    if (top < 3 || top > 4) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "warp_to_level", 3, 4, top);
         return 0;
     }
 
@@ -32266,8 +32271,13 @@ int smlua_func_warp_to_level(lua_State* L) {
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "warp_to_level"); return 0; }
     s32 aAct = smlua_to_integer(L, 3);
     if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "warp_to_level"); return 0; }
+    bool aGotoActSelect = (bool) 0;
+    if (top >= 4) {
+        aGotoActSelect = smlua_to_boolean(L, 4);
+        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 4, "warp_to_level"); return 0; }
+    }
 
-    lua_pushboolean(L, warp_to_level(aLevel, aArea, aAct));
+    lua_pushboolean(L, warp_to_level(aLevel, aArea, aAct, aGotoActSelect));
 
     return 1;
 }
@@ -32338,8 +32348,8 @@ int smlua_func_warp_delayed(lua_State* L) {
     if (L == NULL) { return 0; }
 
     int top = lua_gettop(L);
-    if (top < 6 || top > 7) {
-        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "warp_delayed", 6, 7, top);
+    if (top < 6 || top > 8) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "warp_delayed", 6, 8, top);
         return 0;
     }
 
@@ -32360,8 +32370,13 @@ int smlua_func_warp_delayed(lua_State* L) {
         aWarpId = smlua_to_integer(L, 7);
         if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 7, "warp_delayed"); return 0; }
     }
+    bool aGotoActSelect = (bool) 0;
+    if (top >= 8) {
+        aGotoActSelect = smlua_to_boolean(L, 8);
+        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 8, "warp_delayed"); return 0; }
+    }
 
-    lua_pushboolean(L, warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId));
+    lua_pushboolean(L, warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect));
 
     return 1;
 }

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -32334,6 +32334,38 @@ int smlua_func_warp_to_castle(lua_State* L) {
     return 1;
 }
 
+int smlua_func_warp_delayed(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top < 6 || top > 7) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected between %u and %u, Received %u", "warp_delayed", 6, 7, top);
+        return 0;
+    }
+
+    s32 aLevel = smlua_to_integer(L, 1);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "warp_delayed"); return 0; }
+    s32 aArea = smlua_to_integer(L, 2);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "warp_delayed"); return 0; }
+    s32 aAct = smlua_to_integer(L, 3);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "warp_delayed"); return 0; }
+    s16 aTransType = smlua_to_integer(L, 4);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 4, "warp_delayed"); return 0; }
+    s16 aDelay = smlua_to_integer(L, 5);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 5, "warp_delayed"); return 0; }
+    Color aColor; smlua_get_color(aColor, 6);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 6, "warp_delayed"); return 0; }
+    s32 aWarpId = (s32) 0;
+    if (top >= 7) {
+        aWarpId = smlua_to_integer(L, 7);
+        if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 7, "warp_delayed"); return 0; }
+    }
+
+    lua_pushboolean(L, warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId));
+
+    return 1;
+}
+
   ////////////////////////
  // smlua_misc_utils.h //
 ////////////////////////
@@ -38117,6 +38149,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "warp_to_start_level", smlua_func_warp_to_start_level);
     smlua_bind_function(L, "warp_exit_level", smlua_func_warp_exit_level);
     smlua_bind_function(L, "warp_to_castle", smlua_func_warp_to_castle);
+    smlua_bind_function(L, "warp_delayed", smlua_func_warp_delayed);
 
     // smlua_misc_utils.h
     smlua_bind_function(L, "get_network_area_timer", smlua_func_get_network_area_timer);

--- a/src/pc/lua/utils/smlua_level_utils.c
+++ b/src/pc/lua/utils/smlua_level_utils.c
@@ -195,6 +195,6 @@ bool warp_to_castle(s32 aLevel) {
     return dynos_warp_to_castle(aLevel);
 }
 
-bool warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect) {
-    return dynos_warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect);
+bool warp_with_transition(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect) {
+    return dynos_warp_with_transition(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect);
 }

--- a/src/pc/lua/utils/smlua_level_utils.c
+++ b/src/pc/lua/utils/smlua_level_utils.c
@@ -171,12 +171,12 @@ bool level_is_vanilla_level(s16 levelNum) {
     return dynos_level_is_vanilla_level(levelNum);
 }
 
-bool warp_to_warpnode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId) {
-    return dynos_warp_to_warpnode(aLevel, aArea, aAct, aWarpId);
+bool warp_to_warpnode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId, bool aGotoActSelect) {
+    return dynos_warp_to_warpnode(aLevel, aArea, aAct, aWarpId, aGotoActSelect);
 }
 
-bool warp_to_level(s32 aLevel, s32 aArea, s32 aAct) {
-    return dynos_warp_to_level(aLevel, aArea, aAct);
+bool warp_to_level(s32 aLevel, s32 aArea, s32 aAct, bool aGotoActSelect) {
+    return dynos_warp_to_level(aLevel, aArea, aAct, aGotoActSelect);
 }
 
 bool warp_to_start_level(void) {
@@ -195,6 +195,6 @@ bool warp_to_castle(s32 aLevel) {
     return dynos_warp_to_castle(aLevel);
 }
 
-bool warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId) {
-    return dynos_warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId);
+bool warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId, bool aGotoActSelect) {
+    return dynos_warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId, aGotoActSelect);
 }

--- a/src/pc/lua/utils/smlua_level_utils.c
+++ b/src/pc/lua/utils/smlua_level_utils.c
@@ -194,3 +194,7 @@ bool warp_exit_level(s32 aDelay) {
 bool warp_to_castle(s32 aLevel) {
     return dynos_warp_to_castle(aLevel);
 }
+
+bool warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, s32 aWarpId) {
+    return dynos_warp_delayed(aLevel, aArea, aAct, aTransType, aDelay, aColor, aWarpId);
+}

--- a/src/pc/lua/utils/smlua_level_utils.h
+++ b/src/pc/lua/utils/smlua_level_utils.h
@@ -44,6 +44,6 @@ bool warp_exit_level(s32 aDelay);
 /* |description|Warps back to the castle from `aLevel`|descriptionEnd| */
 bool warp_to_castle(s32 aLevel);
 /* |description|Warps to `aWarpId` of `aArea` in `aLevel` during `aAct` with a transition|descriptionEnd| */
-bool warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, OPTIONAL s32 aWarpId, OPTIONAL bool aGotoActSelect);
+bool warp_with_transition(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, OPTIONAL s32 aWarpId, OPTIONAL bool aGotoActSelect);
 
 #endif

--- a/src/pc/lua/utils/smlua_level_utils.h
+++ b/src/pc/lua/utils/smlua_level_utils.h
@@ -32,9 +32,9 @@ s16 level_register(const char* scriptEntryName, s16 courseNum, const char* fullN
 /* |description|Checks if `levelNum` is a vanilla level|descriptionEnd| */
 bool level_is_vanilla_level(s16 levelNum);
 /* |description|Warps to `aWarpId` of `aArea` in `aLevel` during `aAct`|descriptionEnd| */
-bool warp_to_warpnode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId);
+bool warp_to_warpnode(s32 aLevel, s32 aArea, s32 aAct, s32 aWarpId, OPTIONAL bool aGotoActSelect);
 /* |description|Warps to `aArea` of `aLevel` in `aAct`|descriptionEnd| */
-bool warp_to_level(s32 aLevel, s32 aArea, s32 aAct);
+bool warp_to_level(s32 aLevel, s32 aArea, s32 aAct, OPTIONAL bool aGotoActSelect);
 /* |description|Restarts the current level|descriptionEnd| */
 bool warp_restart_level(void);
 /* |description|Warps to the start level (Castle Grounds by default)|descriptionEnd| */
@@ -44,6 +44,6 @@ bool warp_exit_level(s32 aDelay);
 /* |description|Warps back to the castle from `aLevel`|descriptionEnd| */
 bool warp_to_castle(s32 aLevel);
 /* |description|Warps to `aWarpId` of `aArea` in `aLevel` during `aAct` with a transition|descriptionEnd| */
-bool warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, OPTIONAL s32 aWarpId);
+bool warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, OPTIONAL s32 aWarpId, OPTIONAL bool aGotoActSelect);
 
 #endif

--- a/src/pc/lua/utils/smlua_level_utils.h
+++ b/src/pc/lua/utils/smlua_level_utils.h
@@ -43,5 +43,7 @@ bool warp_to_start_level(void);
 bool warp_exit_level(s32 aDelay);
 /* |description|Warps back to the castle from `aLevel`|descriptionEnd| */
 bool warp_to_castle(s32 aLevel);
+/* |description|Warps to `aWarpId` of `aArea` in `aLevel` during `aAct` with a transition|descriptionEnd| */
+bool warp_delayed(s32 aLevel, s32 aArea, s32 aAct, s16 aTransType, s16 aDelay, Color aColor, OPTIONAL s32 aWarpId);
 
 #endif


### PR DESCRIPTION
Adds a new `warp_delayed` function for performing delayed warps (warp with transition), so you don't have to reimplement them in lua.

Also adds an optional `aGotoActSelect` parameter to `warp_to_warpnode`, `warp_to_level`, and `warp_delayed` to show the act selector before entering a level
