### PR TITLE
Implement FastDL (optional mod download over HTTP)

### DIFF
--- a/lang/Czech.ini
+++ b/lang/Czech.ini
@@ -30,6 +30,8 @@ LOBBY_HOST = "host lobby"
 UPDATE_AVAILABLE = "Nová aktualizace!"
 LATEST_VERSION = "Nejnovější verze"
 YOUR_VERSION = "Vaše verze"
+FASTDL_FAILED = "\\#ffa0a0\\FastDL:\\#\\ @ file(s) failed, using in-game transfer"
+FASTDL_UNREACHABLE = "\\#ffa0a0\\FastDL:\\#\\ could not connect to '@', using in-game transfer"
 
 [CHAT]
 KICKING = "Vyhazování '@'!"
@@ -259,6 +261,7 @@ BOUNCY_BOUNDS_ON = "Zapnuto"
 BOUNCY_BOUNDS_OFF = "Vypnuto"
 BOUNCY_LEVEL_BOUNDS = "Omezení odražejícího úrovně"
 AMOUNT_OF_PLAYERS = "Počet hráčů"
+FASTDL_URL = "Fast Download URL"
 PAUSE_ANYWHERE = "Pozastavit kdekoli"
 
 [HOST]
@@ -327,6 +330,10 @@ DEBUG_ERRORS = "Debug Errors"
 MISC_TITLE = "JINE"
 PAUSE_IN_SINGLEPLAYER = "Pauza v hře s jedním hráčem"
 DISABLE_POPUPS = "Vypnout vyskakovací okna"
+FASTDL_MODE = "Fast Downloads (HTTP)"
+FASTDL_ALWAYS_OFF = "Always Off"
+FASTDL_LET_ME_CHOOSE = "Let Me Choose"
+FASTDL_ALWAYS_ON = "Always On"
 USE_STANDARD_KEY_BINDINGS_CHAT = "Klasické ovládání chatu"
 MENU_OPTIONS = "Nastavení hlavního menu"
 INFORMATION = "Informace"
@@ -334,6 +341,12 @@ DEBUG = "Debug"
 LANGUAGE = "Jazyk"
 R_BUTTON = "Tlačítko [R] - Možnosti"
 L_BUTTON = "Tlačítko [L] - Znovu načíst aktivní mody"
+
+
+[FASTDL]
+TITLE = "FAST DOWNLOAD"
+POPUP_BODY = "The host wants to send @ files (#) over HTTP from:"
+CONTINUE = "Continue?"
 
 [INFORMATION]
 INFORMATION_TITLE = "INFORMACE"

--- a/lang/Dutch.ini
+++ b/lang/Dutch.ini
@@ -30,6 +30,8 @@ LOBBY_HOST = "De Lobby's organisator."
 UPDATE_AVAILABLE = "Nieuwe update!"
 LATEST_VERSION = "Laatste versie"
 YOUR_VERSION = "Uw versie"
+FASTDL_FAILED = "\\#ffa0a0\\FastDL:\\#\\ @ file(s) failed, using in-game transfer"
+FASTDL_UNREACHABLE = "\\#ffa0a0\\FastDL:\\#\\ could not connect to '@', using in-game transfer"
 
 [CHAT]
 KICKING = "'@' eruit schoppen!"
@@ -259,6 +261,7 @@ BOUNCY_BOUNDS_ON = "Aan"
 BOUNCY_BOUNDS_OFF = "Uit"
 BOUNCY_LEVEL_BOUNDS = "Springende Niveau Grenzen"
 AMOUNT_OF_PLAYERS = "Hoeveelheid spelers"
+FASTDL_URL = "Fast Download URL"
 PAUSE_ANYWHERE = "Pauzeer waar dan ook"
 
 [HOST]
@@ -327,6 +330,10 @@ DEBUG_ERRORS = "Debug Errors"
 MISC_TITLE = "MISC"
 PAUSE_IN_SINGLEPLAYER = "Pauzeer in een speler"
 DISABLE_POPUPS = "Popups uitzetten"
+FASTDL_MODE = "Fast Downloads (HTTP)"
+FASTDL_ALWAYS_OFF = "Always Off"
+FASTDL_LET_ME_CHOOSE = "Let Me Choose"
+FASTDL_ALWAYS_ON = "Always On"
 USE_STANDARD_KEY_BINDINGS_CHAT = "Klassieke chatbediening"
 MENU_OPTIONS = "Menu Instellingen"
 INFORMATION = "Informatie"
@@ -334,6 +341,12 @@ DEBUG = "Debuggen"
 LANGUAGE = "Taal"
 R_BUTTON = "[R]-knop - Opties"
 L_BUTTON = "[L]-knop - Actieve mods opnieuw laden"
+
+
+[FASTDL]
+TITLE = "FAST DOWNLOAD"
+POPUP_BODY = "The host wants to send @ files (#) over HTTP from:"
+CONTINUE = "Continue?"
 
 [INFORMATION]
 INFORMATION_TITLE = "INFORMATIE"

--- a/lang/English.ini
+++ b/lang/English.ini
@@ -30,6 +30,8 @@ LOBBY_HOST = "the lobby's host"
 UPDATE_AVAILABLE = "A new update is available!"
 LATEST_VERSION = "Latest version"
 YOUR_VERSION = "Your version"
+FASTDL_FAILED = "\\#ffa0a0\\FastDL:\\#\\ @ file(s) failed, using in-game transfer"
+FASTDL_UNREACHABLE = "\\#ffa0a0\\FastDL:\\#\\ could not connect to '@', using in-game transfer"
 
 [CHAT]
 KICKING = "Kicking '@'!"
@@ -259,6 +261,7 @@ BOUNCY_BOUNDS_ON = "On"
 BOUNCY_BOUNDS_OFF = "Off"
 BOUNCY_LEVEL_BOUNDS = "Bouncy Level Bounds"
 AMOUNT_OF_PLAYERS = "Amount Of Players"
+FASTDL_URL = "Fast Download URL"
 PAUSE_ANYWHERE = "Pause Anywhere"
 
 [HOST]
@@ -327,6 +330,10 @@ DEBUG_ERRORS = "Debug Errors"
 MISC_TITLE = "MISC"
 PAUSE_IN_SINGLEPLAYER = "Pause In Singleplayer"
 DISABLE_POPUPS = "Disable Popups"
+FASTDL_MODE = "Fast Downloads (HTTP)"
+FASTDL_ALWAYS_OFF = "Always Off"
+FASTDL_LET_ME_CHOOSE = "Let Me Choose"
+FASTDL_ALWAYS_ON = "Always On"
 USE_STANDARD_KEY_BINDINGS_CHAT = "Classic Chatbox Controls"
 MENU_OPTIONS = "Menu Options"
 INFORMATION = "Info"
@@ -334,6 +341,12 @@ DEBUG = "Debug"
 LANGUAGE = "Language"
 R_BUTTON = "[R] Button - Options"
 L_BUTTON = "[L] Button - Reload Active Mods"
+
+
+[FASTDL]
+TITLE = "FAST DOWNLOAD"
+POPUP_BODY = "The host wants to send @ files (#) over HTTP from:"
+CONTINUE = "Continue?"
 
 [INFORMATION]
 INFORMATION_TITLE = "INFO"

--- a/lang/French.ini
+++ b/lang/French.ini
@@ -30,6 +30,8 @@ LOBBY_HOST = "hôte de la partie"
 UPDATE_AVAILABLE = "Nouvelle mise à jour !"
 LATEST_VERSION = "Dernière version "
 YOUR_VERSION = "Votre version "
+FASTDL_FAILED = "\\#ffa0a0\\FastDL:\\#\\ @ file(s) failed, using in-game transfer"
+FASTDL_UNREACHABLE = "\\#ffa0a0\\FastDL:\\#\\ could not connect to '@', using in-game transfer"
 
 [CHAT]
 KICKING = "Vous avez expulsé '@' !"
@@ -259,6 +261,7 @@ BOUNCY_BOUNDS_ON = "Activés"
 BOUNCY_BOUNDS_OFF = "Désactivés"
 BOUNCY_LEVEL_BOUNDS = "Bords de niveau rebondissants"
 AMOUNT_OF_PLAYERS = "Nombre de joueurs"
+FASTDL_URL = "Fast Download URL"
 PAUSE_ANYWHERE = "Mettre en pause n'importe où"
 
 [HOST]
@@ -327,6 +330,10 @@ DEBUG_ERRORS = "Erreurs de débogage"
 MISC_TITLE = "AUTRES"
 PAUSE_IN_SINGLEPLAYER = "Pause en solo"
 DISABLE_POPUPS = "Désactiver les pop-ups"
+FASTDL_MODE = "Fast Downloads (HTTP)"
+FASTDL_ALWAYS_OFF = "Always Off"
+FASTDL_LET_ME_CHOOSE = "Let Me Choose"
+FASTDL_ALWAYS_ON = "Always On"
 USE_STANDARD_KEY_BINDINGS_CHAT = "Commandes de chat classiques"
 MENU_OPTIONS = "Options du menu"
 INFORMATION = "Information"
@@ -334,6 +341,12 @@ DEBUG = "Débogage"
 LANGUAGE = "Langue"
 R_BUTTON = "Bouton [R] - Options"
 L_BUTTON = "Bouton [L] - Recharger les mods actifs"
+
+
+[FASTDL]
+TITLE = "FAST DOWNLOAD"
+POPUP_BODY = "The host wants to send @ files (#) over HTTP from:"
+CONTINUE = "Continue?"
 
 [INFORMATION]
 INFORMATION_TITLE = "INFORMATION"

--- a/lang/German.ini
+++ b/lang/German.ini
@@ -30,6 +30,8 @@ LOBBY_HOST = "Lobby-Host"
 UPDATE_AVAILABLE = "Ein neues Update ist verfügbar!"
 LATEST_VERSION = "Neueste Version"
 YOUR_VERSION = "Deine Version"
+FASTDL_FAILED = "\\#ffa0a0\\FastDL:\\#\\ @ file(s) failed, using in-game transfer"
+FASTDL_UNREACHABLE = "\\#ffa0a0\\FastDL:\\#\\ could not connect to '@', using in-game transfer"
 
 [CHAT]
 KICKING = "'@' wurde gekickt!"
@@ -259,6 +261,7 @@ BOUNCY_BOUNDS_ON = "An"
 BOUNCY_BOUNDS_OFF = "Aus"
 BOUNCY_LEVEL_BOUNDS = "Rückprall an Levelgrenzen"
 AMOUNT_OF_PLAYERS = "Spieleranzahl"
+FASTDL_URL = "Fast Download URL"
 PAUSE_ANYWHERE = "Überall pausieren"
 
 [HOST]
@@ -327,6 +330,10 @@ DEBUG_ERRORS = "Debug Fehler"
 MISC_TITLE = "SONSTIGES"
 PAUSE_IN_SINGLEPLAYER = "Pause im Einzelspieler"
 DISABLE_POPUPS = "Pop-ups deaktivieren"
