### PR TITLE
Fix Windows console colors on conhost

### DIFF
--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -520,6 +520,10 @@ int main(int argc, char *argv[]) {
         console = pcount > 1;
     }
     if (console) {
+        HANDLE out = GetStdHandle(STD_OUTPUT_HANDLE);
+        DWORD mode = 0;
+        GetConsoleMode(out, &mode);
+        SetConsoleMode(out, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
         SetConsoleOutputCP(CP_UTF8);
     } else {
         FreeConsole();


### PR DESCRIPTION
Before:
<img width="935" height="140" alt="image" src="https://github.com/user-attachments/assets/884cd140-a206-455b-8b14-9d11f752be93" />

After:
<img width="741" height="404" alt="image" src="https://github.com/user-attachments/assets/75c315c2-8ee7-4aa8-8bb9-cfe08f3ee2f7" />

Credit to https://stackoverflow.com/a/79686178/15417580 stack overflow always got you