### PR TITLE
Query gpu sample limit for msaa in OpenGL before init

### DIFF
--- a/src/pc/gfx/gfx_window_opengl.c
+++ b/src/pc/gfx/gfx_window_opengl.c
@@ -74,6 +74,12 @@ static int clamp_window_msaa_before_init() {
         }
     }
 
+#ifdef USE_GLES
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+#endif
+
     // hidden window
     SDL_Window *window = SDL_CreateWindow(
         "",

--- a/src/pc/gfx/gfx_window_opengl.c
+++ b/src/pc/gfx/gfx_window_opengl.c
@@ -50,6 +50,12 @@
 static SDL_Window *sSdlWindow;
 static SDL_GLContext sGlContext = NULL;
 
+  //////////////////////////
+ // forward declarations //
+//////////////////////////
+
+static int gfx_window_opengl_get_max_msaa(void);
+
 static inline void gfx_window_opengl_set_vsync(const bool enabled) {
     SDL_GL_SetSwapInterval(enabled);
 }
@@ -61,7 +67,44 @@ static void gfx_window_opengl_reset_dimension_and_pos(void) {
     gfx_window_opengl_set_vsync(configWindow.vsync);
 }
 
+static int clamp_window_msaa_before_init() {
+    if (!(SDL_WasInit(SDL_INIT_VIDEO) & SDL_INIT_VIDEO)) {
+        if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0) {
+            return 0;
+        }
+    }
+
+    // hidden window
+    SDL_Window *window = SDL_CreateWindow(
+        "",
+        SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 1, 1,
+        SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN
+    );
+
+    if (!window) {
+        return 0;
+    }
+
+    SDL_GLContext ctx = SDL_GL_CreateContext(window);
+
+    if (!ctx) {
+        SDL_DestroyWindow(window);
+        return 0;
+    }
+
+    SDL_GL_MakeCurrent(window, ctx);
+
+    u32 maxMsaa = gfx_window_opengl_get_max_msaa();
+    configWindow.msaa = MIN(configWindow.msaa, maxMsaa);
+
+    SDL_GL_DeleteContext(ctx);
+    SDL_DestroyWindow(window);
+
+    return maxMsaa;
+}
+
 static void gfx_window_opengl_init(const char *window_title) {
+    clamp_window_msaa_before_init();
     if (configWindow.msaa > 0) {
         SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
         SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, configWindow.msaa);

--- a/src/pc/gfx/gfx_window_opengl.c
+++ b/src/pc/gfx/gfx_window_opengl.c
@@ -67,10 +67,10 @@ static void gfx_window_opengl_reset_dimension_and_pos(void) {
     gfx_window_opengl_set_vsync(configWindow.vsync);
 }
 
-static int clamp_window_msaa_before_init() {
+static void clamp_window_msaa_before_init() {
     if (!(SDL_WasInit(SDL_INIT_VIDEO) & SDL_INIT_VIDEO)) {
         if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0) {
-            return 0;
+            return;
         }
     }
 
@@ -87,15 +87,13 @@ static int clamp_window_msaa_before_init() {
         SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN
     );
 
-    if (!window) {
-        return 0;
-    }
+    if (!window) { return; }
 
     SDL_GLContext ctx = SDL_GL_CreateContext(window);
 
     if (!ctx) {
         SDL_DestroyWindow(window);
-        return 0;
+        return;
     }
 
     SDL_GL_MakeCurrent(window, ctx);
@@ -105,8 +103,6 @@ static int clamp_window_msaa_before_init() {
 
     SDL_GL_DeleteContext(ctx);
     SDL_DestroyWindow(window);
-
-    return maxMsaa;
 }
 
 static void gfx_window_opengl_init(const char *window_title) {


### PR DESCRIPTION
Fixes a portion, or fully, the issue presented in <https://github.com/coop-deluxe/sm64coopdx/issues/1369>

If the configfile ever had a msaa setting set that was above what a persons computer could handle, the game could crash depending on the os and gpu drivers. The fix was querying compatibility beforehand in init. The code mainly follows the compatibility function below, but modifying it to query msaa compatibility.