+FASTDL_MODE = "Fast Downloads (HTTP)"
+FASTDL_ALWAYS_OFF = "Always Off"
+FASTDL_LET_ME_CHOOSE = "Let Me Choose"
+FASTDL_ALWAYS_ON = "Always On"
 USE_STANDARD_KEY_BINDINGS_CHAT = "Klassische Chatbox-Steuerung"
 MENU_OPTIONS = "Menüoptionen"
 INFORMATION = "Informationen"
@@ -334,6 +341,12 @@ DEBUG = "Debug"
 LANGUAGE = "Sprache"
 R_BUTTON = "[R]-Taste - Optionen"
 L_BUTTON = "[L]-Taste - Aktive Mods neu laden"
+
+
+[FASTDL]
+TITLE = "FAST DOWNLOAD"
+POPUP_BODY = "The host wants to send @ files (#) over HTTP from:"
+CONTINUE = "Continue?"
 
 [INFORMATION]
 INFORMATION_TITLE = "INFORMATION"

--- a/lang/Italian.ini
+++ b/lang/Italian.ini
@@ -30,6 +30,8 @@ LOBBY_HOST = "l'host della stanza"
 UPDATE_AVAILABLE = "Nuovo aggiornamento!"
 LATEST_VERSION = "Ultima versione"
 YOUR_VERSION = "La tua versione"
+FASTDL_FAILED = "\\#ffa0a0\\FastDL:\\#\\ @ file(s) failed, using in-game transfer"
+FASTDL_UNREACHABLE = "\\#ffa0a0\\FastDL:\\#\\ could not connect to '@', using in-game transfer"
 
 [CHAT]
 KICKING = "'@' è stato espulso!"
@@ -257,6 +259,7 @@ BOUNCY_BOUNDS_ON = "Attivo"
 BOUNCY_BOUNDS_OFF = "Disattivo"
 BOUNCY_LEVEL_BOUNDS = "Limiti Livello Rimbalzanti"
 AMOUNT_OF_PLAYERS = "Numero di Giocatori"
+FASTDL_URL = "Fast Download URL"
 PAUSE_ANYWHERE = "Pausa Ovunque"
 
 [HOST]
@@ -325,6 +328,10 @@ DEBUG_ERRORS = "Errori di debug"
 MISC_TITLE = "VARIE"
 PAUSE_IN_SINGLEPLAYER = "Pausa in Giocatore Singolo"
 DISABLE_POPUPS = "Disabilita Popup"
+FASTDL_MODE = "Fast Downloads (HTTP)"
+FASTDL_ALWAYS_OFF = "Always Off"
+FASTDL_LET_ME_CHOOSE = "Let Me Choose"
+FASTDL_ALWAYS_ON = "Always On"
 USE_STANDARD_KEY_BINDINGS_CHAT = "Controlli della chat classici"
 MENU_OPTIONS = "Opzioni Menù"
 INFORMATION = "Informazione"
@@ -332,6 +339,12 @@ DEBUG = "Debug"
 LANGUAGE = "Lingua"
 R_BUTTON = "Pulsante [R] - Opzioni"
 L_BUTTON = "Pulsante [L] - Ricarica Mod Attive"
+
+
+[FASTDL]
+TITLE = "FAST DOWNLOAD"
+POPUP_BODY = "The host wants to send @ files (#) over HTTP from:"
+CONTINUE = "Continue?"
 
 [INFORMATION]
 INFORMATION_TITLE = "INFORMAZIONI"

--- a/lang/Japanese.ini
+++ b/lang/Japanese.ini
@@ -30,6 +30,8 @@ LOBBY_HOST = "ルームのホスト"
 UPDATE_AVAILABLE = "アップデートが利用可能です！"
 LATEST_VERSION = "最新のバージョン"
 YOUR_VERSION = "あなたのバージョン"
+FASTDL_FAILED = "\\#ffa0a0\\FastDL:\\#\\ @ file(s) failed, using in-game transfer"
+FASTDL_UNREACHABLE = "\\#ffa0a0\\FastDL:\\#\\ could not connect to '@', using in-game transfer"
 
 [CHAT]
 KICKING = "@ をキックしました！"
@@ -259,6 +261,7 @@ BOUNCY_BOUNDS_ON = "オン"
 BOUNCY_BOUNDS_OFF = "オフ"
 BOUNCY_LEVEL_BOUNDS = "コース境界での跳ね返り"
 AMOUNT_OF_PLAYERS = "最大ルーム人数"
+FASTDL_URL = "Fast Download URL"
 PAUSE_ANYWHERE = "どこでもポーズ"
 
 [HOST]
@@ -327,6 +330,10 @@ DEBUG_ERRORS = "デバッグエラーの表示"
 MISC_TITLE = "MISC"
 PAUSE_IN_SINGLEPLAYER = "1人プレイ中にポーズで一時停止を有効化"
 DISABLE_POPUPS = "ポップアップを無効にする"
+FASTDL_MODE = "Fast Downloads (HTTP)"
+FASTDL_ALWAYS_OFF = "Always Off"
+FASTDL_LET_ME_CHOOSE = "Let Me Choose"
+FASTDL_ALWAYS_ON = "Always On"
 USE_STANDARD_KEY_BINDINGS_CHAT = "旧式チャット操作"
 MENU_OPTIONS = "メニューの設定"
 INFORMATION = "情報"
@@ -334,6 +341,12 @@ DEBUG = "デバッグ"
 LANGUAGE = "言語"
 R_BUTTON = "Rボタン - 設定"
 L_BUTTON = "Lボタン - 有効化されたMODを再読み込み"
+
+
+[FASTDL]
+TITLE = "FAST DOWNLOAD"
+POPUP_BODY = "The host wants to send @ files (#) over HTTP from:"
+CONTINUE = "Continue?"
 
 [INFORMATION]
 INFORMATION_TITLE = "INFO"

--- a/lang/Polish.ini
+++ b/lang/Polish.ini
@@ -30,6 +30,8 @@ LOBBY_HOST = "Host lobby"
 UPDATE_AVAILABLE = "Dostępna jest nowa aktualizacja!"
 LATEST_VERSION = "Najnowsza wersja"
 YOUR_VERSION = "Twoja wersja"
+FASTDL_FAILED = "\\#ffa0a0\\FastDL:\\#\\ @ file(s) failed, using in-game transfer"
+FASTDL_UNREACHABLE = "\\#ffa0a0\\FastDL:\\#\\ could not connect to '@', using in-game transfer"
 
 [CHAT]
 KICKING = "Wyrzucanie gracza '@'!"
@@ -259,6 +261,7 @@ BOUNCY_BOUNDS_ON = "Włączone"
 BOUNCY_BOUNDS_OFF = "Wyłączone"
 BOUNCY_LEVEL_BOUNDS = "Odbijanie na Granicach Poziomów"
 AMOUNT_OF_PLAYERS = "Liczba Graczy"
+FASTDL_URL = "Fast Download URL"
 PAUSE_ANYWHERE = "Zatrzymanie Gry w Dowolnym Momencie"
 
 [HOST]
@@ -327,6 +330,10 @@ DEBUG_ERRORS = "Błędy z Debugowania"
 MISC_TITLE = "POZOSTAŁE OPCJE"
 PAUSE_IN_SINGLEPLAYER = "Pauza w Trybie Pojedynczego Gracza"
 DISABLE_POPUPS = "Wyłącz Dymki Powiadomień"
+FASTDL_MODE = "Fast Downloads (HTTP)"
+FASTDL_ALWAYS_OFF = "Always Off"
+FASTDL_LET_ME_CHOOSE = "Let Me Choose"
+FASTDL_ALWAYS_ON = "Always On"
 USE_STANDARD_KEY_BINDINGS_CHAT = "Klasyczna Historia Czatu"
 MENU_OPTIONS = "Opcje Menu"
 INFORMATION = "Informacja"
@@ -334,6 +341,12 @@ DEBUG = "Debugowanie"
 LANGUAGE = "Język"
 R_BUTTON = "Przycisk [R] - Opcje"
 L_BUTTON = "Przycisk [L] - Przeładuj aktywne mody"
+
+
+[FASTDL]
+TITLE = "FAST DOWNLOAD"
+POPUP_BODY = "The host wants to send @ files (#) over HTTP from:"
+CONTINUE = "Continue?"
 
 [INFORMATION]
 INFORMATION_TITLE = "INFORMACJA"

--- a/lang/Portuguese.ini
+++ b/lang/Portuguese.ini
@@ -30,6 +30,8 @@ LOBBY_HOST = "o criador da sala"
 UPDATE_AVAILABLE = "Uma nova atualização está disponível!"
 LATEST_VERSION = "Versão mais recente"
 YOUR_VERSION = "Sua versão"
+FASTDL_FAILED = "\\#ffa0a0\\FastDL:\\#\\ @ file(s) failed, using in-game transfer"
+FASTDL_UNREACHABLE = "\\#ffa0a0\\FastDL:\\#\\ could not connect to '@', using in-game transfer"
 
 [CHAT]
 KICKING = "Expulsando '@'!"
@@ -259,6 +261,7 @@ BOUNCY_BOUNDS_ON = "Ativado"
 BOUNCY_BOUNDS_OFF = "Desativado"
 BOUNCY_LEVEL_BOUNDS = "Bordas de fase quicantes"
 AMOUNT_OF_PLAYERS = "Quantidade de jogadores"
+FASTDL_URL = "Fast Download URL"
 PAUSE_ANYWHERE = "Pausar em qualquer lugar"
 
 [HOST]
@@ -327,6 +330,10 @@ DEBUG_ERRORS = "Erros de debug"
 MISC_TITLE = "OUTROS"
 PAUSE_IN_SINGLEPLAYER = "Pausar com apenas um jogador"
 DISABLE_POPUPS = "Desativar pop-ups"
+FASTDL_MODE = "Fast Downloads (HTTP)"
+FASTDL_ALWAYS_OFF = "Always Off"
+FASTDL_LET_ME_CHOOSE = "Let Me Choose"
+FASTDL_ALWAYS_ON = "Always On"
 USE_STANDARD_KEY_BINDINGS_CHAT = "Controles clássicos do chat"
 MENU_OPTIONS = "Opções de menu"
 INFORMATION = "Informações"
@@ -334,6 +341,12 @@ DEBUG = "Debug"
 LANGUAGE = "Idioma"
 R_BUTTON = "Botão [R] - Opções"
 L_BUTTON = "Botão [L] - Recarregar mods ativos"
+
+
+[FASTDL]
+TITLE = "FAST DOWNLOAD"
+POPUP_BODY = "The host wants to send @ files (#) over HTTP from:"
+CONTINUE = "Continue?"
 
 [INFORMATION]
 INFORMATION_TITLE = "INFORMAÇÃO"

--- a/lang/Russian.ini
+++ b/lang/Russian.ini
@@ -30,6 +30,8 @@ LOBBY_HOST = "хост группы"
 UPDATE_AVAILABLE = "Доступно новое обновление!"
 LATEST_VERSION = "Последняя версия"
 YOUR_VERSION = "Ваша версия"
+FASTDL_FAILED = "\\#ffa0a0\\FastDL:\\#\\ @ file(s) failed, using in-game transfer"
+FASTDL_UNREACHABLE = "\\#ffa0a0\\FastDL:\\#\\ could not connect to '@', using in-game transfer"
 
 [CHAT]
 KICKING = "'@' выгнан!"
