### PR TITLE
Fix UB in `level_cmd_place_object` when gCurrActNum is <= 0

### DIFF
--- a/include/model_ids.h
+++ b/include/model_ids.h
@@ -11,8 +11,8 @@
 // If an object is set as active for the first 5 acts only, it is treated as always active.
 // It's possible that there were only planned to be 5 acts per level early in development.
 // Hence, they added a macro so they wouldn't have to change the acts for every object.
-#define ALL_ACTS_MACRO ACT_1 | ACT_2 | ACT_3 | ACT_4 | ACT_5
-#define ALL_ACTS       ACT_1 | ACT_2 | ACT_3 | ACT_4 | ACT_5 | ACT_6
+#define ALL_ACTS_MACRO (ACT_1 | ACT_2 | ACT_3 | ACT_4 | ACT_5)
+#define ALL_ACTS       (ACT_1 | ACT_2 | ACT_3 | ACT_4 | ACT_5 | ACT_6)
 
 #define COIN_FORMATION_FLAG_VERTICAL  (1 << 0)
 #define COIN_FORMATION_FLAG_RING      (1 << 1)

--- a/src/engine/level_script.c
+++ b/src/engine/level_script.c
@@ -538,7 +538,7 @@ static void level_cmd_place_object(void) {
     u8 actMatch;
 
     if (gCurrActNum > 0) {
-        actMatch = actFlags & (1 << (gCurrActNum - 1));
+        actMatch = actFlags & (1 << (gCurrActNum - 1)) || actFlags == ALL_ACTS_MACRO;
     } else {
         actMatch = (actFlags == ALL_ACTS_MACRO) || (actFlags == ALL_ACTS);
     }

--- a/src/engine/level_script.c
+++ b/src/engine/level_script.c
@@ -531,11 +531,19 @@ static void level_cmd_init_mario(void) {
 }
 
 static void level_cmd_place_object(void) {
-    u8 val7 = gCurrActNum > 0 ? (1 << (gCurrActNum - 1)) : ALL_ACTS;
     u16 model;
     struct SpawnInfo *spawnInfo;
 
-    if (sCurrAreaIndex != -1 && (gLevelValues.disableActs || (CMD_GET(u8, 2) & val7) || CMD_GET(u8, 2) == 0x1F)) {
+    u8 actFlags = CMD_GET(u8, 2);
+    u8 actMatch;
+
+    if (gCurrActNum > 0) {
+        actMatch = actFlags & (1 << (gCurrActNum - 1));
+    } else {
+        actMatch = (actFlags == ALL_ACTS_MACRO) || (actFlags == ALL_ACTS);
+    }
+
+    if (sCurrAreaIndex != -1 && (gLevelValues.disableActs || actMatch)) {
         model = CMD_GET(u8, 3);
         spawnInfo = dynamic_pool_alloc(gLevelPool, sizeof(struct SpawnInfo));
 

--- a/src/engine/level_script.c
+++ b/src/engine/level_script.c
@@ -531,7 +531,7 @@ static void level_cmd_init_mario(void) {
 }
 
 static void level_cmd_place_object(void) {
-    u8 val7 = 1 << (gCurrActNum - 1);
+    u8 val7 = gCurrActNum > 0 ? (1 << (gCurrActNum - 1)) : ALL_ACTS;
     u16 model;
     struct SpawnInfo *spawnInfo;
 


### PR DESCRIPTION
We ran into an issue in our romhack port where scrolling textures wouldn't work in some levels. It turned out the current act number was `0`, so `level_cmd_place_object` was doing:

```c
actFlags & (1 << (gCurrActNum - 1))
```

Since `gCurrActNum == 0`, that became a left shift by `-1`, which is undefined behavior, so our editor_Scroll_Textures wouldn't spawn.

`level_cmd_place_object` now handles `gCurrActNum <= 0` by only spawning objects marked with `ALL_ACTS` or `ALL_ACTS_MACRO`. Other act numbers behave just like it did before.

Shoutouts to @ManIsCat2 for spotting this
