### PR TITLE
Fix non-functional "Force 4:3" option on windows taller than 4:3

### DIFF
--- a/src/pc/controller/controller_mouse.c
+++ b/src/pc/controller/controller_mouse.c
@@ -28,6 +28,7 @@ void controller_mouse_read_window(void) {
 
     mouse_window_buttons = SDL_GetMouseState(&mouse_window_x, &mouse_window_y);
     mouse_window_x -= gfx_current_dimensions.x_adjust_4by3;
+    mouse_window_y -= gfx_current_dimensions.y_adjust_4by3;
 }
 
 void controller_mouse_read_relative(void) {

--- a/src/pc/gfx/gfx.h
+++ b/src/pc/gfx/gfx.h
@@ -54,6 +54,7 @@ struct GfxDimensions {
     float aspect_ratio;
     float x_adjust_ratio;
     uint32_t x_adjust_4by3;
+    uint32_t y_adjust_4by3;
 };
 
 struct GfxTexture {

--- a/src/pc/gfx/gfx_pc.c
+++ b/src/pc/gfx/gfx_pc.c
@@ -1131,20 +1131,24 @@ static void OPTIMIZE_O3 gfx_sp_tri1(uint8_t vtx1_idx, uint8_t vtx2_idx, uint8_t 
 
     if (rdp.viewport_or_scissor_changed) {
         static uint32_t x_adjust_4by3_prev;
+        static uint32_t y_adjust_4by3_prev;
         if (memcmp(&rdp.viewport, &rendering_state.viewport, sizeof(rdp.viewport)) != 0
-            || x_adjust_4by3_prev != gfx_current_dimensions.x_adjust_4by3) {
+            || x_adjust_4by3_prev != gfx_current_dimensions.x_adjust_4by3
+            || y_adjust_4by3_prev != gfx_current_dimensions.y_adjust_4by3) {
             gfx_flush();
-            gfx_rapi->set_viewport(rdp.viewport.x + gfx_current_dimensions.x_adjust_4by3, rdp.viewport.y, rdp.viewport.width, rdp.viewport.height);
+            gfx_rapi->set_viewport(rdp.viewport.x + gfx_current_dimensions.x_adjust_4by3, rdp.viewport.y + gfx_current_dimensions.y_adjust_4by3, rdp.viewport.width, rdp.viewport.height);
             rendering_state.viewport = rdp.viewport;
         }
         if (memcmp(&rdp.scissor, &rendering_state.scissor, sizeof(rdp.scissor)) != 0
-            || x_adjust_4by3_prev != gfx_current_dimensions.x_adjust_4by3) {
+            || x_adjust_4by3_prev != gfx_current_dimensions.x_adjust_4by3
+            || y_adjust_4by3_prev != gfx_current_dimensions.y_adjust_4by3) {
             gfx_flush();
-            gfx_rapi->set_scissor(rdp.scissor.x + gfx_current_dimensions.x_adjust_4by3, rdp.scissor.y, rdp.scissor.width, rdp.scissor.height);
+            gfx_rapi->set_scissor(rdp.scissor.x + gfx_current_dimensions.x_adjust_4by3, rdp.scissor.y + gfx_current_dimensions.y_adjust_4by3, rdp.scissor.width, rdp.scissor.height);
             rendering_state.scissor = rdp.scissor;
         }
         rdp.viewport_or_scissor_changed = false;
         x_adjust_4by3_prev = gfx_current_dimensions.x_adjust_4by3;
+        y_adjust_4by3_prev = gfx_current_dimensions.y_adjust_4by3;
     }
 
     struct CombineMode* cm = &rdp.combine_mode;
@@ -2059,7 +2063,14 @@ static void gfx_sp_reset(void) {
 void gfx_get_dimensions(uint32_t *width, uint32_t *height) {
     gfx_wm_get_dimensions(width, height);
     if (configForce4By3) {
-        *width = gfx_current_dimensions.aspect_ratio * *height;
+        if (((4.0f / 3.0f) * *height) < *width) {
+            *width = (4.0f / 3.0f) * *height;
+        } else {
+            *height = (3.0f / 4.0f) * *width;
+        }
+        // Avoid division by zero in callers
+        if (*width  == 0) { *width  = 1; }
+        if (*height == 0) { *height = 1; }
     }
 }
 
@@ -2085,15 +2096,32 @@ void gfx_start_frame(void) {
     }
     gfx_wm_handle_events();
     gfx_wm_get_dimensions(&gfx_current_dimensions.width, &gfx_current_dimensions.height);
+    if (gfx_current_dimensions.width == 0) {
+        // Avoid division by zero
+        gfx_current_dimensions.width = 1;
+    }
     if (gfx_current_dimensions.height == 0) {
         // Avoid division by zero
         gfx_current_dimensions.height = 1;
     }
-    if (configForce4By3
-        && ((4.0f / 3.0f) * gfx_current_dimensions.height) < gfx_current_dimensions.width) {
-        gfx_current_dimensions.x_adjust_4by3 = (gfx_current_dimensions.width - (4.0f / 3.0f) * gfx_current_dimensions.height) / 2;
-        gfx_current_dimensions.width = (4.0f / 3.0f) * gfx_current_dimensions.height;
-    } else { gfx_current_dimensions.x_adjust_4by3 = 0; }
+    if (configForce4By3) {
+        if (((4.0f / 3.0f) * gfx_current_dimensions.height) < gfx_current_dimensions.width) {
+            uint32_t width4by3 = (4.0f / 3.0f) * gfx_current_dimensions.height;
+            if (width4by3 == 0) { width4by3 = 1; }
+            gfx_current_dimensions.x_adjust_4by3 = (gfx_current_dimensions.width - width4by3) / 2;
+            gfx_current_dimensions.y_adjust_4by3 = 0;
+            gfx_current_dimensions.width = width4by3;
+        } else {
+            uint32_t height4by3 = (3.0f / 4.0f) * gfx_current_dimensions.width;
+            if (height4by3 == 0) { height4by3 = 1; }
+            gfx_current_dimensions.x_adjust_4by3 = 0;
+            gfx_current_dimensions.y_adjust_4by3 = (gfx_current_dimensions.height - height4by3) / 2;
+            gfx_current_dimensions.height = height4by3;
+        }
+    } else {
+        gfx_current_dimensions.x_adjust_4by3 = 0;
+        gfx_current_dimensions.y_adjust_4by3 = 0;
+    }
     gfx_current_dimensions.aspect_ratio = ((float)gfx_current_dimensions.width / (float)gfx_current_dimensions.height);
     gfx_current_dimensions.x_adjust_ratio = (4.0f / 3.0f) / gfx_current_dimensions.aspect_ratio;
 }

--- a/src/pc/gfx/gfx_pc.c
+++ b/src/pc/gfx/gfx_pc.c
@@ -2068,10 +2068,10 @@ void gfx_get_dimensions(uint32_t *width, uint32_t *height) {
         } else {
             *height = (3.0f / 4.0f) * *width;
         }
-        // Avoid division by zero in callers
-        if (*width  == 0) { *width  = 1; }
-        if (*height == 0) { *height = 1; }
     }
+    // Avoid division by zero in callers
+    if (*width  == 0) { *width  = 1; }
+    if (*height == 0) { *height = 1; }
 }
 
 void gfx_init(struct GfxRenderingAPI *rapi, const char *window_title) {


### PR DESCRIPTION
Force 4:3 only handles the pillarbox case, so a window taller than it is wide is left stretched instead of constrained to a 4:3 area.

This PR adds y_adjust_4by3 alongside x_adjust_4by3, clamps the height in the tall case, and offsets the viewport and scissor by it. Both backends already clear the whole target to black each frame, so the top and bottom bars appear the same way the existing side bars do.

I also fit gfx_get_dimensions() to whichever dimension is constraining, which additionally stops it returning a zero width before the first frame, and I correct the mouse y position to match.

Wide-window behavior is unchanged.