@@ -258,6 +260,7 @@ BOUNCY_BOUNDS_ON = "Вкл"
 BOUNCY_BOUNDS_OFF = "Выкл"
 BOUNCY_LEVEL_BOUNDS = "Упругие пределы уровня"
 AMOUNT_OF_PLAYERS = "Количество игроков"
+FASTDL_URL = "Fast Download URL"
 PAUSE_ANYWHERE = "Пауза в любом месте"
 
 [HOST]
@@ -326,6 +329,10 @@ DEBUG_ERRORS = "Ошибки отладки"
 MISC_TITLE = "MISC"
 PAUSE_IN_SINGLEPLAYER = "Пауза в одиночной игре"
 DISABLE_POPUPS = "Отключить всплывающие окна"
+FASTDL_MODE = "Fast Downloads (HTTP)"
+FASTDL_ALWAYS_OFF = "Always Off"
+FASTDL_LET_ME_CHOOSE = "Let Me Choose"
+FASTDL_ALWAYS_ON = "Always On"
 USE_STANDARD_KEY_BINDINGS_CHAT = "Классическое управление чатом"
 MENU_OPTIONS = "Параметры меню"
 INFORMATION = "Информация"
@@ -333,6 +340,12 @@ DEBUG = "Отладка"
 LANGUAGE = "Язык"
 R_BUTTON = "Кнопка [R] - Опции"
 L_BUTTON = "Кнопка [L] - Перезагрузить активные моды"
+
+
+[FASTDL]
+TITLE = "FAST DOWNLOAD"
+POPUP_BODY = "The host wants to send @ files (#) over HTTP from:"
+CONTINUE = "Continue?"
 
 [INFORMATION]
 INFORMATION_TITLE = "INFORMATION"

--- a/lang/Spanish.ini
+++ b/lang/Spanish.ini
@@ -30,6 +30,8 @@ LOBBY_HOST = "la partida del anfitrión"
 UPDATE_AVAILABLE = "¡Nueva actualización!"
 LATEST_VERSION = "Última versión"
 YOUR_VERSION = "Su versión"
+FASTDL_FAILED = "\\#ffa0a0\\FastDL:\\#\\ @ file(s) failed, using in-game transfer"
+FASTDL_UNREACHABLE = "\\#ffa0a0\\FastDL:\\#\\ could not connect to '@', using in-game transfer"
 
 [CHAT]
 KICKING = "'@' ha sido expulsado."
@@ -259,6 +261,7 @@ BOUNCY_BOUNDS_ON = "Activado"
 BOUNCY_BOUNDS_OFF = "Desactivado"
 BOUNCY_LEVEL_BOUNDS = "Límites del nivel rebotantes"
 AMOUNT_OF_PLAYERS = "Número de jugadores"
+FASTDL_URL = "Fast Download URL"
 PAUSE_ANYWHERE = "Pausa en cualquier momento"
 
 [HOST]
@@ -327,6 +330,10 @@ DEBUG_ERRORS = "Errores de Depuración"
 MISC_TITLE = "OTROS"
 PAUSE_IN_SINGLEPLAYER = "Pausa en modo de un jugador"
 DISABLE_POPUPS = "Deshabilitar mensajes emergentes"
+FASTDL_MODE = "Fast Downloads (HTTP)"
+FASTDL_ALWAYS_OFF = "Always Off"
+FASTDL_LET_ME_CHOOSE = "Let Me Choose"
+FASTDL_ALWAYS_ON = "Always On"
 USE_STANDARD_KEY_BINDINGS_CHAT = "Controles de chat clásicos"
 MENU_OPTIONS = "Opciones del menú"
 INFORMATION = "Información"
@@ -334,6 +341,12 @@ DEBUG = "Depuración"
 LANGUAGE = "Idioma"
 R_BUTTON = "Botón [R] - Opciones"
 L_BUTTON = "Botón [L] - Recargar mods activos"
+
+
+[FASTDL]
+TITLE = "FAST DOWNLOAD"
+POPUP_BODY = "The host wants to send @ files (#) over HTTP from:"
+CONTINUE = "Continue?"
 
 [INFORMATION]
 INFORMATION_TITLE = "INFORMACIÓN"

--- a/lang/Swedish.ini
+++ b/lang/Swedish.ini
@@ -32,6 +32,8 @@ LOBBY_HOST = "lobbyns värd"
 UPDATE_AVAILABLE = "En ny uppdatering är tillgänglig!"
 LATEST_VERSION = "Senaste versionen"
 YOUR_VERSION = "Din version"
+FASTDL_FAILED = "\\#ffa0a0\\FastDL:\\#\\ @ file(s) failed, using in-game transfer"
+FASTDL_UNREACHABLE = "\\#ffa0a0\\FastDL:\\#\\ could not connect to '@', using in-game transfer"
 
 [CHAT]
 KICKING = "Kickar '@'!"
@@ -263,6 +265,7 @@ BOUNCY_BOUNDS_ON = "På"
 BOUNCY_BOUNDS_OFF = "Av"
 BOUNCY_LEVEL_BOUNDS = "Studsiga bangränser"
 AMOUNT_OF_PLAYERS = "Antal spelare"
+FASTDL_URL = "Fast Download URL"
 PAUSE_ANYWHERE = "Pausa var som helst"
 
 [HOST]
@@ -332,6 +335,10 @@ DEBUG_ERRORS = "Debug-fel"
 MISC_TITLE = "ÖVRIGT"
 PAUSE_IN_SINGLEPLAYER = "Pausa I enspelarläge"
 DISABLE_POPUPS = "Inaktivera Popups"
+FASTDL_MODE = "Fast Downloads (HTTP)"
+FASTDL_ALWAYS_OFF = "Always Off"
+FASTDL_LET_ME_CHOOSE = "Let Me Choose"
+FASTDL_ALWAYS_ON = "Always On"
 USE_STANDARD_KEY_BINDINGS_CHAT = "Klassiska chattkontroller"
 MENU_OPTIONS = "Menyalternativ"
 INFORMATION = "Info"
@@ -339,6 +346,12 @@ DEBUG = "Debug"
 LANGUAGE = "Språk"
 R_BUTTON = "[R]-Knappen - Inställningar"
 L_BUTTON = "[L]-Knappen - Ladda Om Aktiva Moddar"
+
+
+[FASTDL]
+TITLE = "FAST DOWNLOAD"
+POPUP_BODY = "The host wants to send @ files (#) over HTTP from:"
+CONTINUE = "Continue?"
 
 [INFORMATION]
 INFORMATION_TITLE = "INFO"

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -222,6 +222,9 @@ char         configLanguage[MAX_CONFIG_STRING]    = "";
 bool         configForce4By3                      = false;
 bool         configDynosLocalPlayerModelOnly      = false;
 unsigned int configPvpType                        = PLAYER_PVP_CLASSIC;
+// FastDL settings
+unsigned int configFastDlMode                     = 1; // 0 = always off, 1 = let me choose, 2 = always on
+char         configFastDlUrl[FASTDL_URL_MAX]      = "";
 // CoopNet settings
 char         configCoopNetIp[MAX_CONFIG_STRING]   = DEFAULT_COOPNET_IP;
 unsigned int configCoopNetPort                    = DEFAULT_COOPNET_PORT;
