### PR TITLE
fixes since the window manager merge + vsync input delay fix

### DIFF
--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -82,7 +82,7 @@ ConfigWindow configWindow = {
 ConfigStick configStick = { 0 };
 
 // display settings
-unsigned int configGraphicsBackend       = GFX_WINDOW_BACKEND_OPENGL;
+unsigned int configGraphicsBackend                = GFX_WINDOW_BACKEND_OPENGL;
 unsigned int configFiltering                      = 2; // 0 = Nearest, 1 = Bilinear, 2 = Trilinear
 bool         configShowFPS                        = false;
 bool         configShowPing                       = false;

--- a/src/pc/configfile.c
+++ b/src/pc/configfile.c
@@ -82,7 +82,7 @@ ConfigWindow configWindow = {
 ConfigStick configStick = { 0 };
 
 // display settings
-enum GfxWindowBackend configGraphicsBackend       = GFX_WINDOW_BACKEND_OPENGL;
+unsigned int configGraphicsBackend       = GFX_WINDOW_BACKEND_OPENGL;
 unsigned int configFiltering                      = 2; // 0 = Nearest, 1 = Bilinear, 2 = Trilinear
 bool         configShowFPS                        = false;
 bool         configShowPing                       = false;
@@ -818,7 +818,7 @@ NEXT_OPTION:
 
     fs_close(file);
 
-    if (configGraphicsBackend < GFX_WINDOW_BACKEND_OPENGL || configGraphicsBackend > GFX_WINDOW_BACKEND_MAX) { configGraphicsBackend = GFX_WINDOW_BACKEND_OPENGL; }
+    if (configGraphicsBackend > GFX_WINDOW_BACKEND_MAX) { configGraphicsBackend = GFX_WINDOW_BACKEND_OPENGL; }
 
     if (configFramerateMode < 0 || configFramerateMode > RRM_MAX) { configFramerateMode = 0; }
     if (configFrameLimit < 30)   { configFrameLimit = 30; }

--- a/src/pc/configfile.h
+++ b/src/pc/configfile.h
@@ -49,7 +49,7 @@ extern char configSaveNames[4][MAX_SAVE_NAME_STRING];
 // display settings
 extern ConfigWindow configWindow;
 extern ConfigStick configStick;
-extern enum GfxWindowBackend configGraphicsBackend;
+extern unsigned int configGraphicsBackend;
 extern unsigned int configFiltering;
 extern bool         configShowFPS;
 extern bool         configShowPing;

--- a/src/pc/djui/djui_panel_display.c
+++ b/src/pc/djui/djui_panel_display.c
@@ -72,15 +72,10 @@ void djui_panel_display_create(struct DjuiBase* caller) {
         djui_checkbox_create(body, DLANG(DISPLAY, SHOW_FPS), &configShowFPS, NULL);
         djui_checkbox_create(body, DLANG(DISPLAY, VSYNC), &configWindow.vsync, djui_panel_display_apply);
 
-        if (GFX_WINDOW_BACKEND_MAX > 1) {
-            char* gfxBackendChoices[GFX_WINDOW_BACKEND_MAX] = {
-                "OpenGL",
 #if defined(_WIN32)
-                "DirectX 11"
+        static char *gfxBackendChoices[] = { "OpenGL", "DirectX 11" };
+        djui_selectionbox_create(body, DLANG(DISPLAY, GRAPHICS_BACKEND), gfxBackendChoices, ARRAY_COUNT(gfxBackendChoices), &configGraphicsBackend, djui_panel_display_update_restart_text);
 #endif
-            };
-            djui_selectionbox_create(body, DLANG(DISPLAY, GRAPHICS_BACKEND), gfxBackendChoices, GFX_WINDOW_BACKEND_MAX, &configGraphicsBackend, djui_panel_display_update_restart_text);
-        }
 
         char* framerateModeChoices[3] = { DLANG(DISPLAY, AUTO), DLANG(DISPLAY, MANUAL), DLANG(DISPLAY, UNCAPPED) };
         djui_selectionbox_create(body, DLANG(DISPLAY, FRAMERATE_MODE), framerateModeChoices, 3, &configFramerateMode, djui_panel_display_framerate_mode_change);

--- a/src/pc/gfx/gfx_window_manager.c
+++ b/src/pc/gfx/gfx_window_manager.c
@@ -27,7 +27,6 @@ static struct GfxWindowBackendAPI *sBackends[GFX_WINDOW_BACKEND_COUNT] = {
 #if defined(_WIN32)
     [GFX_WINDOW_BACKEND_DIRECTX] = &gfx_window_dxgi,
 #endif
-    [GFX_WINDOW_BACKEND_DUMMY] = &gfx_window_dummy,
 };
 
 // TODO: figure out how to switch the backend without restarting
@@ -45,6 +44,12 @@ static void (*kb_text_editing)(char*, int) = NULL;
 static void (*m_scroll)(float, float) = NULL;
 
 #define IS_FULLSCREEN() ((SDL_GetWindowFlags(sSdlWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) != 0)
+
+// Getter for the current window backend API
+static struct GfxWindowBackendAPI *gfx_wm_backend(void) {
+    if (currBackend == GFX_WINDOW_BACKEND_DUMMY) { return &gfx_window_dummy; }
+    return sBackends[currBackend];
+}
 
 void gfx_wm_set_window(SDL_Window *window) {
     sSdlWindow = window;
@@ -70,7 +75,7 @@ static void gfx_wm_set_fullscreen(void) {
         SDL_ShowCursor(1);
         configWindow.exiting_fullscreen = true;
     }
-    sBackends[currBackend]->set_fullscreen();
+    gfx_wm_backend()->set_fullscreen();
 }
 
 static void gfx_wm_reset_dimension_and_pos(void) {
@@ -112,7 +117,12 @@ void gfx_wm_init(const char *window_title) {
 #else
     currBackend = configGraphicsBackend;
 #endif
-    sBackends[currBackend]->init(window_title);
+    if (currBackend != GFX_WINDOW_BACKEND_DUMMY &&
+        (currBackend < GFX_WINDOW_BACKEND_OPENGL || currBackend > GFX_WINDOW_BACKEND_MAX)
+    ) {
+        currBackend = GFX_WINDOW_BACKEND_OPENGL;
+    }
+    gfx_wm_backend()->init(window_title);
 
     gfx_wm_set_fullscreen();
     if (configWindow.fullscreen) {
@@ -226,7 +236,7 @@ void gfx_wm_handle_events(void) {
                 game_exit();
                 break;
         }
-        sBackends[currBackend]->handle_events(event);
+        gfx_wm_backend()->handle_events(event);
     }
 
     if (configWindow.settings_changed) {
@@ -252,28 +262,27 @@ void gfx_wm_set_scroll_callback(void (*on_scroll)(float, float)) {
 }
 
 bool gfx_wm_start_frame(void) {
-    return sBackends[currBackend]->start_frame();
+    return gfx_wm_backend()->start_frame();
 }
 
 void gfx_wm_swap_buffers_begin(void) {
-    sBackends[currBackend]->swap_buffers_begin();
+    gfx_wm_backend()->swap_buffers_begin();
 }
 
 void gfx_wm_swap_buffers_end(void) {
-    sBackends[currBackend]->swap_buffers_end();
+    gfx_wm_backend()->swap_buffers_end();
 }
 
 double gfx_wm_get_time(void) {
-    return sBackends[currBackend]->get_time();
+    return gfx_wm_backend()->get_time();
 }
 
 void gfx_wm_delay(u32 ms) {
-    if (currBackend == GFX_WINDOW_BACKEND_DUMMY) { return; }
     SDL_Delay(ms);
 }
 
 int gfx_wm_get_max_msaa(void) {
-    return sBackends[currBackend]->get_max_msaa();
+    return gfx_wm_backend()->get_max_msaa();
 }
 
 void gfx_wm_set_window_title(const char *title) {

--- a/src/pc/gfx/gfx_window_manager.c
+++ b/src/pc/gfx/gfx_window_manager.c
@@ -118,7 +118,7 @@ void gfx_wm_init(const char *window_title) {
     currBackend = configGraphicsBackend;
 #endif
     if (currBackend != GFX_WINDOW_BACKEND_DUMMY &&
-        (currBackend < GFX_WINDOW_BACKEND_OPENGL || currBackend > GFX_WINDOW_BACKEND_MAX)
+        (currBackend < 0 || currBackend > GFX_WINDOW_BACKEND_MAX)
     ) {
         currBackend = GFX_WINDOW_BACKEND_OPENGL;
     }

--- a/src/pc/gfx/gfx_window_manager.h
+++ b/src/pc/gfx/gfx_window_manager.h
@@ -14,11 +14,11 @@
 typedef bool (*kb_callback_t)(int code);
 
 enum GfxWindowBackend {
+    GFX_WINDOW_BACKEND_DUMMY = -1,
     GFX_WINDOW_BACKEND_OPENGL,
 #if defined(_WIN32)
     GFX_WINDOW_BACKEND_DIRECTX,
 #endif
-    GFX_WINDOW_BACKEND_DUMMY,
     GFX_WINDOW_BACKEND_COUNT,
     GFX_WINDOW_BACKEND_MAX = GFX_WINDOW_BACKEND_COUNT - 1,
 };

--- a/src/pc/gfx/gfx_window_opengl.c
+++ b/src/pc/gfx/gfx_window_opengl.c
@@ -49,6 +49,7 @@
 
 static SDL_Window *sSdlWindow;
 static SDL_GLContext sGlContext = NULL;
+static bool sAppliedVsync = false;
 
   //////////////////////////
  // forward declarations //
@@ -135,6 +136,7 @@ static void gfx_window_opengl_init(const char *window_title) {
 
     gfx_wm_set_window(sSdlWindow);
     gfx_window_opengl_set_vsync(configWindow.vsync);
+    sAppliedVsync = configWindow.vsync;
 }
 
 bool gfx_window_opengl_check_compatibility(void) {
@@ -178,6 +180,10 @@ static void gfx_window_opengl_handle_events(UNUSED SDL_Event event) {
 }
 
 static bool gfx_window_opengl_start_frame(void) {
+    if (sAppliedVsync != configWindow.vsync) {
+        gfx_window_opengl_set_vsync(configWindow.vsync);
+        sAppliedVsync = configWindow.vsync;
+    }
     return true;
 }
 

--- a/src/pc/gfx/gfx_window_opengl.c
+++ b/src/pc/gfx/gfx_window_opengl.c
@@ -57,8 +57,8 @@ static bool sAppliedVsync = false;
 
 static int gfx_window_opengl_get_max_msaa(void);
 
-static inline void gfx_window_opengl_set_vsync(const bool enabled) {
-    SDL_GL_SetSwapInterval(enabled);
+static inline int gfx_window_opengl_set_vsync(const bool enabled) {
+    return SDL_GL_SetSwapInterval(enabled);
 }
 
 static void gfx_window_opengl_set_fullscreen(void) {
@@ -135,8 +135,9 @@ static void gfx_window_opengl_init(const char *window_title) {
     sGlContext = SDL_GL_CreateContext(sSdlWindow);
 
     gfx_wm_set_window(sSdlWindow);
-    gfx_window_opengl_set_vsync(configWindow.vsync);
-    sAppliedVsync = configWindow.vsync;
+    if (gfx_window_opengl_set_vsync(configWindow.vsync) == 0) {
+        sAppliedVsync = configWindow.vsync;
+    }
 }
 
 bool gfx_window_opengl_check_compatibility(void) {
@@ -181,8 +182,9 @@ static void gfx_window_opengl_handle_events(UNUSED SDL_Event event) {
 
 static bool gfx_window_opengl_start_frame(void) {
     if (sAppliedVsync != configWindow.vsync) {
-        gfx_window_opengl_set_vsync(configWindow.vsync);
-        sAppliedVsync = configWindow.vsync;
+        if (gfx_window_opengl_set_vsync(configWindow.vsync) == 0) {
+            sAppliedVsync = configWindow.vsync;
+        }
     }
     return true;
 }

--- a/src/pc/pc_main.c
+++ b/src/pc/pc_main.c
@@ -237,6 +237,10 @@ static void select_graphics_backend(void) {
 #endif
 
     switch (backend) {
+        case GFX_WINDOW_BACKEND_DUMMY:
+            gRenderApi = &gfx_dummy_renderer_api;
+            gAudioApi  = &audio_null;
+            break;
         case GFX_WINDOW_BACKEND_OPENGL:
             gRenderApi = &gfx_opengl_api;
             gAudioApi  = &audio_sdl;
@@ -248,8 +252,8 @@ static void select_graphics_backend(void) {
             break;
 #endif
         default:
-            gRenderApi = &gfx_dummy_renderer_api;
-            gAudioApi  = &audio_null;
+            gRenderApi = &gfx_opengl_api;
+            gAudioApi  = &audio_sdl;
             break;
     }
 
@@ -264,8 +268,9 @@ void produce_interpolation_frames_and_delay(void) {
     gRenderingInterpolated = true;
 
     u32 displayRefreshRate = get_display_refresh_rate();
-    bool shouldDelay = configFramerateMode != RRM_UNLIMITED;
-    if (configWindow.vsync && displayRefreshRate <= refreshRate) {
+    bool isPacedGrid = configFramerateMode != RRM_UNLIMITED;
+    bool shouldDelay = isPacedGrid;
+    if (gRenderApi == &gfx_dummy_renderer_api && configWindow.vsync && displayRefreshRate <= refreshRate) {
         shouldDelay = false;
         refreshRate = displayRefreshRate;
     }
@@ -287,7 +292,7 @@ void produce_interpolation_frames_and_delay(void) {
         ++framesDrawn;
 
         // when we know how many frames to draw, use a precise delta
-        f64 idealTime = shouldDelay ? (sFrameTimeStart + interpFrameTime * framesDrawn) : curTime;
+        f64 idealTime = isPacedGrid ? (sFrameTimeStart + interpFrameTime * framesDrawn) : curTime;
         f32 delta = clamp((idealTime - sFrameTimeStart) / sFrameTime, 0.f, 1.f);
         gFramePercentage = clamp((curTime - sFrameTimeStart) / sFrameTime, 0.f, 1.f);
         gRenderingDelta = delta;
@@ -310,7 +315,7 @@ void produce_interpolation_frames_and_delay(void) {
         }
 
         sDrawnFrames++;
-        if (shouldDelay) { numFramesToDraw--; }
+        if (isPacedGrid) { numFramesToDraw--; }
     } while ((curTime = clock_elapsed_f64()) < targetTime && numFramesToDraw > 0);
 
     // compute and update the frame rate every second


### PR DESCRIPTION
- Fixed an input delay issue when VSync was enabled. I accidentally gave `shouldDelay` two meanings. It meant "not uncapped framerate, so frames should be timed in a grid-like pattern", and it also meant "enable our internal frame pacing".
VSync would have `shouldDelay` as false (because SDL does the frame pacing itself). This meant that we were using `curTime` in the calculation for the frame delta, so VSync always appeared to interpolate incorrectly ~50% of a frame behind for 60fps.
- After fixing this, it was discovered that a recently merged PR (specifically #1337) removed the code responsible for updating the VSync state in SDL. This was fixed, and I noticed one other issue with that PR which was worth fixing:
- `configGraphicsBackend` allowed setting the headless backend in the config file, and `gfxBackendChoices` misleadingly used an unrelated constant that happened to have the correct value as the buffer size. 