### PR TITLE
Re-issue the viewport and scissor when the 4:3 offsets change

### DIFF
--- a/src/pc/gfx/gfx_pc.c
+++ b/src/pc/gfx/gfx_pc.c
@@ -2096,6 +2096,7 @@ void gfx_start_frame(void) {
     } else { gfx_current_dimensions.x_adjust_4by3 = 0; }
     gfx_current_dimensions.aspect_ratio = ((float)gfx_current_dimensions.width / (float)gfx_current_dimensions.height);
     gfx_current_dimensions.x_adjust_ratio = (4.0f / 3.0f) / gfx_current_dimensions.aspect_ratio;
+    rdp.viewport_or_scissor_changed = true;
 }
 
 void gfx_run(Gfx *commands) {


### PR DESCRIPTION
gfx_start_frame recalculates the 4:3 offsets every frame but never sets rdp.viewport_or_scissor_changed, and the offset comparisons in gfx_sp_tri1 sit inside that guard. So if the offsets change on a frame that doesn't emit a viewport or scissor command, the rendering API keeps the previous coordinates.

In practice G_MV_VIEWPORT calls gfx_calc_and_set_viewport at least once per frame, so the flag is normally set anyway and the worst case is a single odd frame after a window resize or a Force 4:3 toggle. This predates the letterbox change I worked on and came up in review there: https://github.com/coop-deluxe/sm64coopdx/pull/1414#discussion_r3954716658

This PR sets the flag at the end of gfx_start_frame. I set it unconditionally rather than only when the offsets differ, because the memcmp and previous-value checks in gfx_sp_tri1 already gate the actual work, so this costs one store per frame and covers both the x and y offsets without caching the previous values in a second place.

Rendering behavior is otherwise unchanged.