@@ -385,6 +388,9 @@ static const struct ConfigOption options[] = {
     {.name = "language",                       .type = CONFIG_TYPE_STRING, .stringValue = (char*)&configLanguage, .maxStringLength = MAX_CONFIG_STRING},
     {.name = "force_4by3",                     .type = CONFIG_TYPE_BOOL,   .boolValue   = &configForce4By3},
     {.name = "dynos_local_player_model_only",  .type = CONFIG_TYPE_BOOL,   .boolValue   = &configDynosLocalPlayerModelOnly},
+    // FastDL settings
+    {.name = "fastdl_mode",                    .type = CONFIG_TYPE_UINT,   .uintValue   = &configFastDlMode},
+    {.name = "fastdl_url",                     .type = CONFIG_TYPE_STRING, .stringValue = (char*)&configFastDlUrl, .maxStringLength = FASTDL_URL_MAX},
     // CoopNet settings
     {.name = "coopnet_ip",                     .type = CONFIG_TYPE_STRING, .stringValue = (char*)&configCoopNetIp, .maxStringLength = MAX_CONFIG_STRING},
     {.name = "coopnet_port",                   .type = CONFIG_TYPE_UINT,   .uintValue   = &configCoopNetPort},

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -13,6 +13,7 @@
 #define MAX_VOLUME 127
 #define MAX_CONFIG_STRING 64
 #define MAX_SAVE_NAME_STRING 32
+#define FASTDL_URL_MAX 256
 
 #define DEFAULT_PORT 7777
 #define DEFAULT_COOPNET_IP "net.coop64.us"
@@ -161,6 +162,9 @@ extern char         configLanguage[MAX_CONFIG_STRING];
 extern bool         configForce4By3;
 extern bool         configDynosLocalPlayerModelOnly;
 extern unsigned int configPvpType;
+// FastDL settings
+extern unsigned int configFastDlMode;
+extern char         configFastDlUrl[FASTDL_URL_MAX];
 // CoopNet settings
 extern char         configCoopNetIp[MAX_CONFIG_STRING];
 extern unsigned int configCoopNetPort;

--- a/src/pc/djui/djui_panel_host_settings.c
+++ b/src/pc/djui/djui_panel_host_settings.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 #include "djui.h"
 #include "djui_panel.h"
 #include "djui_panel_menu.h"
@@ -43,6 +44,32 @@ static void djui_panel_host_player_text_change(struct DjuiBase* caller) {
         return;
     }
     configAmountOfPlayers = atoi(sPlayerAmount->buffer);
+}
+
+static void djui_panel_host_fastdl_text_change(struct DjuiBase* caller) {
+    struct DjuiInputbox* inputbox = (struct DjuiInputbox*)caller;
+
+    // sanitize as the URL is typed: drop everything the FastDL receiver would reject
+    char cleaned[FASTDL_URL_MAX] = { 0 };
+    u16 writeIndex = 0;
+    for (u16 i = 0; inputbox->buffer[i] != '\0' && writeIndex < FASTDL_URL_MAX - 1; i++) {
+        char c = inputbox->buffer[i];
+        if (c < 0x21 || c > 0x7E || c == '\\' || c == '"') { continue; }
+        cleaned[writeIndex++] = c;
+    }
+    cleaned[writeIndex] = '\0';
+
+    snprintf(configFastDlUrl, FASTDL_URL_MAX, "%s", cleaned);
+
+    struct DjuiTheme* theme = gDjuiThemes[configDjuiTheme];
+    struct DjuiColor* textColor = &theme->interactables.textColor;
+    bool valid = (configFastDlUrl[0] == '\0') ||
+                 (strncmp(configFastDlUrl, "http://", 7) == 0 || strncmp(configFastDlUrl, "https://", 8) == 0);
+    if (valid) {
+        djui_inputbox_set_text_color(inputbox, textColor->r, textColor->g, textColor->b, textColor->a);
+    } else {
+        djui_inputbox_set_text_color(inputbox, 255, 0, 0, 255);
+    }
 }
 
 void djui_panel_host_settings_create(struct DjuiBase* caller) {
@@ -93,6 +120,23 @@ void djui_panel_host_settings_create(struct DjuiBase* caller) {
             djui_inputbox_set_text(inputbox1, limitString);
             djui_interactable_hook_value_change(&inputbox1->base, djui_panel_host_player_text_change);
             sPlayerAmount = inputbox1;
+        }
+
+        struct DjuiRect* rect2 = djui_rect_container_create(body, 32);
+        {
+            struct DjuiText* text2 = djui_text_create(&rect2->base, DLANG(HOST_SETTINGS, FASTDL_URL));
+            djui_base_set_size_type(&text2->base, DJUI_SVT_RELATIVE, DJUI_SVT_ABSOLUTE);
+            djui_base_set_color(&text2->base, 220, 220, 220, 255);
+            djui_base_set_size(&text2->base, 0.585f, 64);
+            djui_base_set_alignment(&text2->base, DJUI_HALIGN_LEFT, DJUI_VALIGN_TOP);
+            djui_text_set_drop_shadow(text2, 64, 64, 64, 100);
+
+            struct DjuiInputbox* inputbox2 = djui_inputbox_create(&rect2->base, FASTDL_URL_MAX);
+            djui_base_set_size_type(&inputbox2->base, DJUI_SVT_RELATIVE, DJUI_SVT_ABSOLUTE);
+            djui_base_set_size(&inputbox2->base, 0.45f, 32);
+            djui_base_set_alignment(&inputbox2->base, DJUI_HALIGN_RIGHT, DJUI_VALIGN_TOP);
+            djui_inputbox_set_text(inputbox2, configFastDlUrl);
+            djui_interactable_hook_value_change(&inputbox2->base, djui_panel_host_fastdl_text_change);
         }
 
         djui_button_create(body, DLANG(MENU, BACK), DJUI_BUTTON_STYLE_BACK, djui_panel_menu_back);

--- a/src/pc/djui/djui_panel_misc.c
+++ b/src/pc/djui/djui_panel_misc.c
@@ -48,6 +48,9 @@ void djui_panel_misc_create(struct DjuiBase* caller) {
     {
         djui_checkbox_create(body, DLANG(DISPLAY, SHOW_PING), &configShowPing, NULL);
         djui_checkbox_create(body, DLANG(MISC, DISABLE_POPUPS), &configDisablePopups, NULL);
+
+        char* fastDlChoices[3] = { DLANG(MISC, FASTDL_ALWAYS_OFF), DLANG(MISC, FASTDL_LET_ME_CHOOSE), DLANG(MISC, FASTDL_ALWAYS_ON) };
+        djui_selectionbox_create(body, DLANG(MISC, FASTDL_MODE), fastDlChoices, 3, &configFastDlMode, NULL);
 #ifndef DEVELOPMENT
         djui_checkbox_create(body, DLANG(MISC, LUA_PROFILER), &configLuaProfiler, NULL);
 #endif

--- a/src/pc/mods/mod_fastdl.c
+++ b/src/pc/mods/mod_fastdl.c
@@ -79,7 +79,9 @@ struct FastDlCtx {
 static char sFastDlUrl[FASTDL_URL_MAX] = { 0 };
 static enum FastDlState sFastDlState = FDLS_IDLE;
 static struct FastDlCtx* sFastDlCtx = NULL;
-static struct FastDlCtx* sFastDlPendingFree = NULL; // aborted transfer awaiting its worker's done signal
+static struct FastDlCtx** sFastDlPendingFree = NULL; // canceled transfers awaiting their workers' done signals
+static u32 sFastDlPendingCount = 0;
+static u32 sFastDlPendingCapacity = 0;
 static volatile u32 sFastDlGeneration = 0;
 static struct ThreadHandle sFastDlThread = { 0 };
 
@@ -94,9 +96,8 @@ static bool sFastDlSessionAnswer = false;
 // URL helpers
 ///////////////////////////////////////////////////////////
 
-bool fastdl_set_url(const char* url) {
-    sFastDlUrl[0] = '\0';
-    if (url == NULL || url[0] == '\0') { return true; }
+bool fastdl_url_valid(const char* url) {
+    if (url == NULL) { return false; }
 
     size_t len = strlen(url);
     if (len == 0 || len >= FASTDL_URL_MAX) { return false; }
@@ -107,16 +108,22 @@ bool fastdl_set_url(const char* url) {
         if (c < 0x21 || c > 0x7E || c == '\\' || c == '"') { return false; }
     }
 
+    const char* schemeSep = strstr(url, "://");
+    size_t hostLen = len - (size_t)(schemeSep - url) - 3;
+    while (hostLen > 0 && schemeSep[3 + hostLen - 1] == '/') { hostLen--; }
+    return hostLen > 0;
+}
+
+bool fastdl_set_url(const char* url) {
+    sFastDlUrl[0] = '\0';
+    if (url == NULL || url[0] == '\0') { return true; }
+
+    if (!fastdl_url_valid(url)) { return false; }
+
     snprintf(sFastDlUrl, FASTDL_URL_MAX, "%s", url);
     size_t dstLen = strlen(sFastDlUrl);
     while (dstLen > 0 && sFastDlUrl[dstLen - 1] == '/') {
         sFastDlUrl[--dstLen] = '\0';
-    }
-    // require a non-empty host part after the scheme
-    const char* schemeSep = strstr(sFastDlUrl, "://");
-    if (schemeSep == NULL || schemeSep[3] == '\0') {
-        sFastDlUrl[0] = '\0';
-        return false;
     }
     return true;
 }
@@ -680,7 +687,7 @@ static void fastdl_popup_create(u32 fileCount, u64 totalBytes) {
 
 // stops the current transfer, if any: the worker is told to stop starting new
 // work; its context is freed right away when it already signaled done, and
-// parked in sFastDlPendingFree for fastdl_update to free once it does
+// parked otherwise for fastdl_update to free once its worker does
 // (the worker never frees the context itself)
 static void fastdl_stop_transfer(void) {
     sFastDlGeneration++;
@@ -690,12 +697,25 @@ static void fastdl_stop_transfer(void) {
     ctx->aborted = true;
     if (ctx->done) {
         fastdl_free_ctx(ctx);
-    } else if (sFastDlPendingFree == NULL || sFastDlPendingFree->done) {
-        if (sFastDlPendingFree != NULL) { fastdl_free_ctx(sFastDlPendingFree); }
-        sFastDlPendingFree = ctx;
+    } else {
+        // the worker stops touching the context right after signaling done;
+        // park it here so fastdl_update can free it then
+        if (sFastDlPendingCount == sFastDlPendingCapacity) {
+            u32 newCapacity = (sFastDlPendingCapacity == 0) ? 4 : sFastDlPendingCapacity * 2;
+            struct FastDlCtx** grown = realloc(sFastDlPendingFree, newCapacity * sizeof(struct FastDlCtx*));
+            if (grown != NULL) {
+                sFastDlPendingFree = grown;
+                sFastDlPendingCapacity = newCapacity;
+            }
+        }
+        if (sFastDlPendingCount < sFastDlPendingCapacity) {
+            sFastDlPendingFree[sFastDlPendingCount++] = ctx;
+        } else {
+            // allocation failed; leak the context rather than risk freeing
+            // one its worker may still touch
+            LOG_ERROR("FastDL: out of memory parking a canceled transfer");
+        }
     }
-    // (in the remaining case - an earlier transfer still in flight - this one
-    // is leaked rather than risk freeing a context its worker may still touch)
 
     sFastDlCtx = NULL;
     sFastDlState = FDLS_IDLE;
@@ -793,14 +813,19 @@ bool fastdl_on_mod_list_done(void) {
 }
 
 void fastdl_update(void) {
-    // an aborted transfer's worker stops touching its context after signaling
-    // done; that is the cue to free it
-    if (sFastDlPendingFree != NULL && sFastDlPendingFree->done) {
-        struct FastDlCtx* ctx = sFastDlPendingFree;
-        sFastDlPendingFree = NULL;
-        __sync_synchronize(); // pair with the worker's barrier before ->done
-        fastdl_free_ctx(ctx);
+    // canceled transfers: each worker stops touching its context after
+    // signaling done; that is the cue to free it
+    u32 keepCount = 0;
+    for (u32 i = 0; i < sFastDlPendingCount; i++) {
+        struct FastDlCtx* ctx = sFastDlPendingFree[i];
+        if (ctx->done) {
+            __sync_synchronize(); // pair with the worker's barrier before ->done
+            fastdl_free_ctx(ctx);
+        } else {
+            sFastDlPendingFree[keepCount++] = ctx;
+        }
     }
+    sFastDlPendingCount = keepCount;
 
     if (sFastDlState != FDLS_DOWNLOADING || sFastDlCtx == NULL) { return; }
 

--- a/src/pc/mods/mod_fastdl.c
+++ b/src/pc/mods/mod_fastdl.c
@@ -1,0 +1,829 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "pc/thread.h"
+#include "pc/platform.h"
+#include "pc/configfile.h"
+#include "pc/debuglog.h"
+#include "pc/utils/misc.h"
+#include "pc/utils/md5.h"
+#include "pc/fs/fs.h"
+#include "pc/mods/mods.h"
+#include "pc/mods/mods_utils.h"
+#include "pc/mods/mod_cache.h"
+#include "pc/mods/mod_fastdl.h"
+#include "pc/djui/djui.h"
+#include "pc/djui/djui_language.h"
+#include "pc/djui/djui_panel.h"
+#include "pc/djui/djui_panel_menu.h"
+#include "pc/djui/djui_panel_join_message.h"
+#include "pc/lua/utils/smlua_misc_utils.h"
+#include "pc/network/network.h"
+#include "pc/network/packets/packet.h"
+
+#if defined(_WIN32)
+#include <windows.h>
+#include <wininet.h>
+#else
+#include <curl/curl.h>
+#endif
+
+#define FASTDL_HTTP_BUFFER       (16 * 1024)
+#define FASTDL_TIMEOUT_MS        5000
+
+enum FastDlState {
+    FDLS_IDLE,
+    FDLS_POPUP,
+    FDLS_DOWNLOADING,
+};
+
+enum FastDlJobResult {
+    FDR_PENDING = 0,
+    FDR_OK,
+    FDR_FAIL,
+};
+
+enum FastDlFetchResult {
+    FETCH_OK = 0,
+    FETCH_FILE_FAILED, // file-level problems (bad status/hash/size) fall back per file
+    FETCH_SERVER_FAILED, // server-level problems (not started, wrong addr, dropped, etc.) abort FastDL and go back to in-game path entirely
+};
+
+struct FastDlJob {
+    // filled by the main thread
+    u16 modIndex;
+    u16 fileIndex;
+    u64 size;
+    u8 dataHash[16];
+    char* url;
+    char* destPath;
+    // written by the worker, read by the main thread after ctx->done
+    volatile enum FastDlJobResult result;
+};
+
+struct FastDlCtx {
+    u32 generation;
+    struct FastDlJob* jobs;
+    u32 jobCount;
+    f32 startTime;
+    volatile u64 totalBytes;
+    volatile u64 doneBytes;
+    volatile u32 jobsSucceeded;
+    volatile bool unreachable;
+    volatile bool aborted;     // set by the main thread to stop the worker
+    volatile bool done;        // set by the worker as its very last write
+};
+
+static char sFastDlUrl[FASTDL_URL_MAX] = { 0 };
+static enum FastDlState sFastDlState = FDLS_IDLE;
+static struct FastDlCtx* sFastDlCtx = NULL;
+static struct FastDlCtx* sFastDlPendingFree = NULL; // aborted transfer awaiting its worker's done signal
+static volatile u32 sFastDlGeneration = 0;
+static struct ThreadHandle sFastDlThread = { 0 };
+
+static bool sFastDlAnswerYes = false;
+
+// sticky answer for "let me choose": ask once per connection attempt, then
+// reuse the answer across the join flow's reconnect cycles
+static bool sFastDlAskedSession = false;
+static bool sFastDlSessionAnswer = false;
+
+///////////////////////////////////////////////////////////
+// URL helpers
+///////////////////////////////////////////////////////////
+
+bool fastdl_set_url(const char* url) {
+    sFastDlUrl[0] = '\0';
+    if (url == NULL || url[0] == '\0') { return true; }
+
+    size_t len = strlen(url);
+    if (len == 0 || len >= FASTDL_URL_MAX) { return false; }
+    if (strncmp(url, "http://", 7) != 0 && strncmp(url, "https://", 8) != 0) { return false; }
+
+    for (size_t i = 0; i < len; i++) {
+        char c = url[i];
+        if (c < 0x21 || c > 0x7E || c == '\\' || c == '"') { return false; }
+    }
+
+    snprintf(sFastDlUrl, FASTDL_URL_MAX, "%s", url);
+    size_t dstLen = strlen(sFastDlUrl);
+    while (dstLen > 0 && sFastDlUrl[dstLen - 1] == '/') {
+        sFastDlUrl[--dstLen] = '\0';
+    }
+    // require a non-empty host part after the scheme
+    const char* schemeSep = strstr(sFastDlUrl, "://");
+    if (schemeSep == NULL || schemeSep[3] == '\0') {
+        sFastDlUrl[0] = '\0';
+        return false;
+    }
+    return true;
+}
+
+void fastdl_clear_url(void) {
+    sFastDlUrl[0] = '\0';
+}
+
+static void fastdl_url_encode(const char* in, char* out, size_t outSize) {
+    static const char* hex = "0123456789ABCDEF";
+    size_t o = 0;
+    for (const char* p = in; *p != '\0' && o + 4 < outSize; p++) {
+        char c = *p;
+        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+            c == '-' || c == '.' || c == '_' || c == '~' || c == '/') {
+            out[o++] = c;
+        } else {
+            out[o++] = '%';
+            out[o++] = hex[((u8)c >> 4) & 0xF];
+            out[o++] = hex[(u8)c & 0xF];
+        }
+    }
+    out[o] = '\0';
+}
+
+// builds "<base>/<mod relative path>/<file relative path>", mirroring the host's mods/ folder layout
+static bool fastdl_build_file_url(char* out, size_t outSize, const struct Mod* mod, const struct ModFile* file) {
+    char relPath[SYS_MAX_PATH] = { 0 };
+    if (mod->isDirectory) {
+        if (snprintf(relPath, SYS_MAX_PATH, "%s/%s", mod->relativePath, file->relativePath) < 0) { return false; }
+    } else {
+        if (snprintf(relPath, SYS_MAX_PATH, "%s", file->relativePath) < 0) { return false; }
+    }
+
+    if (path_has_traversal(mod->relativePath) || path_has_traversal(file->relativePath)) {
+        LOG_ERROR("FastDL: refusing to traverse '%s'", relPath);
+        return false;
+    }
+
+    for (char* p = relPath; *p != '\0'; p++) {
+        if (*p == '\\') { *p = '/'; }
+    }
+
+    char encoded[SYS_MAX_PATH] = { 0 };
+    fastdl_url_encode(relPath, encoded, SYS_MAX_PATH);
+
+    int written = snprintf(out, outSize, "%s/%s", sFastDlUrl, encoded);
+    return (written > 0 && (size_t)written < outSize);
+}
+
+static void fastdl_format_size(u64 bytes, char* out, size_t outSize) {
+    if (bytes >= (1024 * 1024)) {
+        snprintf(out, outSize, "%.1f MB", (f64)bytes / (1024.0 * 1024.0));
+    } else if (bytes >= 1024) {
+        snprintf(out, outSize, "%.1f KB", (f64)bytes / 1024.0);
+    } else {
+        snprintf(out, outSize, "%u B", (u32)bytes);
+    }
+}
+
+///////////////////////////////////////////////////////////
+// HTTP fetch (WinINet on Windows, libcurl elsewhere)
+///////////////////////////////////////////////////////////
+
+#if defined(_WIN32)
+
+static enum FastDlFetchResult fastdl_http_fetch(const char* url, FILE* fp, MD5_CTX* md5, u64 maxBytes, u64 startBytes, volatile u64* progressBytes, volatile bool* abortFlag) {
+    HINTERNET hInternet = NULL;
+    HINTERNET hUrl = NULL;
+    enum FastDlFetchResult ret = FETCH_FILE_FAILED;
+    u64 total = 0;
+
+    hInternet = InternetOpenA("sm64coopdx-fastdl", INTERNET_OPEN_TYPE_DIRECT, NULL, NULL, 0);
+    if (hInternet == NULL) { return FETCH_SERVER_FAILED; }
+
+    DWORD timeout = FASTDL_TIMEOUT_MS;
+    InternetSetOptionA(hInternet, INTERNET_OPTION_CONNECT_TIMEOUT, &timeout, sizeof(timeout));
+    InternetSetOptionA(hInternet, INTERNET_OPTION_SEND_TIMEOUT, &timeout, sizeof(timeout));
+    InternetSetOptionA(hInternet, INTERNET_OPTION_RECEIVE_TIMEOUT, &timeout, sizeof(timeout));
+    DWORD retries = 1; // don't let WinINet stack its own connect retries on top of the timeout
+    InternetSetOptionA(hInternet, INTERNET_OPTION_CONNECT_RETRIES, &retries, sizeof(retries));
+
+    hUrl = InternetOpenUrlA(hInternet, url, NULL, 0,
+        INTERNET_FLAG_RELOAD | INTERNET_FLAG_NO_CACHE_WRITE | INTERNET_FLAG_PRAGMA_NOCACHE, 0);
+    if (hUrl == NULL) {
+        LOG_ERROR("FastDL: failed to open '%s' (%lu)", url, GetLastError());
+        ret = FETCH_SERVER_FAILED;
+        goto cleanup;
+    }
+
+    DWORD status = 0;
+    DWORD statusSize = sizeof(status);
+    if (!HttpQueryInfoA(hUrl, HTTP_QUERY_STATUS_CODE | HTTP_QUERY_FLAG_NUMBER, &status, &statusSize, NULL) || status != 200) {
+        LOG_ERROR("FastDL: '%s' answered status %lu", url, status);
+        goto cleanup;
+    }
+
+    {
+        u8 buffer[FASTDL_HTTP_BUFFER];
+        while (true) {
+            if (abortFlag != NULL && *abortFlag) { goto cleanup; }
+            DWORD bytesRead = 0;
+            if (!InternetReadFile(hUrl, buffer, sizeof(buffer), &bytesRead)) {
+                LOG_ERROR("FastDL: read failed for '%s' (%lu)", url, GetLastError());
+                ret = FETCH_SERVER_FAILED;
+                goto cleanup;
+            }
+            if (bytesRead == 0) { break; }
+            total += bytesRead;
+            if (total > maxBytes) { // maxBytes == 0 means the file should be empty
+                LOG_ERROR("FastDL: '%s' sent more bytes than expected", url);
+                goto cleanup;
+            }
+            if (fwrite(buffer, sizeof(u8), bytesRead, fp) != bytesRead) {
+                LOG_ERROR("FastDL: write failed for '%s' (%s)", url, strerror(errno));
+                goto cleanup;
+            }
+            MD5_Update(md5, buffer, bytesRead);
+            if (progressBytes != NULL) { *progressBytes = startBytes + total; }
+        }
+    }
+
+    ret = FETCH_OK;
+
+cleanup:
+    if (hUrl != NULL) { InternetCloseHandle(hUrl); }
+    if (hInternet != NULL) { InternetCloseHandle(hInternet); }
+    return ret;
+}
+
+#else
+
+static bool sFastDlInited = false;
+
+static void fastdl_curl_init(void) {
+    // must be called from the main thread
+    if (!sFastDlInited) {
+        curl_global_init(CURL_GLOBAL_ALL);
+        sFastDlInited = true;
+    }
+}
+
+struct FastDlCurlData {
+    FILE* fp;
+    MD5_CTX* md5;
+    u64 maxBytes;
+    u64 startBytes;
+    volatile u64* progressBytes;
+    volatile bool* abortFlag;
+    u64 total;
+    bool overflow;
+};
+
+static size_t fastdl_curl_write_cb(char* ptr, size_t size, size_t nmemb, void* userdata) {
+    struct FastDlCurlData* data = userdata;
+    size_t bytes = size * nmemb;
+
+    if (data->abortFlag != NULL && *data->abortFlag) { return 0; }
+
+    data->total += bytes;
+    if (data->total > data->maxBytes) { // maxBytes == 0 means the file should be empty
+        data->overflow = true;
+        return 0;
+    }
+    if (fwrite(ptr, sizeof(u8), bytes, data->fp) != bytes) { return 0; }
+    MD5_Update(data->md5, ptr, bytes);
+    if (data->progressBytes != NULL) { *data->progressBytes = data->startBytes + data->total; }
+    return bytes;
+}
+
+static enum FastDlFetchResult fastdl_http_fetch(const char* url, FILE* fp, MD5_CTX* md5, u64 maxBytes, u64 startBytes, volatile u64* progressBytes, volatile bool* abortFlag) {
+    struct FastDlCurlData data = { 0 };
+    data.fp = fp;
+    data.md5 = md5;
+    data.maxBytes = maxBytes;
+    data.startBytes = startBytes;
+    data.progressBytes = progressBytes;
+    data.abortFlag = abortFlag;
+
+    CURL* curl = curl_easy_init();
+    if (curl == NULL) { return FETCH_FILE_FAILED; }
+
+    long timeout = FASTDL_TIMEOUT_MS / 1000;
+    curl_easy_setopt(curl, CURLOPT_URL, url);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, fastdl_curl_write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &data);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, timeout);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 15L);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+
+    CURLcode res = curl_easy_perform(curl);
+
+    long status = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status);
+    curl_easy_cleanup(curl);
+
+    if (res != CURLE_OK) {
+        if (!data.overflow && !(abortFlag != NULL && *abortFlag)) {
+            LOG_ERROR("FastDL: request failed for '%s' (%s)", url, curl_easy_strerror(res));
+        }
+        // connection-level failures mean the whole phase is pointless
+        switch (res) {
+            case CURLE_COULDNT_RESOLVE_HOST:
+            case CURLE_COULDNT_CONNECT:
+            case CURLE_OPERATION_TIMEDOUT:
+            case CURLE_RECV_ERROR:
+                return FETCH_SERVER_FAILED;
+            default:
+                return FETCH_FILE_FAILED;
+        }
+    }
+    if (data.overflow) {
+        LOG_ERROR("FastDL: '%s' sent more bytes than expected", url);
+        return FETCH_FILE_FAILED;
+    }
+    if (status != 200) {
+        LOG_ERROR("FastDL: '%s' answered status %ld", url, status);
+        return FETCH_FILE_FAILED;
+    }
+    return FETCH_OK;
+}
+
+#endif
+
+///////////////////////////////////////////////////////////
+// download worker
+///////////////////////////////////////////////////////////
+
+static enum FastDlFetchResult fastdl_download_file(struct FastDlCtx* ctx, struct FastDlJob* job) {
+    enum FastDlFetchResult ret = FETCH_FILE_FAILED;
+    FILE* fp = NULL;
+
+    char partPath[SYS_MAX_PATH] = { 0 };
+    int partPathLen = snprintf(partPath, SYS_MAX_PATH, "%s.part", job->destPath);
+    if (partPathLen < 0 || partPathLen >= SYS_MAX_PATH) { return FETCH_FILE_FAILED; }
+
+    fp = fopen(partPath, "wb");
+    if (fp == NULL) {
+        LOG_ERROR("FastDL: unable to open '%s' for write (%s)", partPath, strerror(errno));
+        return FETCH_FILE_FAILED;
+    }
+
+    MD5_CTX md5 = { 0 };
+    MD5_Init(&md5);
+
+    u64 startBytes = ctx->doneBytes;
+    ret = fastdl_http_fetch(job->url, fp, &md5, job->size, startBytes, &ctx->doneBytes, &ctx->aborted);
+    if (ret != FETCH_OK) {
+        goto cleanup;
+    }
+    fclose(fp);
+    fp = NULL;
+
+    u64 fetched = ctx->doneBytes - startBytes;
+    if (fetched != job->size) {
+        LOG_ERROR("FastDL: '%s' sent %llu bytes, expected %llu", job->url, (u64)fetched, (u64)job->size);
+        goto cleanup;
+    }
+
+    // verify against the hash the host advertised in the mod list
+    {
+        u8 hash[16] = { 0 };
+        MD5_Final(hash, &md5);
+        if (memcmp(hash, job->dataHash, 16) != 0) {
+            LOG_ERROR("FastDL: hash mismatch for '%s'", job->url);
+            goto cleanup;
+        }
+    }
+
+    remove(job->destPath);
+    if (rename(partPath, job->destPath) != 0) {
+        LOG_ERROR("FastDL: failed to move '%s' to '%s' (%s)", partPath, job->destPath, strerror(errno));
+        goto cleanup;
+    }
+
+    LOG_INFO("FastDL: downloaded and verified '%s'", job->url);
+    ret = FETCH_OK;
+
+cleanup:
+    if (fp != NULL) { fclose(fp); }
+    if (ret != FETCH_OK) { remove(partPath); }
+    return ret;
+}
+
+// display side only: the worker just bumps ctx->doneBytes, all UI math
+// happens here on the main thread
+static void fastdl_update_progress(struct FastDlCtx* ctx) {
+    if (ctx->totalBytes > 0) {
+        gDownloadProgress = (f32)ctx->doneBytes / (f32)ctx->totalBytes;
+    } else {
+        gDownloadProgress = 1.0f;
+    }
+
+    f32 elapsed = clock_elapsed() - ctx->startTime;
+    u64 remaining = (ctx->doneBytes < ctx->totalBytes) ? (ctx->totalBytes - ctx->doneBytes) : 0;
+    if (ctx->doneBytes > 0 && remaining > 0 && elapsed > 0.1f) {
+        f32 bytesPerSecond = (f32)ctx->doneBytes / elapsed;
+        u32 seconds = (u32)((remaining / bytesPerSecond) + 1);
+        u32 minutes = seconds / 60;
+        u32 hours = minutes / 60;
+        seconds %= 60;
+        minutes %= 60;
+        if (hours) {
+            snprintf(gDownloadEstimate, DOWNLOAD_ESTIMATE_LENGTH, "FastDL %uh %um", hours, minutes);
+        } else if (minutes) {
+            snprintf(gDownloadEstimate, DOWNLOAD_ESTIMATE_LENGTH, "FastDL %um %us", minutes, seconds);
+        } else {
+            snprintf(gDownloadEstimate, DOWNLOAD_ESTIMATE_LENGTH, "FastDL %us", seconds);
+        }
+    }
+}
+
+static void* fastdl_worker(void* arg) {
+    struct FastDlCtx* ctx = arg;
+
+    for (u32 i = 0; i < ctx->jobCount; i++) {
+        struct FastDlJob* job = &ctx->jobs[i];
+        if (ctx->aborted || ctx->generation != sFastDlGeneration) {
+            break; // the main thread moved on; it owns the context again
+        }
+        if (job->url == NULL || job->destPath == NULL) {
+            // job was never built; the file just stays on the chunk path
+            continue;
+        }
+
+        enum FastDlFetchResult res = fastdl_download_file(ctx, job);
+        if (res == FETCH_OK) {
+            job->result = FDR_OK;
+            ctx->jobsSucceeded++;
+        } else {
+            job->result = FDR_FAIL;
+            if (res == FETCH_SERVER_FAILED) {
+                // server unreachable (not started, wrong address, dropped):
+                // likely to repeat - go back to in-game download path
+                ctx->unreachable = true;
+                break;
+            }
+        }
+    }
+
+    // make every prior write visible before signaling completion; done is
+    // this thread's very last write, after which it never touches ctx again
+    // and the main thread is free to apply the results and free the context
+    __sync_synchronize();
+    ctx->done = true;
+    return NULL;
+}
+
+///////////////////////////////////////////////////////////
+// job building + result application (main thread)
+///////////////////////////////////////////////////////////
+
+static void fastdl_free_ctx(struct FastDlCtx* ctx) {
+    for (u32 i = 0; i < ctx->jobCount; i++) {
+        if (ctx->jobs[i].url != NULL) { free(ctx->jobs[i].url); }
+        if (ctx->jobs[i].destPath != NULL) { free(ctx->jobs[i].destPath); }
+    }
+    free(ctx->jobs);
+    free(ctx);
+}
+
+static struct FastDlCtx* fastdl_build_ctx(void) {
+    u32 jobCount = 0;
+    u64 totalBytes = 0;
+    for (u16 i = 0; i < gRemoteMods.entryCount; i++) {
+        struct Mod* mod = gRemoteMods.entries[i];
+        if (mod == NULL) { continue; }
+        for (u16 j = 0; j < mod->fileCount; j++) {
+            struct ModFile* file = &mod->files[j];
+            if (file->cachedPath != NULL) { continue; }
+            jobCount++;
+            totalBytes += file->size;
+        }
+    }
+    if (jobCount == 0) { return NULL; }
+
+    struct FastDlCtx* ctx = calloc(1, sizeof(struct FastDlCtx));
+    struct FastDlJob* jobs = calloc(jobCount, sizeof(struct FastDlJob));
+    if (ctx == NULL || jobs == NULL) {
+        free(ctx);
+        free(jobs);
+        return NULL;
+    }
+
+    ctx->jobs = jobs;
+    ctx->jobCount = jobCount;
+    ctx->totalBytes = totalBytes;
+
+    u32 jobIndex = 0;
+    for (u16 i = 0; i < gRemoteMods.entryCount; i++) {
+        struct Mod* mod = gRemoteMods.entries[i];
+        if (mod == NULL) { continue; }
+        for (u16 j = 0; j < mod->fileCount; j++) {
+            struct ModFile* file = &mod->files[j];
+            if (file->cachedPath != NULL) { continue; }
+
+            struct FastDlJob* job = &jobs[jobIndex];
+            job->modIndex = i;
+            job->fileIndex = j;
+            job->size = file->size;
+            memcpy(job->dataHash, file->dataHash, sizeof(u8) * 16);
+
+            char destPath[SYS_MAX_PATH] = { 0 };
+            if (!mod_file_full_path(destPath, mod, file)) {
+                LOG_ERROR("FastDL: could not build destination path for '%s'", file->relativePath);
+                jobIndex++;
+                continue;
+            }
+            mod_file_create_directories(mod, file);
+            job->destPath = strdup(destPath);
+
+            char url[SYS_MAX_PATH] = { 0 };
+            if (job->destPath == NULL || !fastdl_build_file_url(url, SYS_MAX_PATH, mod, file)) {
+                LOG_ERROR("FastDL: could not build URL for '%s', falling back", file->relativePath);
+                jobIndex++;
+                continue;
+            }
+            job->url = strdup(url);
+            jobIndex++;
+        }
+    }
+
+    // jobs that failed to build fall back to the chunk path; don't count their bytes
+    for (u32 i = 0; i < ctx->jobCount; i++) {
+        if (ctx->jobs[i].url == NULL || ctx->jobs[i].destPath == NULL) {
+            ctx->totalBytes -= ctx->jobs[i].size;
+        }
+    }
+
+    return ctx;
+}
+
+static void fastdl_apply_results(struct FastDlCtx* ctx) {
+    u32 failed = 0;
+
+    for (u32 i = 0; i < ctx->jobCount; i++) {
+        struct FastDlJob* job = &ctx->jobs[i];
+        if (job->url == NULL || job->destPath == NULL) {
+            // job was never built; the file just stays on the chunk path
+            continue;
+        }
+        if (job->result != FDR_OK) {
+            if (job->result == FDR_FAIL) { failed++; }
+            continue;
+        }
+        if (job->modIndex >= gRemoteMods.entryCount) { continue; }
+        struct Mod* mod = gRemoteMods.entries[job->modIndex];
+        if (mod == NULL || job->fileIndex >= mod->fileCount) { continue; }
+        struct ModFile* file = &mod->files[job->fileIndex];
+        if (file->cachedPath == NULL && mod_should_cache(mod)) {
+            // mod_cache_add hashes the verified file and registers it in mod.cache
+            mod_cache_add(mod, file, false);
+        } else if (file->cachedPath == NULL) {
+            // WIP mods are never cached; just mark the file as present
+            char modFilePath[SYS_MAX_PATH] = { 0 };
+            if (concat_path(modFilePath, mod->basePath, file->relativePath)) {
+                normalize_path(modFilePath);
+                file->cachedPath = strdup(modFilePath);
+            }
+        }
+    }
+
+    if (ctx->unreachable) {
+        LOG_ERROR("FastDL: could not connect to '%s', using in-game transfer", sFastDlUrl);
+        char message[FASTDL_URL_MAX + 128] = { 0 };
+        djui_language_replace(DLANG(NOTIF, FASTDL_UNREACHABLE), message, sizeof(message), '@', sFastDlUrl);
+        djui_popup_create(message, 2);
+    } else if (failed > 0) {
+        LOG_INFO("FastDL: %u file(s) failed, using in-game transfer for them", failed);
+        char countStr[16] = { 0 };
+        snprintf(countStr, sizeof(countStr), "%u", failed);
+        char message[160] = { 0 };
+        djui_language_replace(DLANG(NOTIF, FASTDL_FAILED), message, sizeof(message), '@', countStr);
+        djui_popup_create(message, 2);
+    }
+
+    network_start_download_requests();
+}
+
+///////////////////////////////////////////////////////////
+// "let me choose" popup
+///////////////////////////////////////////////////////////
+
+static void fastdl_begin(void);
+
+static bool fastdl_popup_back(UNUSED struct DjuiBase* base) {
+    if (sFastDlState != FDLS_POPUP) {
+        return false; // stale popup (the connection went away); just close it
+    }
+
+    bool accept = sFastDlAnswerYes;
+    sFastDlAnswerYes = false;
+    sFastDlSessionAnswer = accept;
+    sFastDlState = FDLS_IDLE;
+
+    if (accept) {
+        fastdl_begin();
+    } else {
+        network_start_download_requests();
+    }
+    return false; // let the default back logic close the popup
+}
+
+static void fastdl_popup_yes(struct DjuiBase* caller) {
+    sFastDlAnswerYes = true;
+    djui_panel_menu_back(caller);
+}
+
+static void fastdl_popup_no(struct DjuiBase* caller) {
+    sFastDlAnswerYes = false;
+    djui_panel_menu_back(caller);
+}
+
+static void fastdl_popup_create(u32 fileCount, u64 totalBytes) {
+    static char sMessage[1024];
+
+    sFastDlAnswerYes = false;
+
+    char filesStr[16] = { 0 };
+    char sizeStr[32] = { 0 };
+    snprintf(filesStr, sizeof(filesStr), "%u", fileCount);
+    fastdl_format_size(totalBytes, sizeStr, sizeof(sizeStr));
+
+    char body[384] = { 0 };
+    djui_language_replace2(DLANG(FASTDL, POPUP_BODY), body, sizeof(body), '@', filesStr, '#', sizeStr);
+    snprintf(sMessage, sizeof(sMessage), "%s\n\\#a0a0ff\\%s\\#\\\n\n%s", body, sFastDlUrl, DLANG(FASTDL, CONTINUE));
+
+    struct DjuiThreePanel* panel = djui_panel_menu_create(DLANG(FASTDL, TITLE), false);
+    panel->on_back = fastdl_popup_back;
+    struct DjuiBase* bodyBase = djui_three_panel_get_body(panel);
+    {
+        struct DjuiText* text = djui_text_create(bodyBase, sMessage);
+        djui_base_set_size_type(&text->base, DJUI_SVT_RELATIVE, DJUI_SVT_ABSOLUTE);
+
+        djui_base_set_size(&text->base, 1.0f, 64);
+        djui_base_compute_tree(&text->base);
+        u16 lines = djui_text_count_lines(text, 12);
+        f32 textHeight = 32 * 0.8125f * lines + 8;
+        djui_base_set_size(&text->base, 1.0f, textHeight);
+        djui_base_set_color(&text->base, 220, 220, 220, 255);
+        djui_text_set_alignment(text, DJUI_HALIGN_CENTER, DJUI_VALIGN_TOP);
+
+        struct DjuiRect* rect = djui_rect_container_create(bodyBase, 64);
+        {
+            djui_button_left_create(&rect->base, DLANG(MENU, NO), DJUI_BUTTON_STYLE_NORMAL, fastdl_popup_no);
+            djui_button_right_create(&rect->base, DLANG(MENU, YES), DJUI_BUTTON_STYLE_NORMAL, fastdl_popup_yes);
+        }
+    }
+
+    djui_panel_add(NULL, panel, NULL);
+    sFastDlState = FDLS_POPUP;
+}
+
+///////////////////////////////////////////////////////////
+// public flow
+///////////////////////////////////////////////////////////
+
+// stops the current transfer, if any: the worker is told to stop starting new
+// work; its context is freed right away when it already signaled done, and
+// parked in sFastDlPendingFree for fastdl_update to free once it does
+// (the worker never frees the context itself)
+static void fastdl_stop_transfer(void) {
+    sFastDlGeneration++;
+    struct FastDlCtx* ctx = sFastDlCtx;
+    if (ctx == NULL) { return; }
+
+    ctx->aborted = true;
+    if (ctx->done) {
+        fastdl_free_ctx(ctx);
+    } else if (sFastDlPendingFree == NULL || sFastDlPendingFree->done) {
+        if (sFastDlPendingFree != NULL) { fastdl_free_ctx(sFastDlPendingFree); }
+        sFastDlPendingFree = ctx;
+    }
+    // (in the remaining case - an earlier transfer still in flight - this one
+    // is leaked rather than risk freeing a context its worker may still touch)
+
+    sFastDlCtx = NULL;
+    sFastDlState = FDLS_IDLE;
+}
+
+static void fastdl_begin(void) {
+    if (sFastDlUrl[0] == '\0') {
+        // the connection went away while the popup was up; let the chunk path wrap up
+        network_start_download_requests();
+        return;
+    }
+
+    struct FastDlCtx* ctx = fastdl_build_ctx();
+    if (ctx == NULL) {
+        // nothing left to fetch; let the chunk path wrap up (it will skip straight to the join)
+        network_start_download_requests();
+        return;
+    }
+
+#ifndef _WIN32
+    fastdl_curl_init();
+#endif
+
+    // safety: stop any transfer that is somehow still around before replacing it
+    fastdl_stop_transfer();
+
+    ctx->generation = sFastDlGeneration;
+    sFastDlCtx = ctx;
+    sFastDlState = FDLS_DOWNLOADING;
+
+    gDownloadProgress = 0;
+    gDownloadProgressInf = 0;
+    snprintf(gDownloadEstimate, DOWNLOAD_ESTIMATE_LENGTH, "FastDL");
+    ctx->startTime = clock_elapsed();
+
+    LOG_INFO("FastDL: downloading %u file(s), %llu bytes from '%s'", ctx->jobCount, (u64)ctx->totalBytes, sFastDlUrl);
+
+    if (init_thread(&sFastDlThread, fastdl_worker, ctx, NULL, 0) != 0) {
+        LOG_ERROR("FastDL: failed to spawn worker thread");
+        sFastDlCtx = NULL;
+        sFastDlState = FDLS_IDLE;
+        fastdl_free_ctx(ctx);
+        network_start_download_requests();
+        return;
+    }
+    detach_thread(&sFastDlThread);
+}
+
+bool fastdl_on_mod_list_done(void) {
+    if (gNetworkType != NT_CLIENT) { return false; }
+    if (sFastDlState != FDLS_IDLE) { return true; } // already took over the flow
+    if (sFastDlUrl[0] == '\0') { return false; }    // host doesn't offer FastDL
+
+    u32 uncached = 0;
+    u64 totalBytes = 0;
+    for (u16 i = 0; i < gRemoteMods.entryCount; i++) {
+        struct Mod* mod = gRemoteMods.entries[i];
+        if (mod == NULL) { continue; }
+        for (u16 j = 0; j < mod->fileCount; j++) {
+            struct ModFile* file = &mod->files[j];
+            if (file->cachedPath != NULL) { continue; }
+            uncached++;
+            totalBytes += file->size;
+        }
+    }
+    if (uncached == 0) { return false; }
+
+    switch (configFastDlMode) {
+        case FDLM_ALWAYS_ON:
+            fastdl_begin();
+            return true;
+
+        case FDLM_ALWAYS_OFF:
+            return false;
+
+        case FDLM_LET_ME_CHOOSE:
+        default: {
+            if (sFastDlAskedSession) {
+                if (sFastDlSessionAnswer) {
+                    fastdl_begin();
+                    return true;
+                }
+                return false;
+            }
+
+            if (djui_is_popup_disabled()) {
+                LOG_INFO("FastDL: popups disabled, defaulting to in-game transfer");
+                return false;
+            }
+            sFastDlAskedSession = true;
+            fastdl_popup_create(uncached, totalBytes);
+            return true;
+        }
+    }
+}
+
+void fastdl_update(void) {
+    // an aborted transfer's worker stops touching its context after signaling
+    // done; that is the cue to free it
+    if (sFastDlPendingFree != NULL && sFastDlPendingFree->done) {
+        struct FastDlCtx* ctx = sFastDlPendingFree;
+        sFastDlPendingFree = NULL;
+        __sync_synchronize(); // pair with the worker's barrier before ->done
+        fastdl_free_ctx(ctx);
+    }
+
+    if (sFastDlState != FDLS_DOWNLOADING || sFastDlCtx == NULL) { return; }
+
+    fastdl_update_progress(sFastDlCtx);
+
+    if (sFastDlCtx->done) {
+        struct FastDlCtx* ctx = sFastDlCtx;
+        sFastDlCtx = NULL;
+        sFastDlState = FDLS_IDLE;
+        if (ctx->generation == sFastDlGeneration) {
+            fastdl_apply_results(ctx);
+        }
+        fastdl_free_ctx(ctx);
+    }
+}
+
+void fastdl_shutdown(bool reconnecting) {
+    fastdl_stop_transfer();
+    fastdl_clear_url();
+
+    // the sticky answer only survives auto-reconnects, not full disconnects
+    if (!reconnecting) {
+        sFastDlAskedSession = false;
+        sFastDlSessionAnswer = false;
+    }
+}

--- a/src/pc/mods/mod_fastdl.h
+++ b/src/pc/mods/mod_fastdl.h
@@ -12,6 +12,7 @@ enum FastDlMode {
 
 // called by the mod list packet handlers
 bool fastdl_set_url(const char* url); // empty string clears
+bool fastdl_url_valid(const char* url); // receiver-equivalent check; doesn't touch state
 void fastdl_clear_url(void);
 
 // returns true when FastDL took over the join flow (caller must not start the chunk path)

--- a/src/pc/mods/mod_fastdl.h
+++ b/src/pc/mods/mod_fastdl.h
@@ -1,0 +1,27 @@
+#ifndef MOD_FASTDL_H
+#define MOD_FASTDL_H
+
+#include <stdbool.h>
+#include <PR/ultratypes.h>
+
+enum FastDlMode {
+    FDLM_ALWAYS_OFF    = 0,
+    FDLM_LET_ME_CHOOSE = 1,
+    FDLM_ALWAYS_ON     = 2,
+};
+
+// called by the mod list packet handlers
+bool fastdl_set_url(const char* url); // empty string clears
+void fastdl_clear_url(void);
+
+// returns true when FastDL took over the join flow (caller must not start the chunk path)
+bool fastdl_on_mod_list_done(void);
+
+// per-frame main-thread poll; applies finished downloads and continues the join flow
+void fastdl_update(void);
+
+// aborts any running downloads; call from network_shutdown
+// (a sticky "let me choose" answer survives reconnects but not full disconnects)
+void fastdl_shutdown(bool reconnecting);
+
+#endif // MOD_FASTDL_H

--- a/src/pc/mods/mods_utils.c
+++ b/src/pc/mods/mods_utils.c
@@ -15,6 +15,17 @@
 #include <mach-o/dyld.h>
 #endif
 
+bool mod_should_cache(struct Mod *mod) {
+    char modNameLowercase[MOD_NAME_SIZE];
+    memcpy(modNameLowercase, mod->name, MOD_NAME_SIZE * sizeof(char));
+    sys_strlwr(modNameLowercase);
+    bool shouldCache = (
+        !strstr(modNameLowercase, "(wip)") &&
+        !strstr(modNameLowercase, "[wip]")
+    );
+    return shouldCache;
+}
+
 void mods_size_enforce(struct Mods* mods) {
     for (int i = 0; i < mods->entryCount; i++) {
         struct Mod* mod = mods->entries[i];

--- a/src/pc/mods/mods_utils.h
+++ b/src/pc/mods/mods_utils.h
@@ -9,6 +9,8 @@ void mods_size_enforce(struct Mods* mods);
 void mods_update_selectable(void);
 void mods_delete_tmp(void);
 
+bool mod_should_cache(struct Mod* mod);
+
 bool mod_file_full_path(char* destination, struct Mod* mod, struct ModFile* modFile);
 bool mod_file_create_directories(struct Mod* mod, struct ModFile* modFile);
 

--- a/src/pc/network/network.c
+++ b/src/pc/network/network.c
@@ -18,6 +18,7 @@
 #include "pc/lua/utils/smlua_camera_utils.h"
 #include "pc/lua/utils/smlua_gfx_utils.h"
 #include "pc/mods/mods.h"
+#include "pc/mods/mod_fastdl.h"
 #include "pc/crash_handler.h"
 #include "pc/debuglog.h"
 #include "pc/pc_main.h"
@@ -564,6 +565,8 @@ void network_update(void) {
         gNetworkStartupTimer--;
     }
 
+    fastdl_update();
+
     network_rehost_update();
     network_reconnect_update();
 
@@ -673,6 +676,9 @@ void network_mod_dev_mode_reload(void) {
 
 void network_shutdown(bool sendLeaving, bool exiting, bool popup, bool reconnecting) {
     smlua_call_event_hooks(HOOK_ON_EXIT);
+
+    // stop any FastDL transfer before the remote mods go away
+    fastdl_shutdown(reconnecting);
 
     if (gDjuiChatBox != NULL) {
         djui_base_destroy(&gDjuiChatBox->base);

--- a/src/pc/network/packets/packet_download.c
+++ b/src/pc/network/packets/packet_download.c
@@ -316,18 +316,6 @@ after_filled:;
     //LOG_INFO("Sent chunk: offset %llu, length %llu", requestOffset, chunkFill);
 }
 
-// Cache any mod that doesn't have "(wip)" or "[wip]" in its name (case-insensitive)
-static bool should_cache_mod(struct Mod *mod) {
-    char modNameLowercase[MOD_NAME_SIZE];
-    memcpy(modNameLowercase, mod->name, MOD_NAME_SIZE * sizeof(char));
-    sys_strlwr(modNameLowercase);
-    bool shouldCache = (
-        !strstr(modNameLowercase, "(wip)") &&
-        !strstr(modNameLowercase, "[wip]")
-    );
-    return shouldCache;
-}
-
 static void open_mod_file(struct Mod* mod, struct ModFile* file) {
     if (file->fp != NULL) {
         return;
@@ -340,7 +328,7 @@ static void open_mod_file(struct Mod* mod, struct ModFile* file) {
     }
 
     file->wroteBytes = 0;
-    if (should_cache_mod(mod)) {
+    if (mod_should_cache(mod)) {
         mod_file_create_directories(mod, file);
         file->fp = fopen(fullPath, "wb");
     } else {
@@ -456,7 +444,7 @@ after_group:;
                     modFile->fp = NULL;
 
                     // Write cachedPath here so the file doesn't end up in mod.cache
-                    if (!should_cache_mod(mod)) {
+                    if (!mod_should_cache(mod)) {
                         char modFilePath[SYS_MAX_PATH] = { 0 };
                         concat_path(modFilePath, mod->basePath, modFile->relativePath);
                         normalize_path(modFilePath);

--- a/src/pc/network/packets/packet_mod_list.c
+++ b/src/pc/network/packets/packet_mod_list.c
@@ -6,11 +6,14 @@
 #include "pc/djui/djui_panel_join_message.h"
 #include "pc/debuglog.h"
 #include "pc/mods/mod_cache.h"
+#include "pc/mods/mod_fastdl.h"
+#include "pc/configfile.h"
 
 void network_send_mod_list_request(void) {
     SOFT_ASSERT(gNetworkType == NT_CLIENT);
     mods_clear(&gActiveMods);
     mods_clear(&gRemoteMods);
+    fastdl_clear_url();
 
     if (!mods_generate_remote_base_path()) {
         LOG_ERROR("Failed to generate remote base path!");
@@ -51,6 +54,18 @@ void network_send_mod_list(void) {
     LOG_INFO("sending version: %s", version);
     packet_write(&p, &version, sizeof(u8) * MAX_VERSION_LENGTH);
     packet_write(&p, &gActiveMods.entryCount, sizeof(u16));
+
+    // advertise the FastDL URL (empty means the host doesn't offer it)
+    u16 fastDlUrlLength = 0;
+    if (configFastDlUrl[0] != '\0') {
+        fastDlUrlLength = strlen(configFastDlUrl);
+        if (fastDlUrlLength >= FASTDL_URL_MAX) {
+            LOG_ERROR("FastDL URL too long, not advertising it");
+            fastDlUrlLength = 0;
+        }
+    }
+    packet_write(&p, &fastDlUrlLength, sizeof(u16));
+    packet_write(&p, configFastDlUrl, sizeof(u8) * fastDlUrlLength);
     network_send_to(0, &p);
 
     LOG_INFO("sent mod list (%u):", gActiveMods.entryCount);
@@ -152,6 +167,27 @@ void network_receive_mod_list(struct Packet* p) {
     }
 
     packet_read(p, &gRemoteMods.entryCount, sizeof(u16));
+
+    // read the advertised FastDL URL (validates scheme/characters; empty means not offered)
+    {
+        u16 fastDlUrlLength = 0;
+        packet_read(p, &fastDlUrlLength, sizeof(u16));
+        if (p->error || fastDlUrlLength >= FASTDL_URL_MAX) {
+            LOG_ERROR("Received an invalid FastDL URL length!");
+            fastdl_clear_url();
+        } else if (fastDlUrlLength > 0) {
+            char fastDlUrl[FASTDL_URL_MAX] = { 0 };
+            packet_read(p, fastDlUrl, sizeof(u8) * fastDlUrlLength);
+            if (!fastdl_set_url(fastDlUrl)) {
+                LOG_ERROR("Rejected an invalid FastDL URL!");
+            } else {
+                LOG_INFO("Host offers FastDL: %s", fastDlUrl);
+            }
+        } else {
+            fastdl_clear_url();
+        }
+    }
+
     gRemoteMods.entries = calloc(gRemoteMods.entryCount, sizeof(struct Mod*));
     if (gRemoteMods.entries == NULL) {
         LOG_ERROR("Failed to allocate remote mod entries");
@@ -356,6 +392,12 @@ void network_receive_mod_list_done(struct Packet* p) {
         totalSize += mod->size;
     }
     gRemoteMods.size = totalSize;
+
+    // FastDL may take over the download flow (HTTP fetch + hash verification);
+    // when it does, it resumes the join flow itself once it's done
+    if (fastdl_on_mod_list_done()) {
+        return;
+    }
 
     network_start_download_requests();
 }

--- a/src/pc/network/packets/packet_mod_list.c
+++ b/src/pc/network/packets/packet_mod_list.c
@@ -58,10 +58,13 @@ void network_send_mod_list(void) {
     // advertise the FastDL URL (empty means the host doesn't offer it)
     u16 fastDlUrlLength = 0;
     if (configFastDlUrl[0] != '\0') {
-        fastDlUrlLength = strlen(configFastDlUrl);
-        if (fastDlUrlLength >= FASTDL_URL_MAX) {
+        size_t urlLength = strlen(configFastDlUrl);
+        if (urlLength >= FASTDL_URL_MAX) {
             LOG_ERROR("FastDL URL too long, not advertising it");
-            fastDlUrlLength = 0;
+        } else if (!fastdl_url_valid(configFastDlUrl)) {
+            LOG_ERROR("FastDL URL invalid, not advertising it");
+        } else {
+            fastDlUrlLength = (u16)urlLength;
         }
     }
     packet_write(&p, &fastDlUrlLength, sizeof(u16));


### PR DESCRIPTION
## FastDL: optional HTTP(S) mod downloading with MD5 verification

I came up with the idea due to having to wait multiple minutes while downloading bigger mods when joining servers for the first time.

The host can advertise an HTTP(S) URL, and clients
download missing remote mod files from it instead of pulling every byte
through the in-game chunk transfer. This makes hosting modded lobbies far
more practical, especially for large mods - any static file server (nginx, a CDN, GitHub Pages, ...)
can serve the files, and the in-game transfer only handles leftovers.

### How it works

- If the host has set a Fast Download URL in Host Settings, it is advertised
  to clients in `PACKET_MOD_LIST`.
- The client fetches each file the mod cache doesn't already cover.
- Files stream to a `.part` file while an MD5 is computed on the fly and
  compared against the hash the host already advertises per file. Only HTTP
  200 is accepted, the transferred size must match the advertised size
  exactly (0-byte files included), and only on a full match is the file
  renamed into place and registered in mod.cache - so it is skipped on
  future joins like any other cached file. WIP mods keep their existing
  never-cached behavior.
- If HTTP was unavailable or some files failed, everything that didn't
  verify falls back to the regular in-game chunk transfer and the join
  continues as before - FastDL is strictly an accelerator, never a
  requirement.

### Player-facing behavior

- New "Fast Downloads (HTTP)" setting in Misc: Always Off / Let Me Choose
  (default) / Always On. Progress is shown in the existing download screen
  with an ETA.
- In Let Me Choose, a popup asks once per connection attempt before the
  first file (showing the URL and total size). The answer sticks across the
  join flow's reconnect cycles and is only reset on a full disconnect.
- Server-level failures (DNS failure, connection refused, timeout, e.g. the
  HTTP server not being started) are detected fast and return back to the
  in-game path entirely. File-level failures (404, size/hash mismatch)
  fall back per file with a count notice.
- Windows uses WinINet (mirroring update_checker.c) with short timeouts and
  internal connect retries disabled; other platforms use libcurl.

### Implementation notes

- Downloads run on one detached worker thread that is never joined: a
  generation counter aborts stale workers, and the main thread owns all
  result application and cleanup (contexts freed on the main thread only,
  via a done flag + pending-free slot), so shutdown can never race the
  worker or leak a transfer.
- All main-thread integration is three hooks: URL read in
  `network_receive_mod_list`, the takeover gate in
  `network_receive_mod_list_done`, and `fastdl_update`/`fastdl_shutdown` in
  network.c.

### Testing

- Compiled and ran on Windows (WinINet path) and Linux (libcurl path).
- Manually tested: FastDL join from a local HTTP server, unreachable /
  offline HTTP server fallback, per-file fallback, ask-popup flow, host
  settings input, progress + ETA display.