### PR TITLE
Improve chat tab completion and input feedback

### DIFF
--- a/src/pc/djui/djui_chat_box.c
+++ b/src/pc/djui/djui_chat_box.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include "pc/network/network.h"
 #include "pc/lua/smlua_hooks.h"
 #include "pc/commands.h"
@@ -195,8 +196,26 @@ static void free_string_list(char **list) {
     free(list);
 }
 
+static bool string_starts_with_case_insensitive(const char *string, const char *prefix) {
+    return strncasecmp(string, prefix, strlen(prefix)) == 0;
+}
+
 static bool complete_subcommand(const char *mainCommand, const char *subcommandPrefix, bool reverse) {
-    char **subcommands = smlua_get_chat_subcommands_list(mainCommand);
+    char correctlyCasedMainCommand[MAX_CHAT_MSG_LENGTH];
+    snprintf(correctlyCasedMainCommand, MAX_CHAT_MSG_LENGTH, "%s", mainCommand);
+
+    char **mainCommands = smlua_get_chat_maincommands_list();
+    if (mainCommands != NULL) {
+        for (s32 i = 0; mainCommands[i] != NULL; i++) {
+            if (strcasecmp(mainCommands[i], mainCommand) == 0) {
+                snprintf(correctlyCasedMainCommand, MAX_CHAT_MSG_LENGTH, "%s", mainCommands[i]);
+                break;
+            }
+        }
+        free_string_list(mainCommands);
+    }
+
+    char **subcommands = smlua_get_chat_subcommands_list(correctlyCasedMainCommand);
 
     if (!subcommands || !subcommands[0]) {
         free_string_list(subcommands);
@@ -205,7 +224,7 @@ static bool complete_subcommand(const char *mainCommand, const char *subcommandP
 
     s32 foundSubcommandsCount = 0;
     for (s32 i = 0; subcommands[i] != NULL; i++) {
-        if (strncmp(subcommands[i], subcommandPrefix, strlen(subcommandPrefix)) == 0) {
+        if (string_starts_with_case_insensitive(subcommands[i], subcommandPrefix)) {
             foundSubcommandsCount++;
         }
     }
@@ -216,10 +235,10 @@ static bool complete_subcommand(const char *mainCommand, const char *subcommandP
         s32 currentIndex = 0;
 
         for (s32 i = 0; subcommands[i] != NULL; i++) {
-            if (strncmp(subcommands[i], subcommandPrefix, strlen(subcommandPrefix)) == 0) {
+            if (string_starts_with_case_insensitive(subcommands[i], subcommandPrefix)) {
                 if (currentIndex == sCommandsTabCompletionIndex) {
                     char completion[MAX_CHAT_MSG_LENGTH];
-                    snprintf(completion, MAX_CHAT_MSG_LENGTH, "/%s %s", mainCommand, subcommands[i]);
+                    snprintf(completion, MAX_CHAT_MSG_LENGTH, "/%s %s", correctlyCasedMainCommand, subcommands[i]);
                     djui_inputbox_set_text(gDjuiChatBox->chatInput, completion);
                     djui_inputbox_move_cursor_to_end(gDjuiChatBox->chatInput);
                     completionSuccess = true;
@@ -289,7 +308,22 @@ void djui_inputbox_replace_current_word(struct DjuiInputbox* inputbox, char* tex
     djui_inputbox_move_cursor_to_position(inputbox, currentWordStart + strlen(text));
 }
 
-static bool complete_player_name(const char *namePrefix, bool reverse) {
+static char *get_uncolored_player_name(const char *playerName) {
+    return djui_text_get_uncolored_string(NULL, strlen(playerName) + 1, playerName);
+}
+
+static bool player_name_starts_with(const char *playerName, const char *nameSearch) {
+    char *uncoloredName = get_uncolored_player_name(playerName);
+    if (uncoloredName == NULL) { return false; }
+
+    bool matches = string_starts_with_case_insensitive(uncoloredName, nameSearch);
+    free(uncoloredName);
+    return matches;
+}
+
+static bool complete_player_name(const char *nameSearch, bool reverse) {
+    bool isMention = nameSearch[0] == '@';
+    const char *playerNameSearch = isMention ? nameSearch + 1 : nameSearch;
     char **playerNames = smlua_get_chat_player_list();
     if (!playerNames || !playerNames[0]) {
         free_string_list(playerNames);
@@ -298,7 +332,7 @@ static bool complete_player_name(const char *namePrefix, bool reverse) {
 
     s32 foundNamesCount = 0;
     for (s32 i = 0; playerNames[i] != NULL; i++) {
-        if (strncmp(playerNames[i], namePrefix, strlen(namePrefix)) == 0) {
+        if (player_name_starts_with(playerNames[i], playerNameSearch)) {
             foundNamesCount++;
         }
     }
@@ -309,9 +343,11 @@ static bool complete_player_name(const char *namePrefix, bool reverse) {
         s32 currentIndex = 0;
 
         for (s32 i = 0; playerNames[i] != NULL; i++) {
-            if (strncmp(playerNames[i], namePrefix, strlen(namePrefix)) == 0) {
+            if (player_name_starts_with(playerNames[i], playerNameSearch)) {
                 if (currentIndex == sPlayersTabCompletionIndex) {
-                    djui_inputbox_replace_current_word(gDjuiChatBox->chatInput, playerNames[i]);
+                    char completion[MAX_CHAT_MSG_LENGTH];
+                    snprintf(completion, MAX_CHAT_MSG_LENGTH, "%s%s", isMention ? "@" : "", playerNames[i]);
+                    djui_inputbox_replace_current_word(gDjuiChatBox->chatInput, completion);
                     completionSuccess = true;
                     break;
                 }
@@ -324,51 +360,89 @@ static bool complete_player_name(const char *namePrefix, bool reverse) {
     return completionSuccess;
 }
 
-char *djui_chat_box_get_next_tab_completion_preview(const char *input) {
-    if (input == NULL || input[0] != '/') {
+static char *get_player_tab_completion_preview(const char *input) {
+    const char *nameSearch = strrchr(input, ' ');
+    nameSearch = (nameSearch == NULL) ? input : nameSearch + 1;
+    bool isMention = nameSearch[0] == '@';
+    if (isMention) {
+        nameSearch++;
+    } else if (nameSearch[0] == '\0') {
         return NULL;
     }
+    size_t nameSearchLength = strlen(nameSearch);
+
+    char **playerNames = smlua_get_chat_player_list();
+    if (playerNames == NULL) { return NULL; }
 
     char *preview = NULL;
-    char *spacePosition = strrchr(input, ' ');
-    if (spacePosition != NULL) {
-        char *mainCommand = get_main_command_from_input(input);
-        if (mainCommand) {
-            char **subcommands = smlua_get_chat_subcommands_list(mainCommand + 1);
-            if (subcommands) {
-                const char *prefix = spacePosition + 1;
-                size_t prefixLen = strlen(prefix);
-                for (s32 i = 0; subcommands[i] != NULL; i++) {
-                    if (strncmp(subcommands[i], prefix, prefixLen) == 0) {
+    for (s32 i = 0; playerNames[i] != NULL; i++) {
+        if (!player_name_starts_with(playerNames[i], nameSearch)) { continue; }
+
+        char *uncoloredName = get_uncolored_player_name(playerNames[i]);
+        if (uncoloredName == NULL) { continue; }
+
+        if (uncoloredName[nameSearchLength] != '\0') {
+            preview = malloc(MAX_CHAT_MSG_LENGTH);
+            if (preview != NULL) {
+                snprintf(preview, MAX_CHAT_MSG_LENGTH, "%s", uncoloredName + nameSearchLength);
+            }
+        }
+        free(uncoloredName);
+        break;
+    }
+
+    free_string_list(playerNames);
+    return preview;
+}
+
+char *djui_chat_box_get_next_tab_completion_preview(const char *input) {
+    if (input == NULL) { return NULL; }
+
+    char *preview = NULL;
+    if (input[0] == '/') {
+        char *spacePosition = strrchr(input, ' ');
+        if (spacePosition != NULL) {
+            char *mainCommand = get_main_command_from_input(input);
+            if (mainCommand) {
+                char **subcommands = smlua_get_chat_subcommands_list(mainCommand + 1);
+                if (subcommands) {
+                    const char *prefix = spacePosition + 1;
+                    size_t prefixLen = strlen(prefix);
+                    for (s32 i = 0; subcommands[i] != NULL; i++) {
+                        if (string_starts_with_case_insensitive(subcommands[i], prefix)) {
+                            preview = malloc(MAX_CHAT_MSG_LENGTH);
+                            if (preview) {
+                                snprintf(preview, MAX_CHAT_MSG_LENGTH, "%s", subcommands[i] + prefixLen);
+                            }
+                            break;
+                        }
+                    }
+                    free_string_list(subcommands);
+                }
+                free(mainCommand);
+            }
+        } else {
+            const char *bufferWithoutSlash = input + 1;
+            size_t prefixLen = strlen(bufferWithoutSlash);
+            char **commands = smlua_get_chat_maincommands_list();
+            if (commands) {
+                for (s32 i = 0; commands[i] != NULL; i++) {
+                    if (string_starts_with_case_insensitive(commands[i], bufferWithoutSlash)) {
                         preview = malloc(MAX_CHAT_MSG_LENGTH);
                         if (preview) {
-                            snprintf(preview, MAX_CHAT_MSG_LENGTH, "%s", subcommands[i] + prefixLen);
+                            snprintf(preview, MAX_CHAT_MSG_LENGTH, "%s", commands[i] + prefixLen);
                         }
                         break;
                     }
                 }
-                free_string_list(subcommands);
+                free_string_list(commands);
             }
-            free(mainCommand);
-        }
-    } else {
-        const char *bufferWithoutSlash = input + 1;
-        size_t prefixLen = strlen(bufferWithoutSlash);
-        char **commands = smlua_get_chat_maincommands_list();
-        if (commands) {
-            for (s32 i = 0; commands[i] != NULL; i++) {
-                if (strncmp(commands[i], bufferWithoutSlash, prefixLen) == 0) {
-                    preview = malloc(MAX_CHAT_MSG_LENGTH);
-                    if (preview) {
-                        snprintf(preview, MAX_CHAT_MSG_LENGTH, "%s", commands[i] + prefixLen);
-                    }
-                    break;
-                }
-            }
-            free_string_list(commands);
         }
     }
 
+    if (preview == NULL) {
+        preview = get_player_tab_completion_preview(input);
+    }
     if (preview != NULL && preview[0] == '\0') {
         free(preview);
         return NULL;
@@ -401,7 +475,7 @@ static void handle_tab_completion(bool reverse) {
 
             if (commands != NULL) {
                 for (s32 i = 0; commands[i] != NULL; i++) {
-                    if (strncmp(commands[i], bufferWithoutSlash, strlen(bufferWithoutSlash)) == 0) {
+                    if (string_starts_with_case_insensitive(commands[i], bufferWithoutSlash)) {
                         foundCommandsCount++;
                     }
                 }
@@ -411,7 +485,7 @@ static void handle_tab_completion(bool reverse) {
                     s32 currentIndex = 0;
 
                     for (s32 i = 0; commands[i] != NULL; i++) {
-                        if (strncmp(commands[i], bufferWithoutSlash, strlen(bufferWithoutSlash)) == 0) {
+                        if (string_starts_with_case_insensitive(commands[i], bufferWithoutSlash)) {
                             if (currentIndex == sCommandsTabCompletionIndex) {
                                 char completion[MAX_CHAT_MSG_LENGTH];
                                 snprintf(completion, MAX_CHAT_MSG_LENGTH, "/%s", commands[i]);

--- a/src/pc/djui/djui_chat_box.c
+++ b/src/pc/djui/djui_chat_box.c
@@ -6,6 +6,7 @@
 #include "pc/lua/smlua_hooks.h"
 #include "pc/commands.h"
 #include "pc/configfile.h"
+#include "pc/controller/controller_keyboard.h"
 #include "djui.h"
 #include "engine/math_util.h"
 
@@ -29,6 +30,15 @@ static s32 sCommandsTabCompletionIndex = -1;
 static char sCommandsTabCompletionOriginalText[MAX_CHAT_MSG_LENGTH];
 static s32 sPlayersTabCompletionIndex = -1;
 static char sPlayersTabCompletionOriginalText[MAX_CHAT_MSG_LENGTH];
+static bool sTabCompletionUndoAvailable = false;
+static char sTabCompletionUndoText[MAX_CHAT_MSG_LENGTH];
+static u16 sTabCompletionUndoCursorPosition = 0;
+
+static void reset_tab_completion_undo(void) {
+    sTabCompletionUndoAvailable = false;
+    sTabCompletionUndoText[0] = '\0';
+    sTabCompletionUndoCursorPosition = 0;
+}
 
 void reset_tab_completion_commands(void) {
     sCommandsTabCompletionIndex = -1;
@@ -558,6 +568,24 @@ static bool djui_chat_box_input_on_key_down(UNUSED struct DjuiBase* base, int sc
     char previousText[MAX_CHAT_MSG_LENGTH];
     snprintf(previousText, MAX_CHAT_MSG_LENGTH, "%s", gDjuiChatBox->chatInput->buffer);
 
+    bool isModifier = scancode == SCANCODE_SHIFT_LEFT
+                   || scancode == SCANCODE_SHIFT_RIGHT
+                   || scancode == SCANCODE_CONTROL_LEFT
+                   || scancode == SCANCODE_CONTROL_RIGHT
+                   || scancode == SCANCODE_ALT_LEFT
+                   || scancode == SCANCODE_ALT_RIGHT;
+    if (scancode != SCANCODE_TAB && scancode != SCANCODE_BACKSPACE && !isModifier) {
+        reset_tab_completion_undo();
+    }
+
+    if (scancode == SCANCODE_BACKSPACE && sTabCompletionUndoAvailable) {
+        djui_inputbox_set_text(gDjuiChatBox->chatInput, sTabCompletionUndoText);
+        djui_inputbox_move_cursor_to_position(gDjuiChatBox->chatInput, sTabCompletionUndoCursorPosition);
+        reset_tab_completion_all();
+        reset_tab_completion_undo();
+        return true;
+    }
+
     switch (scancode) {
         case SCANCODE_UP:
             if (!configUseStandardKeyBindingsChat && (gDjuiChatBox->chatInput && gDjuiChatBox->chatInput->buffer && gDjuiChatBox->chatInput->buffer[0] != '/')) {
@@ -591,16 +619,28 @@ static bool djui_chat_box_input_on_key_down(UNUSED struct DjuiBase* base, int sc
         case SCANCODE_END:
             gDjuiChatBox->scrollY -= pageAmount;
             break;
-        case SCANCODE_TAB:
+        case SCANCODE_TAB: {
+            bool hadUndoAvailable = sTabCompletionUndoAvailable;
+            if (!hadUndoAvailable) {
+                snprintf(sTabCompletionUndoText, MAX_CHAT_MSG_LENGTH, "%s", previousText);
+                sTabCompletionUndoCursorPosition = gDjuiChatBox->chatInput->selection[0];
+                sTabCompletionUndoAvailable = true;
+            }
             handle_tab_completion(gDjuiInputHeldShift != 0);
+            if (!hadUndoAvailable && strcmp(previousText, gDjuiChatBox->chatInput->buffer) == 0) {
+                reset_tab_completion_undo();
+            }
             return true;
+        }
         case SCANCODE_ENTER:
             reset_tab_completion_all();
+            reset_tab_completion_undo();
             sent_history_reset_navigation(&sentHistory);
             djui_chat_box_input_enter(gDjuiChatBox->chatInput);
             return true;
         case SCANCODE_ESCAPE:
             reset_tab_completion_all();
+            reset_tab_completion_undo();
             sent_history_reset_navigation(&sentHistory);
             djui_chat_box_input_escape(gDjuiChatBox->chatInput);
             return true;
@@ -625,11 +665,13 @@ static void djui_chat_box_input_on_text_input(struct DjuiBase *base, char* text)
     djui_inputbox_on_text_input(base, text);
     if (isTextDifferent) {
         reset_tab_completion_all();
+        reset_tab_completion_undo();
     }
 }
 
 static void djui_chat_box_input_on_text_editing(struct DjuiBase *base, char* text, int cursorPos) {
     djui_inputbox_on_text_editing(base, text, cursorPos);
+    reset_tab_completion_undo();
 }
 
 static void djui_chat_box_input_on_scroll(UNUSED struct DjuiBase *base, UNUSED float x, float y) {

--- a/src/pc/djui/djui_inputbox.c
+++ b/src/pc/djui/djui_inputbox.c
@@ -1,10 +1,12 @@
 #include <string.h>
+#include <strings.h>
 #include <stdio.h>
 #include "djui.h"
 #include "djui_unicode.h"
 #include "djui_hud_utils.h"
 #include "pc/gfx/gfx_window_manager.h"
 #include "pc/pc_main.h"
+#include "pc/lua/smlua_hooks.h"
 #include "game/segment2.h"
 #include "pc/controller/controller_keyboard.h"
 
@@ -17,6 +19,117 @@ u8 gDjuiInputHeldShift   = 0;
 u8 gDjuiInputHeldControl = 0;
 u8 gDjuiInputHeldAlt     = 0;
 static u8 sCursorBlink = 0;
+
+enum DjuiInputboxChatTokenStatus {
+    DJUI_INPUTBOX_CHAT_TOKEN_DEFAULT,
+    DJUI_INPUTBOX_CHAT_TOKEN_INCOMPLETE,
+    DJUI_INPUTBOX_CHAT_TOKEN_INVALID,
+    DJUI_INPUTBOX_CHAT_TOKEN_WRONG_CASE,
+};
+
+struct DjuiInputboxChatStyle {
+    const char *mainCommandStart;
+    const char *mainCommandEnd;
+    const char *subcommandStart;
+    const char *subcommandEnd;
+    enum DjuiInputboxChatTokenStatus mainCommandStatus;
+    enum DjuiInputboxChatTokenStatus subcommandStatus;
+};
+
+static void djui_inputbox_free_string_list(char **list) {
+    if (list == NULL) { return; }
+    for (s32 i = 0; list[i] != NULL; i++) {
+        free(list[i]);
+    }
+    free(list);
+}
+
+static enum DjuiInputboxChatTokenStatus djui_inputbox_get_chat_token_status(char **validTokens, const char *token, size_t tokenLength) {
+    bool foundWrongCase = false;
+    bool foundIncomplete = false;
+
+    for (s32 i = 0; validTokens != NULL && validTokens[i] != NULL; i++) {
+        size_t validTokenLength = strlen(validTokens[i]);
+        if (validTokenLength == tokenLength) {
+            if (strncmp(validTokens[i], token, tokenLength) == 0) {
+                return DJUI_INPUTBOX_CHAT_TOKEN_DEFAULT;
+            }
+            if (strncasecmp(validTokens[i], token, tokenLength) == 0) {
+                foundWrongCase = true;
+            }
+        } else if (validTokenLength > tokenLength && strncasecmp(validTokens[i], token, tokenLength) == 0) {
+            foundIncomplete = true;
+        }
+    }
+
+    if (foundWrongCase) { return DJUI_INPUTBOX_CHAT_TOKEN_WRONG_CASE; }
+    if (foundIncomplete) { return DJUI_INPUTBOX_CHAT_TOKEN_INCOMPLETE; }
+    return DJUI_INPUTBOX_CHAT_TOKEN_INVALID;
+}
+
+static void djui_inputbox_get_chat_style(const char *input, struct DjuiInputboxChatStyle *style) {
+    memset(style, 0, sizeof(*style));
+    if (input[0] != '/') { return; }
+
+    const char *mainCommand = input + 1;
+    const char *mainCommandEnd = strchr(mainCommand, ' ');
+    if (mainCommandEnd == NULL) {
+        mainCommandEnd = input + strlen(input);
+    }
+
+    style->mainCommandStart = input;
+    style->mainCommandEnd = mainCommandEnd;
+
+    char **mainCommands = smlua_get_chat_maincommands_list();
+    style->mainCommandStatus = djui_inputbox_get_chat_token_status(mainCommands, mainCommand, mainCommandEnd - mainCommand);
+    djui_inputbox_free_string_list(mainCommands);
+
+    if (*mainCommandEnd == '\0' || style->mainCommandStatus == DJUI_INPUTBOX_CHAT_TOKEN_INVALID) { return; }
+
+    char mainCommandBuffer[MAX_CHAT_MSG_LENGTH];
+    snprintf(mainCommandBuffer, sizeof(mainCommandBuffer), "%.*s", (s32)(mainCommandEnd - mainCommand), mainCommand);
+    char **subcommands = smlua_get_chat_subcommands_list(mainCommandBuffer);
+    if (subcommands == NULL) { return; }
+
+    const char *subcommand = mainCommandEnd + 1;
+    while (*subcommand == ' ') {
+        subcommand++;
+    }
+    const char *subcommandEnd = strchr(subcommand, ' ');
+    if (subcommandEnd == NULL) {
+        subcommandEnd = input + strlen(input);
+    }
+
+    if (subcommand < subcommandEnd) {
+        style->subcommandStart = subcommand;
+        style->subcommandEnd = subcommandEnd;
+        style->subcommandStatus = djui_inputbox_get_chat_token_status(subcommands, subcommand, subcommandEnd - subcommand);
+    }
+    djui_inputbox_free_string_list(subcommands);
+}
+
+static struct DjuiColor djui_inputbox_get_chat_token_color(struct DjuiColor textColor, enum DjuiInputboxChatTokenStatus status) {
+    switch (status) {
+        case DJUI_INPUTBOX_CHAT_TOKEN_INCOMPLETE:
+            textColor.r = (textColor.r * 2 + 255 * 3) / 5;
+            textColor.g = (textColor.g * 2 + 128 * 3) / 5;
+            textColor.b = (textColor.b * 2 + 16 * 3) / 5;
+            break;
+        case DJUI_INPUTBOX_CHAT_TOKEN_INVALID:
+            textColor.r = (textColor.r * 2 + 255 * 3) / 5;
+            textColor.g = (textColor.g * 2 + 32 * 3) / 5;
+            textColor.b = (textColor.b * 2 + 32 * 3) / 5;
+            break;
+        case DJUI_INPUTBOX_CHAT_TOKEN_WRONG_CASE:
+            textColor.r = (textColor.r * 2 + 255 * 3) / 5;
+            textColor.g = (textColor.g * 2 + 208 * 3) / 5;
+            textColor.b = (textColor.b * 2 + 32 * 3) / 5;
+            break;
+        default:
+            break;
+    }
+    return textColor;
+}
 
 static void djui_inputbox_update_style(struct DjuiBase* base) {
     struct DjuiInputbox* inputbox = (struct DjuiInputbox*)base;
@@ -603,7 +716,15 @@ static bool djui_inputbox_render(struct DjuiBase* base) {
     char* c = inputbox->buffer;
     f32 drawX = inputbox->viewX;
     f32 additionalShift = 0;
-    bool wasInsideSelection = false;
+    bool isChatInput = (gDjuiChatBox != NULL && gDjuiChatBox->chatInput == inputbox);
+    struct DjuiInputboxChatStyle chatStyle;
+    char *colorCodeEnd = NULL;
+    const char *bufferEnd = inputbox->buffer + strlen(inputbox->buffer);
+    struct DjuiColor formattingColor = inputbox->textColor;
+    memset(&chatStyle, 0, sizeof(chatStyle));
+    if (isChatInput) {
+        djui_inputbox_get_chat_style(inputbox->buffer, &chatStyle);
+    }
 
     font->render_begin();
     for (u16 i = 0; i < inputbox->bufferSize; i++) {
@@ -619,23 +740,31 @@ static bool djui_inputbox_render(struct DjuiBase* base) {
 
         if (*c == '\0') { break; }
 
-        // deal with seleciton color
-        if (selection[0] != selection[1]) {
-            bool insideSelection = (i >= selection[0]) && (i < selection[1]);
-            if (insideSelection && !wasInsideSelection) {
-                gDPSetEnvColor(gDisplayListHead++, 255, 255, 255, 255);
-            } else if (!insideSelection && wasInsideSelection) {
-                gDPSetEnvColor(gDisplayListHead++, inputbox->textColor.r, inputbox->textColor.g, inputbox->textColor.b, inputbox->textColor.a);
-            }
-            wasInsideSelection = insideSelection;
+        if (colorCodeEnd != NULL && c >= colorCodeEnd) {
+            colorCodeEnd = NULL;
         }
+        if (isChatInput && colorCodeEnd == NULL) {
+            djui_text_parse_color(c, bufferEnd, true, &inputbox->textColor, &colorCodeEnd, &formattingColor);
+        }
+
+        struct DjuiColor characterColor = inputbox->textColor;
+        bool insideSelection = selection[0] != selection[1] && i >= selection[0] && i < selection[1];
+        if (insideSelection) {
+            characterColor = (struct DjuiColor) { 255, 255, 255, 255 };
+        } else if (colorCodeEnd != NULL) {
+            characterColor = formattingColor;
+        } else if (chatStyle.mainCommandStart != NULL && c >= chatStyle.mainCommandStart && c < chatStyle.mainCommandEnd) {
+            characterColor = djui_inputbox_get_chat_token_color(characterColor, chatStyle.mainCommandStatus);
+        } else if (chatStyle.subcommandStart != NULL && c >= chatStyle.subcommandStart && c < chatStyle.subcommandEnd) {
+            characterColor = djui_inputbox_get_chat_token_color(characterColor, chatStyle.subcommandStatus);
+        }
+        gDPSetEnvColor(gDisplayListHead++, characterColor.r, characterColor.g, characterColor.b, characterColor.a);
 
         // render character
         djui_inputbox_render_char(inputbox, c, &drawX, &additionalShift);
         c = djui_unicode_next_char(c);
     }
 
-    bool isChatInput = (gDjuiChatBox != NULL && gDjuiChatBox->chatInput == inputbox);
     if (isChatInput && djui_interactable_is_input_focus(&inputbox->base)) {
         char *previewText = djui_chat_box_get_next_tab_completion_preview(inputbox->buffer);
         if (previewText != NULL && previewText[0] != '\0') {

--- a/src/pc/djui/djui_inputbox.c
+++ b/src/pc/djui/djui_inputbox.c
@@ -636,7 +636,7 @@ static bool djui_inputbox_render(struct DjuiBase* base) {
     }
 
     bool isChatInput = (gDjuiChatBox != NULL && gDjuiChatBox->chatInput == inputbox);
-    if (isChatInput && djui_interactable_is_input_focus(&inputbox->base) && inputbox->buffer[0] == '/') {
+    if (isChatInput && djui_interactable_is_input_focus(&inputbox->base)) {
         char *previewText = djui_chat_box_get_next_tab_completion_preview(inputbox->buffer);
         if (previewText != NULL && previewText[0] != '\0') {
             struct DjuiTheme *theme = gDjuiThemes[configDjuiTheme];

--- a/src/pc/lua/smlua_hooks.c
+++ b/src/pc/lua/smlua_hooks.c
@@ -19,6 +19,7 @@
 #include "pc/pc_main.h"
 #include "pc/djui/djui_lua_profiler.h"
 #include "pc/djui/djui_panel.h"
+#include "pc/djui/djui_text.h"
 #include "pc/configfile.h"
 #include "pc/utils/misc.h"
 #include "pc/lua/utils/smlua_model_utils.h"
@@ -1305,6 +1306,24 @@ s32 sort_alphabetically(const void *a, const void *b) {
     return cmpResult;
 }
 
+static s32 sort_player_names_alphabetically(const void *a, const void *b) {
+    const char *playerNameA = *(const char **)a;
+    const char *playerNameB = *(const char **)b;
+    char *uncoloredNameA = djui_text_get_uncolored_string(NULL, strlen(playerNameA) + 1, playerNameA);
+    char *uncoloredNameB = djui_text_get_uncolored_string(NULL, strlen(playerNameB) + 1, playerNameB);
+
+    if (uncoloredNameA == NULL || uncoloredNameB == NULL) {
+        free(uncoloredNameA);
+        free(uncoloredNameB);
+        return sort_alphabetically(a, b);
+    }
+
+    s32 compareResult = strcasecmp(uncoloredNameA, uncoloredNameB);
+    free(uncoloredNameA);
+    free(uncoloredNameB);
+    return (compareResult != 0) ? compareResult : sort_alphabetically(a, b);
+}
+
 char** smlua_get_chat_player_list(void) {
     char* playerNames[MAX_PLAYERS] = { NULL };
     s32 playerCount = 0;
@@ -1326,7 +1345,7 @@ char** smlua_get_chat_player_list(void) {
         }
     }
 
-    qsort(playerNames, playerCount, sizeof(char*), sort_alphabetically);
+    qsort(playerNames, playerCount, sizeof(char*), sort_player_names_alphabetically);
 
     char** sortedPlayers = (char**) malloc((playerCount + 1) * sizeof(char*));
     for (s32 i = 0; i < playerCount; i++) {
@@ -1375,7 +1394,7 @@ char** smlua_get_chat_maincommands_list(void) {
 }
 
 char** smlua_get_chat_subcommands_list(const char* maincommand) {
-    if (gServerSettings.nametags && strcmp(maincommand, "nametags") == 0) {
+    if (gServerSettings.nametags && strcasecmp(maincommand, "nametags") == 0) {
         s32 count = 2;
         char** subcommands = (char**) malloc((count + 1) * sizeof(char*));
         subcommands[0] = strdup("show-tag");
@@ -1386,7 +1405,7 @@ char** smlua_get_chat_subcommands_list(const char* maincommand) {
 
     for (s32 i = 0; i < sHookedChatCommandsCount; i++) {
         struct LuaHookedCommand* hook = &sHookedChatCommands[i];
-        if (strcmp(hook->command, maincommand) == 0) {
+        if (strcasecmp(hook->command, maincommand) == 0) {
             char* noColorsDesc = djui_text_get_uncolored_string(NULL, strlen(hook->description) + 1, hook->description);
             char* startSubcommands = strstr(noColorsDesc, "[");
             char* endSubcommands = strstr(noColorsDesc, "]");
@@ -1427,7 +1446,7 @@ bool smlua_maincommand_exists(const char* maincommand) {
 
     s32 i = 0;
     while (commands[i] != NULL) {
-        if (strcmp(commands[i], maincommand) == 0) {
+        if (strcasecmp(commands[i], maincommand) == 0) {
             result = true;
             break;
         }
@@ -1452,7 +1471,7 @@ bool smlua_subcommand_exists(const char* maincommand, const char* subcommand) {
     bool result = false;
     s32 i = 0;
     while (subcommands[i] != NULL) {
-        if (strcmp(subcommands[i], subcommand) == 0) {
+        if (strcasecmp(subcommands[i], subcommand) == 0) {
             result = true;
             break;
         }


### PR DESCRIPTION
## This improves chat autocompletion for commands, subcommands, player names, and mentions.

### Tab completion

- Make command, subcommand, and player-name matching case-insensitive
- Complete commands using their canonical casing
- Match and sort player names without color codes
- Preserve player-name formatting when applying completions
- Add player-name previews without formatting
- Suggest and cycle through players after `@`
- Restore the original input when pressing Backspace after cycling completions

### Input feedback

- Show incomplete commands and subcommands in orange
- Show incorrectly cased commands and subcommands in yellow
- Show unknown commands and subcommands in red
- Render visible color codes using the color they represent
- Keep the actual player name in the normal input color